### PR TITLE
modifications selon #1 et #2

### DIFF
--- a/xml/abstemius_hecatomythium.xml
+++ b/xml/abstemius_hecatomythium.xml
@@ -7,7 +7,7 @@
     <fileDesc>
       <titleStmt>
         <title>HECATOMYTHIUM PRIMUM – HECATOMYTHIUM SECUNDUM</title>
-        <author key="Astemio, Lorenzo (14..-15..)" ref="https://fr.wikipedia.org/wiki/Abstémius">Abstemius</author>
+        <author key="Astemio, Lorenzo (14..-15..)" ref="https://data.bnf.fr/fr/13164017/lorenzo_astemio/">Abstemius</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -21,9 +21,9 @@
         </respStmt>
       </editionStmt>
       <publicationStmt>
-        <publisher>Université Paris-Sorbonne, LABEX OBVIL</publisher>
+        <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2015"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/abstemius_hecatomythium/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/abstemius_hecatomythium/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2015 Université Paris-Sorbonne, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
@@ -35,8 +35,8 @@
         </availability>
       </publicationStmt>
       <sourceDesc>
-        <bibl><title>Hecatomythium primum</title>. Édition de référence : <hi rend="i">Fabulæ per latinissimum uirum Laurentium  Abstemium nuper composite</hi>, Venise, Giovanni Tacuino, 3 août 1495, in-4. <ref target="http://gesamtkatalogderwiegendrucke.de/docs/GW00126.htm">GW, n° 126</ref> ; <ref target="http://istc.bl.uk/search/search.html?operation=record&amp;rsid=247630&amp;q=5">ISTC n° ia00010000</ref>.  Exemplaire : <ref target="https://opacplus.bsb-muenchen.de/cgi-bin/redirect?app=webOPAC&amp;location=http://nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb00045190-7">Munich, Bayerische Staatsbibliothek, [4 Inc.c.a. 1117]</ref>.</bibl>
-        <bibl><title>Grunii Corococtæ Porcelli Testamentum Laurentii Abstemii Maceratensis Hecatomythium secundum eiusdem libellus de verbis communibus</title>, Fano, Gershom ben Mosheh  Soncino, 7 mai 1505, in-8°. Exemplaire : British Library, General Reference Collection 1080.f.1.(1.).</bibl>
+        <bibl><hi rend="i">Hecatomythium primum</hi>. Édition de référence : <hi rend="i">Fabulæ per latinissimum uirum Laurentium  Abstemium nuper composite</hi>, Venise, Giovanni Tacuino, 3 août 1495, in-4. <ref target="http://gesamtkatalogderwiegendrucke.de/docs/GW00126.htm">GW, n° 126</ref> ; <ref target="https://data.cerl.org/istc/ia00010000">ISTC n° ia00010000</ref>.  Exemplaire : <ref target="https://opacplus.bsb-muenchen.de/cgi-bin/redirect?app=webOPAC&amp;location=http://nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb00045190-7">Munich, Bayerische Staatsbibliothek, [4 Inc.c.a. 1117]</ref>.</bibl>
+        <bibl><hi rend="i">Grunii Corococtæ Porcelli Testamentum Laurentii Abstemii Maceratensis Hecatomythium secundum eiusdem libellus de verbis communibus</hi>, Fano, Gershom ben Mosheh  Soncino, 7 mai 1505, in-8°. Exemplaire : British Library, General Reference Collection 1080.f.1.(1.).</bibl>
       </sourceDesc>
     </fileDesc>
     <profileDesc>
@@ -44,7 +44,7 @@
         <date when="1495"/><!-- valider ? -->
       </creation>
       <langUsage>
-        <language ident="fr"/>
+        <language ident="fre"/>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/xml/anonymes_chambry.xml
+++ b/xml/anonymes_chambry.xml
@@ -8,9 +8,8 @@
     <!-- encodage provisoire des types de texte en milestone ET -->
     <fileDesc>
       <titleStmt>
-        <title>Fables anonymes grecques attribuées à Ésope (I<hi rend="sup">er</hi>-XIV<hi rend="sup">e</hi> s.)</title>
-        <title type="sub">Édition Chambry <hi rend="i">maior</hi>, 1925-1926</title>
-        <author key="Anonymes">Anonymes</author>
+        <title>Fables anonymes grecques attribuées à Ésope (I<hi rend="sup">er</hi>-XIV<hi rend="sup">e</hi> s.). Édition Chambry <hi rend="i">maior</hi>, 1925-1926</title>
+        <author>Anonymes</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -20,9 +19,9 @@
         </respStmt>
       </editionStmt>
       <publicationStmt>
-        <publisher>Université Paris-Sorbonne, LABEX OBVIL</publisher>
+        <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2016"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/anonymes_chambry/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/anonymes_chambry/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2016 Université Paris-Sorbonne, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
@@ -54,7 +53,7 @@
         <pb ed="perry" n="P274"/>
         <p><milestone unit="recitprose"/>Ὑπὸ τῶν κακῶν τὰ ἀγαθὰ ἐδιώχθη ὡς ἀσθενῆ ὅντα· εἰς οὐρανὸν δὲ ἀνῆλθεν. Τὰ δὲ ἀγαθὰ ἠρώτησαν τὸν Δία πῶς εἶναι μετ’ ἀνθρώπων. Ὁ δὲ εἶπεν &lt;μὴ&gt; μετ’ ἀλλήλων πάντα, ἓν δὲ καθ’ ἓν τοῖς ἀνθρώποις ἐπέρχεσθαι. Διὰ τοῦτο τὰ μὲν κακὰ συνεχῆ τοῖς ἀνθρώποις, ὡς πλησίον ὄντα, ἐπέρχεται, τὰ δὲ ἀγαθὰ βράδιον, ἐξ οὐρανοῦ κατιόντα.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι ἀγαθῶν μὲν οὐδεὶς ταχέως ἐπιτυγχάνει, ὑπὸ δὲ τῶν κακῶν ἕκαστος καθ’ ἑκάστην πλήττεται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 137 Mb 16.</p>
+        <bibl>Codd. Ba 137 Mb 16.</bibl>
         <p><milestone unit="traduction"/>Les Maux, profitant de la faiblesse des Biens, les chassèrent. Ceux-ci montèrent au ciel. Là, ils demandèrent à Zeus comment ils devaient se comporter avec les hommes. Le dieu leur dit de se présenter aux hommes, non pas tous ensemble, mais l’un après l’autre. Voilà pourquoi les Maux, habitant près des hommes, les assaillent sans interruption, tandis que les Biens, descendant du ciel, ne viennent à eux qu’à de longs intervalles.</p>
         <p><milestone unit="traduction"/>L’apologue fait voir que le bien se fait attendre, mais que chaque jour chacun de nous est atteint par les maux.</p>
       </div>
@@ -64,7 +63,7 @@
         <pb ed="perry" n="P99"/>
         <p><milestone unit="recitprose"/>Ξύλινόν τις Ἑρμῆν κατασκευάσας καὶ προσενεγκών εἰς ἀγορὰν ἐπώλει· μηδενὸς δὲ ὠνητοῦ προσιόντος, ἐκκαλέσασθαί τινας βουλόμενος, ἐϐόα ὡς ἀγαθοποιὸν δαίμονα καὶ κέρδους δωρητικὸν πιπράσκει. Τῶν δὲ παρατυχόντων τινὸς εἰπόντος πρὸς αὐτόν· « Ὦ οὗτος, καὶ τί τοῦτον τοιοῦτον ὄντα πωλεῖς, δέον τῶν παρ’ αὐτοῦ ὠφελειῶν ἀπολαύειν ; » ἀπεκρίνατο ὅτι ἐγὼ μὲν ταχείας ὠφελείας τινὸς δέομαι, αὐτὸς δὲ βραδέως εἴωθε τὰ κέρδη περιποιεῖν.</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα αἰσχροκερδῆ μηδὲ θεῶν πεφροντικότα ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 170 Pb 99 Pc 98 Pe 59 Pf 93 Pg 61 Mb 53 Me 120 Mj 110 Ca 128.</p>
+        <bibl>Codd. Pa 170 Pb 99 Pc 98 Pe 59 Pf 93 Pg 61 Mb 53 Me 120 Mj 110 Ca 128.</bibl>
         <p><milestone unit="traduction"/>Un homme, ayant fabriqué un Hermès de bois, l’apporta au marché et le mit en vente. Aucun acheteur ne se présentant, il se mit en tête d’en attirer en criant qu’il vendait un dieu pourvoyeur de biens et de profits. Un de ceux qui se trouvaient là lui dit : « Hé, l’ami, s’il est si bienfaisant, pourquoi le vends-tu, au lieu de tirer parti de ses secours ? — C’est que moi, répondit-il, j’ai besoin d’un secours immédiat, et que lui n’est jamais pressé de procurer ses bienfaits. »</p>
         <p><milestone unit="traduction"/>Cet apologue convient à un homme bassement intéressé et qui ne se soucie même pas des dieux.</p>
       </div>
@@ -76,7 +75,7 @@
           <pb ed="perry" n="P1"/>
           <p><milestone unit="recitprose"/>Ἀετὸς καὶ ἀλώπηξ φιλίαν πρὸς ἀλλήλους ποιησάμενοι πλησίον ἑαυτῶν οἰκεῖν διέγνωσαν, βεϐαίωσιν φιλίας τὴν συνήθειαν ποιούμευοι. Καὶ δὴ ὁ μὲν ἀναϐὰς ἐπί τι περίμηκες δένδρον ἐνεοττοποιήσατο· ἡ δὲ εἰσελθοῦσα εἰς τὸν ὑποκείμενον θάμνον ἔτεκεν. Ἐξελθούσης δὲ αὐτῆς ποτε ἐπὶ νομήν, ὁ ἀετός, ἀπορῶν τροφῆς, καταπτὰς εἰς τὸν θάμνον καὶ τὰ γεννήματα ἀναρπάσας, μετὰ τῶν ἑαυτοῦ νεοττῶν κατεθοινήσατο. Ἡ δὲ ἀλώπηξ ἐπανελθοῦσα, ὡς ἔγνω τὸ πραχθέν, οὐ &lt;τοσοῦτον&gt; ἐπὶ τῷ τῶν νεοττῶν θανάτῳ ἐλυπήθη ὅσον ἐπὶ τῇ ἀμύνῃ· χερσαία γὰρ οὖσα πετεινὸν διώκειν ἠδυνάτει. Διόπερ πόρρωθεν στᾶσα, ὃ μόνον τοῖς ἀδυνάτοις καὶ ἀσθενέσιν ὑπολείπεται, τῷ ἐχθρῷ κατηρᾶτο. Συνέϐη δ’ αὐτῷ τῆς εἰς τὴν φιλίαν ἀσεϐείας οὐκ εἰς μακρὰν δίκην ὑποσχεῖν· θυόντων γάρ τινων αἶγα ἐπ’ ἀγροῦ, καταπτὰς ἀπὸ τοῦ βωμοῦ σπλάγχνον ἔμπυρον ἀνήνεγκεν· οὗ κομισθέντος ἐπὶ τὴν καλιάν, σφοδρὸς ἐμπεσὼν ἄνεμος ἐκ λεπτοῦ καὶ παλαιοῦ κάρφους λαμπρὰν φλόγα ἀνῆψε. Καὶ διὰ τοῦτο καταφλεχθέντες οἱ νεοττοὶ (καὶ γὰρ ἦσαν ἔτι ἀτελεῖς οἱ πτηνοί) ἐπὶ τὴν γῆν κατέπεσον. Καὶ ἡ ἀλώπηξ προσδραμοῦσα ἐν ὄψει τοῦ ἀετοῦ πάντας αὐτοὺς κατέφαγεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φιλίαν παρασπονδοῦντες, κἂν τὴν τῶν ἠδικημένων ἐκφύγωσι κόλασιν δι’ ἀσθένειαν, ἀλλ’ οὖν γε τὴν ἐκ θεοῦ τιμωρίαν οὐ διακρούονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 11 Pb 1 Pd 1 Pf 1 Ph 1 Ma 11 Mb 1 Me 1.</p>
+          <bibl>Codd. Pa 11 Pb 1 Pd 1 Pf 1 Ph 1 Ma 11 Mb 1 Me 1.</bibl>
           <p><milestone unit="traduction"/>Un aigle et un renard, ayant fait amitié ensemble, décidèrent d’habiter l’un près de l’autre, dans la pensée que la cohabitation affermirait leur liaison. Et alors l’aigle prenant son essor s’établit sur un arbre très élevé et y fit sa couvée, tandis que le renard, se glissant dans le buisson qui était au pied de l’arbre, y déposa ses petits. Mais un jour que le renard était sorti pour chercher pâture, l’aigle à court de nourriture fondit sur le buisson, enleva les renardeaux et s’en régala avec ses petits. À son retour, le renard, voyant ce qui s’était passé, fut moins affligé de la mort de ses petits que de l’impossibilité de se venger ; en effet il ne pouvait, lui quadrupède, poursuivre un volatile. Il dut se contenter, seule ressource des impuissants et des faibles, de maudire son ennemi de loin. Or il arriva que l’aigle ne tarda pas à subir la punition de son crime contre l’amitié. Des gens sacrifiaient une chèvre à la campagne ; l’aigle fondit sur l’autel, y ravit un viscère enflammé et l’apporta dans son nid. Or un vent violent s’étant mis à souffler fit flamber un vieux fétu, et par suite les aiglons furent brûlés, car ils étaient encore hors d’état de voler, et ils tombèrent sur le sol. Le renard accourut et sous les yeux de l’aigle les dévora tous.</p>
           <p><milestone unit="traduction"/>Cette fable montre que, si vous trahissez l’amitié, vous pourrez peut-être vous soustraire à la vengeance de vos dupes, si elles sont faibles ; mais qu’en tout cas vous n’échapperez pas à la punition du ciel.</p>
         </div>
@@ -86,7 +85,7 @@
           <pb ed="perry" n="P1"/>
           <p><milestone unit="recitprose"/>Ἀετὸς καὶ ἀλώπηξ φιλίαν πρὸς ἀλλήλους ποιησάμενοι, πλησίον ἑαυτῶν οἰκεῖν διέγνωσαν, βεϐαίωσιν φιλίας τὴν συνήθειαν καὶ τὸ ἐν ταὐτῷ εἶναι ἡγούμενοι. Καὶ δὴ ὁ μὲν ἀναϐὰς ἐπί τι περίμηκες δένδρον ἐνεοττοποίησεν· ἡ δὲ εἰσελθοῦσα εἰς τὸν ὑποκείμενον θάμνον ἔτεκεν. Μετ’ οὐ πολλὰς δὲ ἡμέρας ἐξελθούσης αὐτῆς ποτε ἐπὶ νομήν, ἀπορῶν ὁ ἀετὸς τροφῆς, καταπτὰς εἰς τὸν θάμνον καὶ τὰ γεννήματα ἁρπάσας, μετὰ τῶν ἑαυτοῦ νεοττῶν κατεθοινήσατο. Ἡ δὲ ἀλώπηξ ἐπανιοῦσα, ὡς ἔγνω τὸ πραχθέν, οὐ τοσοῦτον ἐπὶ τῷ τῶν νεοττῶν θανάτῳ ἐλυπήθη ὅσον ἐπὶ τῇ ἀμύνῃ· χερσαία γὰρ οὖσα πετεινὸν διώκειν ἠδυνάτει. Διόπερ πόρρωθαν στᾶσα, ὃ τοῖς ἀσθενέσι καὶ ἀδυνάτοις ὑπάρχει ἔργον, τὸν ἐχθρὸν κατηρᾶτο. Συνέβη οὖν αὐτοῖς ἀντὶ τῆς πολλῆς ἀγάπης μεγίστην ἐχθρὰν ἐσχηκέναι μεταξὺ ἀλλήλων. Ὁ δὲ θεὸς τῆς εἰς τὴν φιλίαν γενομένης ἀσεϐείας οὐκ εἰς μακρὰν δίκην περιέσχε· θυόντων γάρ τινων αἶγα ἐπ’ ἀγρῷ, ὁ ἀετὸς καταπτὰς ἀπὸ τοῦ βωμοῦ σπλάγχνον ἔμπυρον ἀνήνεγκεν ἐπὶ τὴν καλίαν· οὗ κομισθέντος ἐπὶ τῇ καλιᾷ, σφοδρὸς ἐνέπεσεν ἄνεμος· ὑπάρχουσα δὲ ἡ καλιὰ ἐκ λεπτοῦ καὶ παλαιοῦ χόρτου λαμπρὰν φλόγα ἀνῆψε. Καὶ διὰ τοῦτο καταφλεχθέντες οἱ νεοττοί, καὶ γὰρ ἦσαν ἔτι πτῆναι ἀτελεῖς, ἐπὶ τὴν γῆν κατέπεσον. Ἡ δὲ ἀλώπηξ προσδραμοῦσα ἐν ὄψει τοῦ ἀετοῦ πάντας αὐτοὺς κατέφαγεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φιλίαν παρασπονδοῦντες, κἂν τὴν ἐκ τῶν ἠδικημένων ἐκφύγωσιν κόλασιν δι’ ἀσθένειαν, ἀλλά γε τὴν ἐκ τοῦ θεοῦ τιμωρίαν οὐ διακρούσονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 1 Cb 1 Cd 1 Ce 1 Cf 1 Ch 1 Mc 1 Mk 1.</p>
+          <bibl>Codd. Ca 1 Cb 1 Cd 1 Ce 1 Cf 1 Ch 1 Mc 1 Mk 1.</bibl>
         </div>
         <div>
           <head>Chambry 3.3</head>
@@ -94,7 +93,7 @@
           <pb ed="perry" n="P1"/>
           <p><milestone unit="recitprose"/>Ἀετὸς καὶ ἀλώπηξ φιλιωθέντες πλησίον ἀλλήλων οἰκεῖν ἔγνωσαν, βεϐαίωσιν φιλίας ποιούμενοι τὴν συνήθειαν. Ὁ μὲν οὖν ἐφ’ ὑψηλοῦ δένδρου τὴν καλιὰν ἐπήξατο· ἡ δ’ ἀλώπηξ ἐν τοῖς ἔγγιστα θάμνοις ἐτεκνοποιήσατο. Ἐπὶ νομὴν οὖν ποτε τῆς ἀλώπεκος προελθούσης, ὁ ἀετός, τροφῆς ἀπορῶν, καταπτὰς ἐπὶ τῶν θάμνων καὶ τὰ τέκνα ταύτης ἀναρπάσας, ἅμα τοῖς αὐτοῦ νεοττοῖς ἐθοινήσατο. Ἡ δ’ ἀλώπηξ ἐπανελθοῦσα καί τὸ πραχθὲν μαθοῦσα οὐ τοσοῦτον ἐπὶ τῷ τῶν τέκνων ἠνιάθη θανάτῳ ὅσον ἐπὶ τῷ τῆς ἀμύνης ἀπόρῳ· χερσαία γὰρ οὖσα πτηνὸν διώκειν οὐχ οἵα τε ἦν. Διὸ καὶ πόρρωθεν στᾶσα, τοῦθ’ ὅ καὶ τοῖς ἀδυνάτοις ἐστὶν εὔπορον, τῷ ἐχθρῷ κατηρᾶτο. Οὐ πολλῷ δ’ ὕστερον αἶγά τινων ἐπ’ ἀγροῦ θυόντων, καταπτὰς ὁ ἀετὸς μέρος τι τῶν θυμάτων σὺν ἐμπύροις ἄνθραξιν ἥρπασε, κἀπὶ τὴν νεοττιὰν ἤγαγεν. Ἀνέμου δὲ σφοδροῦ πνεύσαντος τηνικαῦτα, καὶ φλογὸς ἀναδοθείσης, οἱ ἀετιδεῖς ἀπτῆνες ἔτι τυγχάνοντες, ὀπτηθέντες εἰς γῆν κατέπεσον. Ἡ δ’ ἀλώπηξ ἐπιδραμοῦσα ἐν ὄψει τοῦ ἀετοῦ πάντας κατέφαγεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φιλίαν παρασπονδοῦντες, κἂν τὴν ἐκ τῶν ἠδικημένων φύγωσι τιμωρίαν δι’ ἀσθένειαν, ἀλλὰ τήν γε θείαν δίκην οὐ διακρούσονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 1 Lb 1 Le 1 Lf 1 Lh 1 Md 1 Me 1 Mf 1 Mg 1 Mi 36 Mj 1 Ml 1 Mm 1.</p>
+          <bibl>Codd. La 1 Lb 1 Le 1 Lf 1 Lh 1 Md 1 Me 1 Mf 1 Mg 1 Mi 36 Mj 1 Ml 1 Mm 1.</bibl>
         </div>
         <div>
           <head>Chambry 3.4</head>
@@ -102,7 +101,7 @@
           <pb ed="perry" n="P1"/>
           <p><milestone unit="recitprose"/>Φιλίαν ἐσπείσατο πρὸς ἀετὸν ἀλώπηξ, καὶ ὁ μὲν εἶχε τὴν καλιὰν ἐπάνω τοῦ δένδρου, ἡ δὲ ὑπὸ τὴν ῥίζαν. Ὁ δὲ ἀετὸς ἐπιορκήσας τοὺς σκύμνους τῆς ἀλώπεκος τοῖς νεοσσοῖς θοίνην ἔδωκεν. Ἄλλοτε δὲ ἱερεῖον ἐκ τοῦ βωμοῦ ἁρπάσας μετὰ ἄνθρακος ἔθετο εἰς τὴν καλιάν. Ἡ δὲ ἐξήφθη καὶ οἱ νεοσσοὶ κατέπεσον. Καὶ ἡ ἀλώπηξ θήραν ἐποιήσατο τὸ συμϐάν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δίκη τις ἐφορᾷ τὰ τῶν ἀθρώπων καὶ τοὺς ἐπιόρκους ἀμύνεται καὶ ἀποδίδωσι κατ’ ἀξίαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 139 Bb 84.</p>
+          <bibl>Codd. Ba 139 Bb 84.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-4">
@@ -113,7 +112,7 @@
           <pb ed="perry" n="P3"/>
           <p><milestone unit="recitprose"/>Ἀετὸς λαγωὸν ἐδίωκεν· ὁ δὲ ἐν ἐρημίᾳ τῶν βοηθησόντων ὑπάρχων, ὅν μόνον ὁ καιρὸς παρέσχε, κάνθαρον ἰδών, τοῦτον ἱκέτευεν. Ὁ δὲ παραθαρσύνας αὐτόν, ὡς ἐγγὺς ἐλθόντα τὸν ἀετὸν ἐθεάσατο, παρεκάλει μὴ ἀπάγειν αὐτοῦ τον ἱκέτην. Κἀκεῖνος ὑπεριδὼν τὴν μικρότητα ἐν ὄψει τοῦ κανθάρου τὸν λαγωὸν κατεθοινήσατο. Ὁ δὲ ἀπ’ ἐκείνου μνησικακῶν διετέλει παρατηρούμενος τοῦ ἀετοῦ τὰς καλιὰς καί, εἴ ποτε ἐκεῖνος ἔτικτε, μετάρσιος αἰρόμενος ἐκύλιε τὰ ὠὰ καὶ κατέασσε, μέχρις οὗ πανταχόθεν ἐλαυνόμενος ὁ ἀετὸς ἐπὶ τὸν Δία κατέφυγεν (ἔστι δὲ τοῦ Διὸς ἱερὸς ὁ ὄρνις ), καὶ αὐτοῦ ἐδεήθη τόπον αὐτῷ πρὸς νεοττοποιίαν ἀσφαλῆ παρασχεῖν. Tοῦ δὲ Διὸς ἐν τοῖς ἐαυτοῦ κόλποις τίκτειν ἐπιτρέψαντος αὐτῷ, ὁ κάνθαρος τοῦτο ἑωρακώς, κόπρου σφαῖραν ποιήσας, ἀνέπτη καὶ γενόμενος κατὰ τοὺς τοῦ Διὸς κόλπους ἐνταῦθα καθῆκεν. Ὁ δὲ Ζεὺς ἀποσείσασθαι τὴν κόπρον βουλόμενος, ὡς διανέστη, ἔλαθεν τὰ ὠὰ ἀπορρίψας. Ἀπ’ ἐκείνου τέ φασι περὶ ὃν καιρὸν οἱ κάνθαροι γίγνονται μὴ νεοττεύειν τοὺς ἀετούς.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος διδάσκει μηδενὸς καταφρονεῖν λογιζομένους ὅτι οὐδεὶς οὕτως ἐστὶν ἀδύνατος ὡς προπηλακισθεὶς μὴ δύνασθαί ποτε ἑαυτὸν ἐκδικῆσαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 13 Pb 3 Pd 5 Pf 2 Ph 2 Ma 13 Me 2 Mh 1 Mk 3 — Cb 3 Cc 1 Cd 3 Cf 3 Ch 3.</p>
+          <bibl>Codd. Pa 13 Pb 3 Pd 5 Pf 2 Ph 2 Ma 13 Me 2 Mh 1 Mk 3 — Cb 3 Cc 1 Cd 3 Cf 3 Ch 3.</bibl>
           <p><milestone unit="traduction"/>Une aigle poursuivait un lièvre. Ce lièvre, se voyant dénué de tout secours, recourut au seul être que le hasard offrit à ses yeux ; c’était un escarbot ; il le supplia de le sauver. L’escarbot le rassura, et, voyant approcher l’aigle, il la conjura de ne pas lui ravir son suppliant. Mais l’aigle, dédaignant sa petitesse, dévora le lièvre sous les yeux de l’escarbot. Dès lors l’escarbot, plein de rancune, ne cessa d’observer les endroits où l’aigle faisait son nid, et, quand elle couvait, il s’élevait en l’air, faisait rouler les œufs et les cassait, tant qu’enfin pourchassée de partout, elle eut recours à Zeus (car c’est à Zeus que cet oiseau est consacré), et elle le pria de lui procurer un asile sûr pour y faire ses petits. Zeus lui permit de pondre dans son giron, mais l’escarbot avait vu la ruse : il fit une boulette de crotte, prit son essor, et, quand il fut au-dessus du giron de Zeus, il l’y laissa tomber. Zeus se leva pour secouer la crotte, et jeta les œufs à terre sans y penser. Depuis ce temps-là, dit-on, pendant la saison où paraissent les escarbots, les aigles ne nichent plus.</p>
           <p><milestone unit="traduction"/>Cette fable apprend à ne mépriser personne ; il faut se dire qu’il n’y a pas d’être si faible qui ne soit capable un jour de venger un affront.</p>
         </div>
@@ -123,7 +122,7 @@
           <pb ed="perry" n="P3"/>
           <p><milestone unit="recitprose"/>Ἀετὸς λαγωὸν ἐδίωκε. Ὁ δὲ ἐν ἐρημίᾳ τῶν βοηθησόντων ὑπάρχων, ὃν μόνον ὁ καιρὸς παρέσχε, κάνθαρον ἰδών, τοῦτον ἱκέτευεν. Ὁ δὲ παραθαρσύνει αὐτόν. Ὁ δὲ κάνθαρος ἐγγὺς ἐλθὼν τὸν ἀετὸν ἐθεάσατο, παρεκάλεσε δὲ μὴ ἀπαγαγεῖν αὐτὸν τὸν ἱκετεύσαντα. Ὁ δὲ ἀετός, ἀπιδὼν περὶ τὴν τοῦ κανθάρου σμικρότητα, ἐν ὄψει αὐτοῦ τὸν λαγωὸν ἐθοινήσατο. Ὁ δὲ κάνθαρος ἀπ’ ἐκείνου μνησικακῶν διετέλει παρατηρούμενος τὰς τοῦ ἀετοῦ καλιάς. Καί ποτε ὁ ἀετὸς ἔτικτε. Εἶτα μετάρσιος αἰρόμενος ὁ κάνθαρος ἐκύλιε τὰ ὠὰ τοῦ ἀετοῦ καὶ κατέασσε ταῦτα, μέχρις οὗ ἐλαυνόμενος πανταχόθεν ὁ ἀετὸς ἐπὶ τὸν Δία κατέφυγεν (ἐστὶ δὲ τοῦ θεοῦ ὁ ὄρνις), καὶ ἐδεήθη αὐτοῦ τόπον αὐτῷ πρὸς νεοττοποιίαν παρασχεῖν. Τοῦ δὲ Διὸς ἐν τοῖς αὐτοῦ κόλποις τίκτειν ἐπιτρέψαντος αὐτὸν, ὁ [δὲ] κάνθαρος, τούτους ἑωρακὼς καὶ αἰσθόμενος, κόπρου σφαῖραν ποιησάμενος, ἀναπτὰς ἐπὶ τοὺς τοῦ Διὸς κόλπους, τὴν κόπρον ἔρριψεν. Ὁ δὲ Ζεὺς τὴν κόπρον αἰσθόμενος καὶ ἀποσείσασθαι βουληθεὶς ἀνέστη. Ὡς δὲ ἀναστὰς ἐπελάθετο τῶν ὠῶν καὶ ἔρριψεν ταῦτα, συνετρίϐησαν. Ἀπ’ ἐκείνου τέ φασι περὶ ὃν καιρὸν οἱ κάνθαροι γίνονται τοὺς ἀετοὺς μὴ νεοττεύειν.</p>
           <p><milestone unit="epimythiumprose"/>Δηλοῖ δὲ ὁ λόγος μηδὲ τῶν μικρῶν καταφρονεῖν λογιζομένους ὅτι προπηλακισθέντες καὶ θεῶν καταφρονοῦσι πρὸς ἄμυναν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 9.</p>
+          <bibl>Cod. Pe 9.</bibl>
         </div>
         <div>
           <head>Chambry 4.3</head>
@@ -131,7 +130,7 @@
           <pb ed="perry" n="P3"/>
           <p><milestone unit="recitprose"/>Λαγωὸς ὑπ’ ἀετοῦ διωκόμενος πρὸς κοίτην κανθάρου κατέφυγε, δεόμενος ὑπ αὐτοῦ σωθῆναι. Ὁ δὲ κάνθαρος ἠξίου τὸν ἀετὸν μὴ ἀνελεῖν τὸν ἱκέτην, ὁρκίζων αὐτὸν κατὰ τοῦ μεγίστου Διὸς ἦ μὴν μὴ καταφρονῆσαι τῆς μικρότητος αὐτοῦ. Ὁ δὲ μετ’ ὀργῆς τῇ πτέρυγι ῥαπίσας τὸν κάνθαρον, τὸν λαγωὸν ἁρπάσας κατέφαγεν. Ὁ δὲ κάνθαρος τῷ τε ἀετῷ συναπέπτη, ὡς τὴν καλιὰν τούτου καταμαθεῖν, καὶ δὴ προσελθὼν τὰ ὠὰ τούτου κατακυλίσας διέφθειρε. Τοῦ δὲ δεινὸν ποιησαμένου εἴ τις τοῦτο τολμήσειε, κἀπὶ μετεωροτέρου τόπου τὸ δεύτερον νεοττοποιησαμένου, κἀκεῖ πάλιν ὁ κάνθαρος τὰ ἴσα τοῦτον διέθηκεν. Ὁ δ’ ἀετός, ἀμηχανήσας τοῖς ὅλοις, ἀναϐὰς ἐπὶ τὸν Δία (τούτου γὰρ ἱερὸς εἶναι λέγεται) τοῖς αὐτοῦ γόνασι τὴν τρίτην γονὴν τῶν ὠῶν ἔθηκε, τῷ θεῷ ταῦτα παραθέμενος καὶ ἱκετεύσας φυλάττειν. Ὁ κάνθαρος δέ, κόπρου σφαῖραν ποιήσας καὶ ἀναϐὰς ἐπὶ τοῦ κόλπου Διός, ταύτην καθῆκεν. Ὁ δὲ Ζεύς, ἀναστὰς ἐφ’ ᾧ τὴν ὄνθον ἀποτινάξασθαι, καὶ τὰ ὠὰ διέρριψεν ἐκλαθόμενος, ἃ καὶ συνετρίϐη πεσόντα. Μαθὼν δὲ πρὸς τοῦ κανθάρου ὅτι ταῦτ’ ἔδρασε τὸν ἀετὸν ἀμυνόμενος, οὐ γὰρ δὴ τὸν κάνθαρον ἐκεῖνος μόνον ἠδίκησεν, ἀλλὰ καὶ εἰς τὸν Δία αὐτὸν ἠσέϐησε, πρὸς τὸν ἀετὸν εἶπεν ἐλθόντα, κάνθαρον εἶναι τὸν λυποῦντα καὶ δὴ καὶ δικαίως λυπεῖν. Μὴ βουλόμενος οὖν τὸ γένος τὸ τῶν ἀετῶν σπανισθῆναι, συνεϐούλευε τῷ κανθάρῳ διαλλαγὰς πρὸς τὸν ἀετὸν θέσθαι. Τοῦ δὲ μὴ πειθομένου, ἐκεῖνος εἰς καιρὸν ἕτερον τὸν τῶν ἀετῶν μετέθηκε τοκετόν, ἥνικα ἂν μὴ φαίνωνται κάνθαροι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ μηδενὸς καταφρονεῖν, λογιζομένους ὡς οὐδείς ἐστιν ὃς προπηλακισθεὶς οὐκ ἂν δυνηθείη ἑαυτῷ ἐπαμῦναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 2 Lf 2 Me 2bis in margine Mf 2 Ml 105.</p>
+          <bibl>Codd. La 2 Lf 2 Me 2bis in margine Mf 2 Ml 105.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-5">
@@ -142,7 +141,7 @@
           <pb ed="perry" n="P2"/>
           <p><milestone unit="recitprose"/>Ἀετὸς καταπτὰς ἀπό τινος ὑψηλῆς πέτρας ἄρνα ἥρπασε· κολοιὸς δὲ τοῦτο θεασάμενος διὰ ζῆλον τοῦτον μιμήσασθαι ἠθέλησε· καὶ δὴ καθεὶς ἑαυτὸν μετὰ πολλοῦ ῥοίζου ἐπὶ κριὸν ἠνέχθῃ. Ἐμπαρέντων δὲ αὐτοῦ τῶν ὀνύχων τοῖς μάλλοις, ἐξαρθῆναι μὴ δυνάμενος ἐπτερύσσετο, ἕως ὁ ποιμήν, τὸ γεγονὸς αἰσθόμενος, προσδραμὼν συνέλαϐεν αὐτὸν καὶ περικόψας αὐτοῦ τὰ ὀξυπτερά, ὡς ἑσπέρα κατέλαϐε, τοῖς ἑαυτοῦ παισὶν ἐκόμισε. Τῶν δὲ πυνθανομένων τί εἴη τὸ ὄρνεον, ἔφη. « Ὡς μὲν ἐγὼ σαφῶς οἶδα, κολοιός, ὡς δὲ αὐτὸς βούλεται, ἀετός. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἡ πρὸς τοὺς ὑπερέχοντας ἅμιλλα, πρὸς τῷ μηδὲν ἀνύειν, καὶ ἐπὶ συμφοραῖς προσκτᾶται γέλωτα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 12 Pb 2 Pd 4 Pe 8 Pg 1 Ma 12 Mb 2 — Ca 3 Cb 2 Cd 2 Ce 2 Cf 2 Ch 2 Mc 2 Mk 2 Ml 21.</p>
+          <bibl>Codd. Pa 12 Pb 2 Pd 4 Pe 8 Pg 1 Ma 12 Mb 2 — Ca 3 Cb 2 Cd 2 Ce 2 Cf 2 Ch 2 Mc 2 Mk 2 Ml 21.</bibl>
           <p><milestone unit="traduction"/>Un aigle, fondant d’une roche élevée, enleva un agneau. À cette vue, un choucas, pris d’émulation, voulut l’imiter. Alors, se précipitant à grand bruit, il s’abattit sur un bélier ; mais ses griffes s’étant enfoncées dans les boucles de laine, il battait des ailes sans pouvoir s’en dépêtrer, Enfin le berger, s’avisant de la chose, accourut et le prit ; puis il lui rogna le bout des ailes, et, quand vint le soir, il l’apporta à ses enfants. Ceux-ci lui demandant quelle espèce d’oiseau c’était, il répondit : « Autant que je sache, moi, c’est un choucas ; mais, à ce qu’il prétend, lui, c’est un aigle. »</p>
           <p><milestone unit="traduction"/>C’est ainsi qu’à rivaliser avec les puissants non seulement vous perdez votre peine, mais encore vous faites rire de vos malheurs.</p>
         </div>
@@ -152,7 +151,7 @@
           <pb ed="perry" n="P3"/>
           <p><milestone unit="recitprose"/>Ὄνυξιν ἄρας ἀετὸς ἄρνα ἤγαγε τοῖς παισὶ δεῖπνον. Τοῦτο δὲ ζηλώσας κολοιὸς ὥρμήθη καὶ δὴ καταπτὰς ἐπὶ ἄρνα ἐνεπάρη τοῖς μαλλοῖς. Οἱ δὲ παῖδες τοῦτον κρατήσαντες ᾔκιζον. Ὁ δὲ κολοιὸς ἔφη· « Δίκαια πάσχω· τί γὰρ κολοιὸς ὢν ἀετὸν ἐμιμούμην ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τὰ κατὰ σὲ καὶ πρὸς δύναμιν ποίει, τὰ ὑπὲρ σὲ δὲ μὴ ζηλοῦ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 110.</p>
+          <bibl>Cod. Ba 110.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-6">
@@ -175,7 +174,7 @@
           <l><milestone unit="recitvers"/>μήπως ὁ αὐτός σε πάλιν κυνηγήσας</l>
           <l><milestone unit="recitvers"/>αὖθις τὰ πτερὰ τὰ σὰ κατερημώσῃ. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ χρηστὰς ἀμοιϐὰς τοῖς εὐεργέταις παρέχειν, τοὺς δὲ κακοὺς ἐκφεύγειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 23 Cb 17 Cc 14 Cd 17 Cf 21 Ch 17 Ma 152 Mc 22 Md 22 Mh 15 Mi 57 Mk 23 Mm 22.</p>
+          <bibl>Codd. Ca 23 Cb 17 Cc 14 Cd 17 Cf 21 Ch 17 Ma 152 Mc 22 Md 22 Mh 15 Mi 57 Mk 23 Mm 22.</bibl>
         </div>
         <div>
           <head>Chambry 6.2</head>
@@ -183,7 +182,7 @@
           <pb ed="perry" n="P275"/>
           <p><milestone unit="recitprose"/>Ποτὲ ἀετὸς ἑάλω ὑπ’ ἀνθρώπου. Τούτου δὲ τὰ πτερὰ ὁ ἄνθρωπος κόψας ἀφῆκε μετὰ τῶν ὀρνίθων ἐν οἴκῳ εἶναι. Ὀ δὲ ἦν κατηφὴς καὶ οὐδεν ἤσθιεν ἐκ τῆς λύπης, ὅμοιος δὲ ἦν βασιλεῖ δεσμώτῃ. Ἕτερος δέ τις τοῦτον ὠνησάμενος καὶ τὰ πτερὰ ἀνασπάσας καὶ μύρῳ χρίσας ἐποίησε πτερῶσαι. Ὁ δὲ πετασθεὶς καὶ τοῖς ὄνυξι λαγωὸν ἁρπάσας ἤνεγκεν αὐτῷ δῶρον. Ἀλώπηξ δὲ ἰδοῦσα εἶπεν· « Μὴ τούτῳ δίδου, ἀλλὰ τῷ πρώτῳ, ὅτι ὁ μὲν φύσει ἀγαθός ἐστι· ἐκεῖνον δὲ μᾶλλον ἐξευμενίζου, μή πως πάλιν λαϐών σε τὸ πτερὸν ἐρημώσῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δεῖ χρηστὰς ἀμοιϐὰς τοῖς εὐεργέταις παρέχειν, τοὺς πονηροὺς δὲ φρονίμως τροποῦσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 128 Bb 76.</p>
+          <bibl>Codd. Ba 128 Bb 76.</bibl>
           <p><milestone unit="traduction"/>Un jour un aigle fut pris par un homme. Celui-ci lui rogna les ailes et le lâcha dans sa basse-cour pour vivre avec la volaille. Alors l’oiseau baissait la tête et, de chagrin, ne mangeait plus : on l’eût pris pour un roi prisonnier. Mais un autre homme l’ayant acheté, lui arracha les plumes de l’aile, puis les fit repousser en en frottant la place avec de la myrrhe. Alors l’aigle, prenant l’essor, saisit un lièvre dans ses serres et le lui rapporta en présent. Un renard, l’ayant aperçu, lui dit : « Ce n’est pas à celui-ci qu’il faut le donner, mais à ton premier maître ; le deuxième en effet est naturellement bon ; tâche plutôt de te faire bien venir de l’autre, de peur qu’il ne te reprenne et ne t’arrache les ailes. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut généreusement payer de retour ses bienfaiteurs, et tenir prudemment les méchants à l’écart.</p>
         </div>
@@ -196,7 +195,7 @@
           <pb ed="perry" n="P276"/>
           <p><milestone unit="recitprose"/>Ὑπεράνωθεν πέτρας ἀετὸς ἐκαθέζετο λαγωοὺς θηρεῦσαι ζητῶν. Τοῦτον δέ τις ἔϐαλε τοξεύσας, καὶ τὸ μὲν βέλος ἔσω εἰσῆλθεν· ἡ δὲ γλυφὶς σὺν τοῖς πτεροῖς πρὸ τῶν ὀφθαλμῶν εἱστήκει. Ὁ δὲ ἰδὼν ἔφη· « Καὶ τοῦτό μοι ἑτέρα λύπη, τὸ τοῖς ἐμοῖς πτεροῖς ἀποθνῄσκειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τὸ κέντρον τῆς λύπης δεινότερόν ἐστιν, ὅταν τις ἐκ τῶν οἰκείων κινδυνεύσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 138 Bb 83 La 137 Lg 39 Md 106 Mg 149 Mh 90 Mi 22 Mm 131.</p>
+          <bibl>Codd. Ba 138 Bb 83 La 137 Lg 39 Md 106 Mg 149 Mh 90 Mi 22 Mm 131.</bibl>
           <p><milestone unit="traduction"/>Un aigle s’était perché au faîte d’un rocher à l’affût des lièvres. Un homme le frappa d’une flèche, et le trait s’enfonça dans sa chair, et la coche avec ses plumes se trouva devant ses yeux. À cette vue, il s’écria : « C’est pour moi un surcroît de chagrin de mourir par mes propres plumes. »</p>
           <p><milestone unit="traduction"/>L’aiguillon de la douleur est plus poignant, quand nous sommes battus par nos propres armes.</p>
         </div>
@@ -206,7 +205,7 @@
           <pb ed="perry" n="P276"/>
           <p><milestone unit="recitprose"/>Ἀετὸς εἰς ὕψος ἐκάθητο θηρεῦσαι λαγωούς. Τοῦτον τοξότης ἰδὼν ἔϐαλεν εὐστοχήσας. Στραφεὶς δέ, ἰδὼν τὴν γλυφίδα τῶν πτερῶν ἐξ αὐτοῦ οὖσαν, ἔφη· « Οὐ τοσοῦτον τὸν πέμψαντά σε μέμφομαι ὅσον τὰ ἐξ ἐμοῦ φυέντα πτερά. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῦτον κρεῖσσον λύπη καθέστηκεν, ὅταν τις ὑπὸ τῶν ἰδίων συγγενῶν πάθος κακὸν ὅσον τῶν ἀλλοτρίων καὶ ξένων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ma 146 Mo 146.</p>
+          <bibl>Codd. Ma 146 Mo 146.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-8">
@@ -217,7 +216,7 @@
           <pb ed="perry" n="P4"/>
           <p><milestone unit="recitprose"/>Ἀηδὼν ἐπί τινος ὑψηλῆς δρυὸς καθημένη κατὰ τὸ σύνηθες ᾖδεν. Ἱέραξ δὲ αὐτὴν θεασάμενος, ὡς ἠπόρει τροφῆς, ἐπιπτὰς συνέλαϐεν. Ἡ δὲ μέλλουσα ἀναιρεῖσθαι ἐδέετο αὐτοῦ μεθεῖναι αὐτήν, λέγουσα ὡς οὐχ ἱκανή ἐστιν ἱέρακος αὐτὴ γαστέρα πληρῶσαι· δεῖ δὲ αὐτόν, εἰ τροφῆς ἀπορεῖ, ἐπὶ τὰ μείζονα τῶν ὀρνέων τρέπεσθαι. Καὶ ὃς ὑποτυχὼν εἶπεν· « Ἀλλ’ ἔγωγε ἀπόπληκτος ἂν εἴην, εἰ τὴν ἐν χερσὶν ἑτοίμην βορὰν παρεὶς τὰ μηδέπω φαινόμενα διώκοιμι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτος καὶ τῶν ἀνθρώπων ἀλόγιστοί εἰσιν οἷ δι’ ἐλπίδα μειζόνων [πραγμάτων] τὰ ἐν χερσὶν ὄντα προΐενται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 14 Pb 4 Pd 6 Pe 10 Pf 3 Pg 2 Ph 3 Ma 14 Me 3 Mf 3.</p>
+          <bibl>Codd. Pa 14 Pb 4 Pd 6 Pe 10 Pf 3 Pg 2 Ph 3 Ma 14 Me 3 Mf 3.</bibl>
           <p><milestone unit="traduction"/>Un rossignol perché sur un chêne élevé chantait à son ordinaire. Un épervier l’aperçut, et, comme il manquait de nourriture, il fondit sur lui et le lia. Se voyant près de mourir, le rossignol le pria de le laisser aller, alléguant qu’il n’était pas capable de remplir à lui seul le ventre d’un épervier, que celui-ci devait, s’il avait besoin de nourriture, s’attaquer à des oiseaux plus gros. L’épervier répliqua : « Mais je serais stupide, si je lâchais la pâture que je tiens pour courir après ce qui n’est pas encore en vue. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que chez les hommes aussi, ceux-là sont déraisonnables qui dans l’espérance de plus grands biens laissent échapper ceux qu’ils ont dans la main.</p>
         </div>
@@ -227,7 +226,7 @@
           <pb ed="perry" n="P4"/>
           <p><milestone unit="recitprose"/>Ἀηδὼν ἐπί τινος δρυὸς ὑψηλῆς καθημένη ᾖδε κατὰ τὸ σύνηθες. Ἱέραξ δὲ αὐτὴν θεασάμενος, ἀπορῶν τροφῆς, ἐπιπτὰς ἀνελάϐετο αὐτήν. Ἡ δὲ μέλλουσα ἀναιρεῖσθαι ἐδέετο αὐτοῦ λέγουσα μὴ βρωθῆναι αὐτήν, ἐπειδὴ οὐχ ἱκανή ἐστιν ἱέρακος πληρῶσαι γαστέρα· δεῖ δὲ αὐτόν, εἰ τροφῆς ἀπορεῖ, ἐπὶ τὰ μείζονα τῶν ὀρνέων τρέπεσθαι. Ὑπολαϐὼν δὲ ὁ ἱέραξ ἔφη· « Ἀλλ’ ἔγωγε ἄφρων ἂν εἴην, εἰ τὴν ἐν χερσὶν ἑτοίμην βορὰν παρεὶς τὰ μηδέπω φαινόμενα διώκοιμι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων ἀλόγιστοί εἰσιν, οἵτινες δι’ ἐλπίδα μειζόνων τὰ ἐν χερσὶν ὄντα προΐενται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 2 Cb 4 Cc 2 Cd 4 Ce 3 Cf 4 Ch 4 Mc 3 Mh 2 Mk 4.</p>
+          <bibl>Codd. Ca 2 Cb 4 Cc 2 Cd 4 Ce 3 Cf 4 Ch 4 Mc 3 Mh 2 Mk 4.</bibl>
         </div>
         <div>
           <head>Chambry 8.3</head>
@@ -235,7 +234,7 @@
           <pb ed="perry" n="P4"/>
           <p><milestone unit="recitprose"/>Ἀηδὼν ἐπὶ δένδρου καθεζομένη κατὰ τὸ εἰωθὸς ᾖδεν. Ἱέραξ δὲ θεασάμενος καὶ τροφῆς ἀπορῶν συνείληφεν ἐπιπτάς. Ἡ δ’ ἀναιρεῖσθαι μέλλουσα ἐδεῖτο τοῦ ἱέρακος μὴ βρωθῆναι· μηδὲ γὰρ ἱκανὴν εἶναι ἱέρακος γαστέρα πληροῦν, δεῖν δὲ αὐτὸν τροφῆς προσδεόμενον ἐπὶ τὰ μείζω τῶν ὀρνέων τραπέσθαι. Καὶ ὁ ἱέραξ ὑπολαϐὼν εἶπεν· « Ἀλλ’ ἔγωγε ἄφρων ἂν εἴην, εἰ τὴν ἐν χερσὶν ἑτοίμην τροφὴν ἀφεὶς τὰ μὴ φαινόμενά πω διώκοιμι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων ἀλόγιστοί εἰσιν οἱ δι’ ἐλπίδα πλειόνων ἀδήλων τὰ ἐν χερσὶν προιέμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 3 Lb 2 Lc 3 Le 2 Lf 3 Lg 3 Lh 2 Md 2 Mg 3 Mi 37 Mj 3 Ml 2 Mm 2.</p>
+          <bibl>Codd. La 3 Lb 2 Lc 3 Le 2 Lf 3 Lg 3 Lh 2 Md 2 Mg 3 Mi 37 Mj 3 Ml 2 Mm 2.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-9">
@@ -246,7 +245,7 @@
           <pb ed="perry" n="P277"/>
           <p><milestone unit="recitprose"/>Ἀηδόνι συνεϐούλευε χελιδὼν τοῖς ἀνθρώποις εἶναι ὁμόροφον καὶ σύνοικον ὡς αὐτή. Ἡ δὲ εἶπεν· « Οὐ θέλω τὴν λύπην τῶν παλαιῶν μου συμφορῶν μεμνῆσθαι, καὶ διὰ τοῦτο τὰς ἐρήμους οἰκῶ. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τὸν λυπηθένθα ἔκ τινος τύχης καὶ τὸν τόπον φεύγειν ἐθέλειν ἔνθα ἡ λύπη συνέϐη.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 2 Bb 1 Bc 2.</p>
+          <bibl>Codd. Ba 2 Bb 1 Bc 2.</bibl>
           <p><milestone unit="traduction"/>L’hirondelle engageait le rossignol à loger sous le toit des hommes et à vivre avec eux, comme elle-même. Le rossignol répondit : « Je ne veux point raviver le souvenir de mes anciens malheurs : voilà pourquoi j’habite les lieux déserts. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’homme affligé par quelque coup de la fortune veut éviter jusqu’au lieu où le chagrin l’a frappé.</p>
         </div>
@@ -261,7 +260,7 @@
           <l><milestone unit="recitvers"/>τῶν γὰρ προγόνων τὴν λύμην ἀναφέρω.</l>
           <l><milestone unit="recitvers"/>Διὰ γὰρ τοῦτο τὰς ἐρήμους οἰκήσω. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι, ἐὰν λυπηθῇ τις ἔκ τινος τύχης, καὶ τὸν τόπον ἐκφεύγει οὗ ἐλυπήθη.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 224.</p>
+          <bibl>Cod. Mb 224.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-10">
@@ -270,7 +269,7 @@
         <pb ed="perry" n="P5"/>
         <p><milestone unit="recitprose"/>Ἀθήνησι χρεωφειλέτης ἀνὴρ ἀπαιτούμενος ὑπὸ τοῦ δανειστοῦ τὸ χρέος τὸ μὲν πρῶτον παρεκάλει ἀναϐολὴν αὐτῷ δοῦναι, ἀπορεῖν φάσκων. Ὡς δὲ οὐκ ἔπειθε, προσαγαγὼν ὗν ἣν εἶχε μόνην, παρόντος αὐτοῦ, ἐπώλει. Ὠνητοῦ δὲ προσελθόντος καὶ διερωτῶντος εἰ τοκὰς ἡ ὗς εἴη, ἐκεῖνος ἔφη μὴ μόνον αὐτὴν τίκτειν, ἀλλὰ καὶ παραδόξως· τοῖς μὲν γὰρ μυστηρίοις θήλεα ἀποκύειν, τοῖς δὲ Παναθηναίοις ἄρσενα. Τοῦ δὲ ἐκπλαγέντος πρὸς τὸν λόγον, ὁ δανειστὴς εἶπεν· « Ἀλλὰ μὴ θαύμαζε· αὕτη γάρ σοι καὶ Διονυσίοις ἐρίφους τέξεται. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλοὶ διὰ τὸ ἴδιον κέρδος οὐκ ὀκνοῦσιν οὐδὲ τοῖς ἀδυνάτοις ψευδομαρτυρεῖν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 15 Pb 5 Pe 11 Pf 4 Pg 3 Ph 4 Me 4 Mf 4.</p>
+        <bibl>Codd. Pa 15 Pb 5 Pe 11 Pf 4 Pg 3 Ph 4 Me 4 Mf 4.</bibl>
         <p><milestone unit="traduction"/>À Athènes, un débiteur, sommé par son créancier de rembourser sa dette, le pria d’abord de lui accorder un délai, sous prétexte qu’il était gêné. Ne pouvant le persuader, il amena une truie, la seule qu’il possédât, et la mit en vente en présence du créancier. Un acheteur se présenta et demanda si la truie était féconde. « Oui, elle est féconde, répondit-il, elle l’est même extraordinairement : aux Mystères elle enfante des femelles, et aux Panathénées des mâles. » Comme l’acheteur était surpris de ce qu’il entendait, le créancier ajouta : « Cesse de t’étonner ; car cette truie te donnera aussi des chevreaux aux Dionysies. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que beaucoup de gens n’hésitent pas, quand leur intérêt personnel est en jeu, à jurer même des choses impossibles.</p>
       </div>
@@ -280,7 +279,7 @@
         <pb ed="perry" n="P393"/>
         <p><milestone unit="recitprose"/>Αἰθίοπά τις ὠνήσατο τοιοῦτον αὐτῷ τὸ χρῶμα εἶναι δοκῶν ἀμελείᾳ τοῦ πρότερον ἔχοντος. Καὶ παραλαϐὼν οἴκαδε, πάντα μὲν αὐτῷ προσῆγε τὰ ῥύμματα, πᾶσι δὲ λούτροις ἐπειρᾶτο καθαίρειν. Καὶ τὸ μὲν χρῶμα μεταϐάλλειν οὐκ εἶχε, νοσεῖν δὲ τῷ πονεῖν παρεσκεύασεν.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι μένουσιν αἱ φύσεις ὡς προῆλθον τὴν ἀρχήν.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 79 Lb 20 Le 20 Lf 79 Lh 9 Ma 157 Md 32 Mg 12 Mi 67 Mj 23 Ml 17 Mm 33.</p>
+        <bibl>Codd. La 79 Lb 20 Le 20 Lf 79 Lh 9 Ma 157 Md 32 Mg 12 Mi 67 Mj 23 Ml 17 Mm 33.</bibl>
         <p><milestone unit="traduction"/>Un homme avait acheté un nègre, s’imaginant que sa couleur venait de la négligence du précédent propriétaire. L’ayant emmené chez lui, il le soumit à tous les savonnages, il essaya tous les lavages pour le blanchir ; mais il ne put modifier sa couleur, et il le rendit malade à force de soins.</p>
         <p><milestone unit="traduction"/>La fable fait voir que le naturel persiste tel qu’il s’est montré d’abord.</p>
       </div>
@@ -292,7 +291,7 @@
           <pb ed="perry" n="P16"/>
           <p><milestone unit="recitprose"/>Αἴλουρος, συλλαϐὼν ἀλεκτρυόνα, τοῦτον ἐϐούλετο μετ’ εὐλόγου αἰτίας καταθοινήσασθαι. Καὶ δὴ ἀρξάμενος κατηγόρει αὐτοῦ λέγων ὀχληρὸν αὐτὸν εἶναι τοῖς ἀνθρώποις νύκτωρ κεκραγότα καὶ οὐδὲ ὕπνου τυχεῖν ἐῶντα αὐτούς. Τοῦ δὲ εἰπόντος ὡς ἐπ’ ὠφελείᾳ αὐτῶν τοῦτο ποιεῖ· ἐπὶ γὰρ τὰ συνήθη τῶν ἔργων διεγείρει, ἐκ δευτέρου ἔλεγεν· « Ἀλλὰ καὶ ασεϐὴς εἰς τὴν φύσιν καθέστηκας καὶ ἀδελφαῖς καὶ μητρὶ ἐπεμϐαίνων. » Τοῦ δὲ καὶ τοῦτο εἰς ὠφέλειαν τῶν δεσποτῶν πράττειν φήσαντος· πολλὰ γὰρ αὐτοῖς ὠὰ τίκτεσθαι παρασκευάζει, διαπορηθεῖς ἐκεῖνος ἔφη· « Ἐὰν οὖν σὺ ἀεὶ ἀφορμῶν εὐπορῇς, ἐγώ σε οὐχ ἥσσον ἔδομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πονηρὰ φύσις πλημμελεῖν προαιρουμένη, κἂν μὴ μετ’ εὐλόγου προσχήματος δυνηθῇ, ἀπαρακαλύπτως πονηρεύεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 3 Pb 16 Pc 3 Pd 13 Pf 5 Pg 12 Ph 5 Pi 2 Ma 3 Me 5 Mf 5.</p>
+          <bibl>Codd. Pa 3 Pb 16 Pc 3 Pd 13 Pf 5 Pg 12 Ph 5 Pi 2 Ma 3 Me 5 Mf 5.</bibl>
         </div>
         <div>
           <head>Chambry 12.2</head>
@@ -300,7 +299,7 @@
           <pb ed="perry" n="P16"/>
           <p><milestone unit="recitprose"/>Αἴλουρος, συλλαϐὼν ἀλεκτρυόνα, μετ’ εὐλόγου τοῦτον αἰτίας ἠϐουλήθη καταφαγεῖν. Καὶ δὴ κατηγόρει αὐτοῦ ὡς ὀχληρὸς εἴη τοῖς ἀνθρώποις νύκτωρ κεκραγὼς καὶ μὴ συγχωρῶν ὕπνου τυγχάνειν. Τοῦ δ’ ἀπολογουμένου ἐπὶ τῇ ἐκείνων ὠφελείᾳ τοῦτο ποιεῖν, ὡς ἐπὶ τὰ συνήθη τῶν ἔργων ἐγείρεσθαι, πάλιν ὁ αἴλουρος αἰτίαν ἐπέφερεν ὡς ἀσεϐὴς εἴη περὶ τὴν φύσιν, μητρὶ καὶ ἀδελφαῖς συμμιγνύμενος. Τοῦ δὲ καὶ τοῦτο πρὸς ὠφέλειαν τῶν δεσποτῶν πράττειν φήσαντος, πολλῶν αὐτοῖς ἐντεῦθεν ὠῶν τικτομένων, ὁ αἴλουρος εἰπών· « Ἀλλ’ εἰ σύ γε πολλῶν εὐπορεῖς εὐπροσώπων ἀπολογιῶν, ἔγωγε μέντοι ἄτροφος οὐ μενῶ », τοῦτον κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἡ πονηρὰ φύσις πλημμελεῖν αἱρουμένη, εἰ μὴ μετ’ εὐλόγου δυνηθείη προσχήματος, ἀπαρακαλύπτως γε μὴν πονηρεύεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 15 Cb 7 Cd 7 Ce 7 Cf 7 Ch 7 Mc 5 Mh 5 Mk 6.</p>
+          <bibl>Codd. Ca 15 Cb 7 Cd 7 Ce 7 Cf 7 Ch 7 Mc 5 Mh 5 Mk 6.</bibl>
           <p><milestone unit="traduction"/>Une belette, ayant attrapé un coq, voulut donner une raison plausible pour le dévorer. En conséquence elle l’accusa d’importuner les hommes en chantant la nuit et en les empêchant de dormir. Le coq se défendit en disant qu’il le faisait pour leur être utile ; car s’il les réveillait, c’était pour les rappeler à leurs travaux accoutumés. Alors la belette produisit un autre grief et l’accusa d’outrager la nature par les rapports qu’il avait avec sa mère et ses sœurs. Il répondit qu’en cela aussi il servait l’intérêt de ses maîtres, puisque grâce à cela les poules leur pondaient beaucoup d’œufs. « Eh bien ! s’écria la belette, tu as beau être en fonds de belles justifications, moi je ne resterai pas à jeun pour cela, » et elle le dévora.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’une mauvaise nature, déterminée à mal faire, quand elle ne peut pas se couvrir d’un beau masque, fait le mal à visage découvert.</p>
         </div>
@@ -310,7 +309,7 @@
           <pb ed="perry" n="P16"/>
           <p><milestone unit="recitprose"/>Αἴλουρος, ἀλεκτρυόνα συλλαϐὼν, ἠϐούλετο μετ’ εὐλόγου αἰτίας τοῦτον καταθοινήσασθαι. Καὶ δὴ λέγοντος ὀχληρὸν αὐτὸν εἶναι τοῖς ἀνθρώποις νύκτωρ κεκραγότα· « Ἐπ’ ὠφελείᾳ, ἔφη, τῶν ἀνθρώπων τοῦτο ποιῶ. » Ἐκ δευτέρου πάλιν φήσαντος· « Ἀλλ’ ἀσεϐὴς εἰς τὴν φύσιν τυγχάνεις », « Καὶ τοῦτο ἐπ’ ὠφελείᾳ τῶν δεσποτῶν, εἴρηκε, πράττω. » Ὁ δὲ ἀποκριθείς· « Ἐὰν σὺ πολλῶν ἀφορμῶν εὐπορήσῃς, ἔφη, ἐγὼ τέως ἄδειπνος οὐ μενῶ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἡ πονηρὰ φύσις ἀδικεῖν προαιρουμένη, κἂν μετ’ εὐλόγου προσχήματος οὐ δυνηθῇ, ἀλλά γε ἀπαρακαλύπτως πονηρεύεται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cc 5.</p>
+          <bibl>Cod. Cc 5.</bibl>
         </div>
         <div>
           <head>Chambry 12.4</head>
@@ -318,7 +317,7 @@
           <pb ed="perry" n="P16"/>
           <p><milestone unit="recitprose"/>Αἴλουρος, ἀλεκτρυόνα συλλαϐὼν, μετ’ εὐλόγου τοῦτον αἰτίας ἠϐουλήθη καταφαγεῖν. Καὶ δὴ κατηγόρει αὐτοῦ ὡς ὀχληρὸς εἴη τοῖς ἀνθρώποις νύκτωρ κεκραγὼς καὶ μὴ συγχωρῶν ὕπνου τυγχάνειν. Τοῦ δ’ ἀπολογουμένου ἐπὶ τῇ ἐκείνων ὠφελείᾳ τοῦτο ποιεῖν, ὡς ἐπὶ τὰ συνήθη τῶν ἔργων ἐγείρεσθαι, πάλιν ὁ αἴλουρος αἰτίαν ἐπέφερεν ὡς ἀσεϐὴς εἴη περὶ τὴν φύσιν, μητρὶ καὶ ἀδελφαῖς συμμιγνύμενος. Τοῦ δὲ καὶ τοῦτο πρὸς ὠφέλειαν τῶν δεσποτῶν πράττειν φήσαντος, πολλῶν αὐτοῖς ἐντεῦθεν ὠῶν τικτομένων, ὁ αἴλουρος εἰπών· « Ἀλλ’ εἰ σύ γε πολλῶν εὐπορεῖς εὐπροσώπων ἀπολογιῶν, ἔγωγε μέντοι ἄτροφος οὐ μενῶ », τοῦτον κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἡ πονηρὰ φύσις πλημμελεῖν αἱρουμένη, εἰ μὴ μετ’ εὐλόγου δυνηθείη προσχήματος, ἀπαρακαλύπτως γε μὴν πονηρεύεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 6 Lb 5 Lc 4 Le 5 Lf 6 Lg 4 Md 5 Mg 6 Mi 40 Mj 6 Ml 5 Mm 5.</p>
+          <bibl>Codd. La 6 Lb 5 Lc 4 Le 5 Lf 6 Lg 4 Md 5 Mg 6 Mi 40 Mj 6 Ml 5 Mm 5.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-13">
@@ -329,7 +328,7 @@
           <pb ed="perry" n="P79"/>
           <p><milestone unit="recitprose"/>Ἔν τινι οἰκίᾳ πολλοὶ μύες ἦσαν. Αἴλουρος δὲ τοῦτο γνοὺς ἦκεν ἐνταῦθα καὶ συλλαμϐάνων ἕνα ἕκαστον κατήσθιεν. Οἱ δὲ μύες συνεχῶς ἀναλισκόμενοι κατὰ τῶν ὀπῶν ἔδυνον, καὶ ὁ αἴλουρος μηκέτι αὐτῶν ἐφικνεῖσθαι δυνάμενος, δεῖν ἔγνω δι’ ἐπινοίας αὐτοὺς ἐκκαλεῖσθαι. Διόπερ ἀναϐὰς ἐπί τινα πάσσαλον καὶ ἑαυτὸν ἐνθένδε ἀποκρεμάσας προσεποιεῖτο τὸν νεκρόν. Τῶν δὲ μυῶν τις παρακύψας, ὡς ἐθεάσατο αὐτὸν, εἶπεν· « Ἀλλ’, ὦ οὗτος, σοί γε, κἂν θύλαψ γένῃ, οὐ προσελεύσομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ἀνθρώπων, ὅταν τῆς ἐνίων μοχθηρίας πειραθῶσιν, οὐκέτι αὐτῶν ταῖς ὑποκρίσεσιν [οὗτοι] ἐξαπατῶνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 76 Pb 80 Pc 41 Pe 45 Pg 51 Ma 59.</p>
+          <bibl>Codd. Pa 76 Pb 80 Pc 41 Pe 45 Pg 51 Ma 59.</bibl>
           <p><milestone unit="traduction"/>Une maison était infestée de rats. Un chat, l’ayant su, s’y rendit, et, les attrapant l’un après l’autre, il les mangeait. Or les rats, se voyant toujours pris, s’enfonçaient dans leurs trous. Ne pouvant plus les atteindre, le chat pensa qu’il fallait imaginer quelque ruse pour les en faire sortir. C’est pourquoi il grimpa à une cheville de bois et, s’y étant suspendu, il contrefit le mort. Mais un des rats sortant la tête pour regarder, l’aperçut et dit : « Hé ! l’ami, quand tu serais sac, je ne t’approcherais pas. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes sensés, quand ils ont éprouvé la méchanceté de certaines gens, ne se laissent plus tromper à leurs grimaces.</p>
         </div>
@@ -339,7 +338,7 @@
           <pb ed="perry" n="P79"/>
           <p><milestone unit="recitprose"/>Ἔν τινι οἰκίᾳ πολλοὶ μύες ἦσαν. Αἴλουρος δὲ τοῦτο γνοὺς ἧκεν ἐνταῦθα καὶ συλλέγων ἕνα καθ’ ἕνα κατήσθιεν. Οἱ δὲ μύες συνεχῶς ἀναλισκόμενοι εἶπον πρὸς ἑαυτούς· « Ἕτοιμοι κατέλθωμεν κάτω καὶ ἐπὶ τῶν ὀπῶν δύνωμεν, ἵνα μὴ παντελῶς ἀπολεσθῶμεν· τοῦ γὰρ αἰλούρου μηκέτι δυναμένου ἀφικνεῖσθαι ἐκεῖσε, ἡμεῖς διασωθησόμεθα. » Ὁ δὲ, μὴ δυνάμενος αὐτῶν ἀφικέσθαι, δεῖν ᾠήθη καὶ ἔγνω δι’ ἐπινοίας καὶ μηχανῆς αὐτοὺς ἐκκαλεῖσθαι. Ἀναϐὰς γὰρ ἐπί τινα πάσσαλον καὶ ἑαυτὸν ἔνθεν ἀποκρημνίσας τε καὶ κρεμάσας, προσεποιεῖτο αὑτὸν νεκρὸν εἶναι. Τῶν δὲ μυῶν τις παρακύψας, ὡς ἐθεάσατο αὐτόν, ἔφη· « Ὦ οὗτος, κἂν θῦλαξ γένῃ σύ, οὐ προσελευσόμεθά σοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ἀνθρώπων, ὅταν τῆς ἐνίων μοχθηρίας πειραθῶσιν, οὐκέτι αὐτῶν ταῖς ὑποκρίσεσιν ἐξαπατῶνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 67 Cb 44 Cd 41 Ce 46 Cf 50 Ch 51 Mc 43 Mh 44 Mk 47.</p>
+          <bibl>Codd. Ca 67 Cb 44 Cd 41 Ce 46 Cf 50 Ch 51 Mc 43 Mh 44 Mk 47.</bibl>
         </div>
         <div>
           <head>Chambry 13.3</head>
@@ -347,7 +346,7 @@
           <pb ed="perry" n="P79"/>
           <p><milestone unit="recitprose"/>Ἐν οἰκίᾳ τινι πολλῶν μυῶν ὄντων, αἴλουρος τοῦτο γνοὺς ἧκεν ἐνταῦθα καὶ καθ’ ἕκαστον αὐτῶν συλλαμϐάνων κατήσθιεν. Οἱ δὲ καθ’ ἑκάστην ἑαυτοὺς ἀναλισκομένους ὁρῶντες ἔφασαν πρὸς ἀλλήλους· « Μηκέτι κάτω κατέλθωμεν, ἵνα μὴ παντάπασιν ἀπολώμεθα. Τοῦ γὰρ αἰλούρου μὴ δυναμένου δεῦρο ἐξικνεῖσθαι, ἡμεῖς σωθησόμεθα. » Ὁ δὲ αἴλουρος , μηκέτι τῶν μυῶν κατιόντων, ἔγνω δι’ ἐπινοίας αὐτοὺς σοφιζόμενος ἐκκαλέσασθαι. Καὶ δὴ ἀπὸ παττάλου τινὸς ἀναϐὰς ἑαυτὸν ἀπῃώρησε καὶ προσεποιεῖτο νεκρὸς εἶναι. Τῶν δὲ μυῶν τις, παρακύψας καὶ ἰδὼν αὐτόν, ἔφη· « Ὦ οὗτος, κἂν θῦλαξ γένῃ, οὐ προσελεύσομαι σοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τῶν ἀνθρώπων οἱ φρόνιμοι, ὅταν τῆς ἐνίων μοχθηρίας πειραθῶσιν, οὐκέτι αὐτῶν ἐξαπατῶνται ταῖς ὑποκρίσεσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 28 Lb 41 Le 41 Lf 28 Md 49 Me 48 Mf 43 Mg 56 Mi 84 Mj 49 Ml 55.</p>
+          <bibl>Codd. La 28 Lb 41 Le 41 Lf 28 Md 49 Me 48 Mf 43 Mg 56 Mi 84 Mj 49 Ml 55.</bibl>
         </div>
         <div>
           <head>Chambry 13.4</head>
@@ -355,7 +354,7 @@
           <pb ed="perry" n="P79"/>
           <p><milestone unit="recitprose"/>Αἰλούρου προσποιουμένου νεκρωθῆναι, ὡς τοῦτον οἱ μύες ἐθεάσαντο, ἔφησαν· « Ὦ οὗτος, κἂν θῦλαξ γένῃ, οὐ προσελευσόμεθά σοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τῶν ἀνθρώπων οἱ φρόνιμοι, ὅταν τῆς ἐνίων μοχθηρίας πειραθῶσιν, οὐκέτι αὐτῶν ἐξαπατῶνται ταῖς ὑποκρίσεσι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mm 35.</p>
+          <bibl>Cod. Mm 35.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-14">
@@ -366,7 +365,7 @@
           <pb ed="perry" n="P7"/>
           <p><milestone unit="recitprose"/>Αἴλουρος ἀκούσας ὅτι ἔν τινι ἐπαύλει ὄρνεις νοσοῦσι, σχηματίσας ἑαυτὸν εἰς ἰατρὸν καὶ τὰ τῆς ἐπιστήμης πρόσφορα ἀναλαϐῶν ἐργαλεῖα, παραγένετο, καὶ στὰς πρὸ τῆς ἐπαύλεως ἐπυνθάνετο αὐτῶν πῶς ἔχοιεν. Αἱ δὲ ὑποτυχοῦσαι· « Καλῶς, ἔφασαν, ἐὰν σὺ ἐντεῦθεν ἀπαλλαγῇς. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ τῶν ἀθρώπων οἱ πονηροὶ τοὺς φρονίμους οὐ λανθάνουσι, κἂν τὰ μάλιστα χρηστότητα ὑποκρίνωνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 17 Pb 7 Pd 8 Pe 12 Pg 5 Ma 15 Mb 3 — Ca 14 Ce 9 Cf 9.</p>
+          <bibl>Codd. Pa 17 Pb 7 Pd 8 Pe 12 Pg 5 Ma 15 Mb 3 — Ca 14 Ce 9 Cf 9.</bibl>
           <p><milestone unit="traduction"/>Une belette, ayant appris qu’il y avait des poules malades dans une métairie, se déguisa en médecin, et, prenant avec elle les instruments de l’art, elle s’y rendit. Arrivée devant la métairie, elle leur demanda comment elles allaient : « Bien, répondirent-elles, si tu t’en vas d’ici. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que les hommes sensés lisent dans le jeu des méchants, malgré toutes leurs affectations d’honnêteté.</p>
         </div>
@@ -383,7 +382,7 @@
           <l><milestone unit="recitvers"/>« Εἰ σὺ παρέλθῃς, ἐγὼ οὐκ ἀποθνῄσκω·</l>
           <l><milestone unit="recitvers"/>ζωὴν γὰρ ζήσω δορκάδος ὑπερτέραν. »</l>
           <p><milestone unit="epimythiumprose"/>Τοὺς δολίους ὑποκριτάας, τοὺς λέγοντας φιλεῖν, ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 157 Cb 85 Cd 99 Cg 30 Ch 105 Mb 139 Mc 84.</p>
+          <bibl>Codd. Ca 157 Cb 85 Cd 99 Cg 30 Ch 105 Mb 139 Mc 84.</bibl>
         </div>
         <div>
           <head>Chambry 14.3</head>
@@ -391,7 +390,7 @@
           <pb ed="perry" n="P7"/>
           <p><milestone unit="recitprose"/>Ὄρνις ποτὲ ἠσθένει· αἴλουρος δὲ προκύψας εἶπεν· « Πῶς ἔχεις ; εἴ τι χρῄζεις, ἐγώ σοι δώσω, μόνον ὑγίαινε. » Ἡ δὲ ἔφη· « Ἐὰν ἀπέλθῃς, οὐκ ἀποθνῄσκω. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] ὑποκριτὰς δολίους φιλεῖν λέγοντας ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 111 Bb 67 Md 90 Mh 82 Mi 6 Mm 108.</p>
+          <bibl>Codd. Ba 111 Bb 67 Md 90 Mh 82 Mi 6 Mm 108.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-15">
@@ -402,7 +401,7 @@
           <pb ed="perry" n="P280"/>
           <p><milestone unit="recitprose"/>Αἰγοϐοσκὸς τὰς αἶγας ἀνεκαλεῖτο πρὸς τὴν μάνδραν. Μία δὲ ἐξ αὐτῶν ὑπελείφθη, ἡδύ τι βοσκομένη. Ῥίψας δ’ ὁ ποιμὴν πέτραν τὸ κέρας αὐτῆς κατέαξεν εὐστοχήσας. Ἐδυσώπει δὲ τὴν αἶγα μὴ εἰπεῖν τοῦτο τῷ δεσπότῃ. Ἡ δὲ εἶπεν· « Κἂν ἐγω σιωπήσω, πῶς κρύψω ; πρόδηλον γάρ ἐστι πᾶσι τὸ κέρας μου κεκλασμένον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, τῆς αἰτίας προδήλου οὔσης, οὐ δυνατὸν ταύτην καλύψαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 4 Bb 3.</p>
+          <bibl>Codd. Ba 4 Bb 3.</bibl>
           <p><milestone unit="traduction"/>Un chevrier rappelait ses chèvres à l’étable. L’une d’ elles s’étant attardée à quelque friande pâture, le chevrier lui lança une pierre, et visa si juste qu’il lui cassa une corne. Alors il se mit à supplier la chèvre de ne pas le dire au maître. La chèvre répondit : « Quand bien même je garderais le silence, comment pourrais-je le cacher ? Il est visible à tous les yeux que ma corne est cassée. »</p>
           <p><milestone unit="traduction"/>Quand la faute est évidente, il est impossible de la dissimuler.</p>
         </div>
@@ -412,7 +411,7 @@
           <pb ed="perry" n="P280"/>
           <p><milestone unit="recitprose"/>Αἰπόλος αἶγας πρὸς μάνδραν ἐνεκαλεῖτο. Μιᾶς δὲ ἐξ αὐτῶν ἐν πόᾳ τινὶ δροσερᾷ καταλειφθείσης, ὁ ποιμὴν κατ’ ἐκείνης λίθον ἀφῆκε, καὶ εὐστόχως βαλὼν τὸ κέρας συνέτριψεν· ὅθεν καὶ ἐδυσώπει τὴν πεπονθυῖαν ἀνέκφραστον τῷ κυρίῳ διατηρῆσαι τὸ δράμα. Ἡ δὲ ἔφησε· « Κἂν ἐγὼ σιωπήσω, τὸ κέρας κεκράξεται. »</p>
           <p><milestone unit="epimythiumprose"/>Τῆς αἰτίας προδήλου οὔσης, ἀδύνατον ταύτην ἐπικαλύψαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 4.</p>
+          <bibl>Cod. Bc 4.</bibl>
         </div>
         <div>
           <head>Chambry 15.3</head>
@@ -432,7 +431,7 @@
           <l><milestone unit="recitvers"/>τῆς γὰρ καρᾶς μου μονοκέρωτος οὔσης,</l>
           <l><milestone unit="recitvers"/>πρόδηλόν ἐστι τοῖς ἐμὲ θεωροῦσι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι, τῆς αἰτίας προδήλου τυγχανούσης, οὐδεὶς δύναται ταύτην κατακαλύψαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 191.</p>
+          <bibl>Cod. Mb 191.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-16">
@@ -443,7 +442,7 @@
           <pb ed="perry" n="P279"/>
           <p><milestone unit="recitprose"/>Αἶγα καὶ ὄνον ἔτρεφέ τις. Ἡ δὲ αἶξ, φθονήσασα τῷ ὄνῳ διὰ τὸ περισσὸν τῆς τροφῆς, ἔλεγεν ὡς ἄπειρα κολάζῃ, ποτὲ μὲν ἀλήθων, ποτὲ δὲ ἀχθοφορῶν, καὶ συνεϐούλευεν ἐπίληπτον ἑαυτὸν ποιήσαντα καταπεσεῖν ἔν τινι βόθρῳ καὶ ἀναπαύσεως τυχεῖν. Ὁ δὲ πιστεύσας καὶ πεσὼν συνετρίϐη. Ὁ δὲ δεσπότης τὸν ἰατρὸν καλέσας ᾔτει βοηθεῖν. Ὁ δὲ αἰγὸς πνεύμονα ἐγχυματίσαι ἔλεγεν αὐτῷ καὶ τῆς ὑγείας τυχεῖν. Τὴν δὲ αἶγα θύσαντες τὸν ὄνον ἰάτρευον.</p>
           <p><milestone unit="epimythiumprose"/>Ὁτι ὅστις καθ’ ἑτέρου δόλια μηχανᾶται ἑαυτοῦ γίνεται τῶν κακῶν ἀρχηγός.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 3 Bb 2.</p>
+          <bibl>Codd. Ba 3 Bb 2.</bibl>
           <p><milestone unit="traduction"/>Un homme nourrissait une chèvre et un âne. Or la chèvre devint envieuse de l’âne, parce qu’il était trop bien nourri. Et elle lui dit : « Entre la meule à tourner et les fardeaux à porter, ta vie est un tourment sans fin, » et elle lui conseillait de simuler l’épilepsie, et de se laisser tomber dans un trou pour avoir du repos. Il suivit le conseil, se laissa tomber et se froissa tout le corps. Son maître ayant fait venir le vétérinaire, lui demanda un remède pour le blessé. Le vétérinaire lui prescrivit d’infuser le poumon d’une chèvre ; ce remède lui rendrait la santé. En conséquence on immola la chèvre pour guérir l’âne.</p>
           <p><milestone unit="traduction"/>Quiconque machine des fourberies contre autrui devient le premier artisan de son malheur.</p>
         </div>
@@ -453,7 +452,7 @@
           <pb ed="perry" n="P279"/>
           <p><milestone unit="recitprose"/>Αἶγα καὶ ὄνον ἔτρεφέ τις. Ἡ δὲ αἲξ, φθονήσασα τῷ ὄνῳ διὰ τὸ περιττὸν τῆς τροφῆς, εἰρωνικῶς συνεϐούλευε λέγουσα· « Ἄπειρα κολάζῃ, ποτὲ μὲν ἀλήθων, ποτὲ δ’ ἀχθηφορῶν. Ἐπίληπτον οὖν ἑαυτὸν ποιήσας τῷ βόθρῳ κρημνίσθητι. » Πεισθεὶς οὖν ὁ ὄνος ἐποίησεν ὡς ἐδιδάχθη· ὅθεν καὶ συνετρίϐη. Ὁ δὲ δεσπότης ἀμφοτέρων καλέσας τὸν ἰατρὸν βοηθεῖν τῷ ὄνῳ ᾐτεῖτο. Ὁ δὲ πόμα τούτῳ δι’ αἰγὸς πνεύμονος κατασκευασθὲν κεράσαι ὠρίσατο καὶ οὕτω τῆς ὑγείας τυχεῖν. Θύσαντες τοίνυν τὴν ἀθλίαν καὶ αὐτεπίϐουλον αἶγα, τὸν ὄνον ἰάτρευον.</p>
           <p><milestone unit="epimythiumprose"/>Ὅστις καθ’ ἑτέρου δόλον μηχανᾶται ἑαυτοῦ ἐστι τῶν κακῶν αὐτουργός.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 3.</p>
+          <bibl>Cod. Bc 3.</bibl>
         </div>
         <div>
           <head>Chambry 16.3</head>
@@ -485,7 +484,7 @@
           <l><milestone unit="recitvers"/>τρίψαντες τὸν πνεύμον’ αἵματι ἰδίῳ</l>
           <l><milestone unit="recitvers"/>ἐγχυματοῦντες ἰάτρευσαν τὴν νόσον.</l>
           <l><milestone unit="recitvers"/>Αὐτὸς καθ’ αὑτοῦ λανθάνει τοῦτο ποιῶν.</l>
-          <p><milestone unit="manuscrits"/>Cod. Mb 12.</p>
+          <bibl>Cod. Mb 12.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-17">
@@ -496,7 +495,7 @@
           <pb ed="perry" n="P6"/>
           <p><milestone unit="recitprose"/>Αἰπόλος τὰς αἶγας αὑτοῦ ἀπελάσας ἐπὶ νομήν, ὡς ἐθεάσατο ἀγρίαις αὐτὰς ἀναμιγείσας, ἑσπέρας ἐπιλαϐούσης, πάσας εἰς τὸ ἑαυτοῦ σπήλαιον εἰσήλασε. Τῇ δὲ ὑστεραίᾳ χειμῶνος πολλοῦ γενομένου, μὴ δυνάμενος ἐπὶ τὴν συνήθη νομὴν αὐτὰς παραγαγεῖν, ἔνδον ἐτημέλει, ταῖς μὲν ἰδίαις μετρίαν τροφὴν παραϐάλλων πρὸς μόνον τὸ μὴ λιμώττειν, ταῖς δὲ ὀθνείαις πλείονα παρασωρεύων πρὸς τὸ καὶ αὐτὰς ἰδιοποιήσασθαι. Παυσαμένου δὲ τοῦ χειμῶνος, ἐπειδὴ πάσας ἐπὶ νομὴν ἐξήγαγεν, αἱ ἄγριαι ἐπιλαϐόμεναι τῶν ὀρῶν ἔφευγον. Τοῦ δὲ ποιμένος ἀχαριστίαν αὐτῶν κατηγοροῦντος, εἴγε περιττοτέρας αὐταὶ τημελείας ἐπιτυχοῦσαι καταλείπουσιν αὐτὸν, ἔφασαν ἐπιστραφεῖσαι· « Ἀλλὰ καὶ δι’ αὐτὸ τοῦτο μᾶλλον φυλαττόμεθα· εἰ γὰρ ἡμᾶς τὰς χθές σοι προσεληλυθυίας τῶν πάλαι σὺν σοὶ προετίμησας, δῆλον ὅτι, εἰ καὶ ἕτεραί σοι μετὰ ταῦτα προσπελάσουσιν, ἐκείνας ἡμῶν προκρινεῖς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ μὴ δεῖν τούτων ἀσμενίζεσθαι τὰς φιλίας οἳ τῶν παλαιῶν φίλων ἡμᾶς τοὺς προσφάτους προτιμῶσι, λογιζομένους ὅτι, κἂν ἡμῶν ἐγχρονιζόντων ἑτέροις φιλιάσωσιν, ἐκείνους προκρινοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 16 Pb 6 Pe 11 altera pars Pg 4.</p>
+          <bibl>Codd. Pa 16 Pb 6 Pe 11 altera pars Pg 4.</bibl>
           <p><milestone unit="traduction"/>Un chevrier, ayant mené ses chèvres au pâturage, s’aperçut qu’elles étaient mêlées à des chèvres sauvages, et, quand le soir tomba, il les poussa toutes dans sa grotte. Le lendemain un gros orage éclata. Ne pouvant les mener au pâturage habituel, il les soigna dedans ; mais il ne donna à ses propres chèvres qu’une poignée de fourrage, juste de quoi les empêcher de mourir de faim ; pour les étrangères, au contraire, il grossit la ration, dans le dessein de se les approprier elles aussi. Le mauvais temps ayant pris fin, il les fit toutes sortir dans le pâtis ; mais les chèvres sauvages, gagnant la montagne, s’enfuirent. Comme le berger les accusait d’ingratitude pour l’abandonner ainsi, après les soins particuliers qu’il avait pris d’elles, elles se retournèrent pour répondre : « Raison de plus pour nous d’être en défiance ; car si tu nous as mieux traitées, nous, tes hôtesses d’hier, que tes vieilles ouailles, il est évident que, si d’autres chèvres viennent encore à toi, tu nous négligeras pour elles. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas accueillir les protestations d’amitié de ceux qui nous font passer, nous, les amis de fraîche date, avant les, vieux amis. Disons-nous que, quand notre amitié aura pris de l’âge, s’ils se lient avec d’autres, c’est ces nouveaux amis qui auront leurs préférences.</p>
         </div>
@@ -506,7 +505,7 @@
           <pb ed="perry" n="P6"/>
           <p><milestone unit="recitprose"/>Ἐν σπηλαίῳ ἀοικήτῳ αἰγοϐοσκὸς ἐν χειμῶνι τὰς αἶγας ἤγαγεν. Εὗρε δὲ ἐκεῖ ἀγρίας αἶγας καὶ τράγους πλείονας ὧν εἶχεν αὐτὸς καὶ μείζους. Τὰς ἰδίας δὲ ἀφείς, τερφθεὶς ἐπὶ ταῖς ἀγρίαις, ταύτας ἔτρεφε τοῖς φύλλοις. Ὅτε δὲ εὐδία γέγονε, τὰς μὲν ἰδίας εὗρε τεθνεώσας ἐκ τοῦ λιμοῦ, αἱ δὲ ἄγριαι πρὸς τὸ ὄρος ἔφυγον. Ὁ δὲ αἰπόλος [γελάσας] εἰς τὸν οἶκον ἦλθε κενός.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐδαμῶς ἡμᾶς πρέπει ἀμελεῖν τῶν οἰκείων ἐπ’ ἐλπίδι κέρδους ἐξ ἀλλοτρίων γινομένου.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 37 Bb 25 Mg 63.</p>
+          <bibl>Codd. Ba 37 Bb 25 Mg 63.</bibl>
         </div>
         <div>
           <head>Chambry 17.3</head>
@@ -527,14 +526,14 @@
           <l><milestone unit="recitvers"/>θρηνῶν ἀπῄει μηδὲν προσκεκτημένος,</l>
           <l><milestone unit="recitvers"/>εἰ μὴ τὴν ῥάϐδον μετὰ τοῦ μαρσιπίου.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ χρὴ ἡμᾶς ἀμελεῖν τῶν ἰδίων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 198.</p>
+          <bibl>Cod. Mb 198.</bibl>
         </div>
         <div>
           <head>Chambry 17.4</head>
           <head type="sub">Aliter — Autre version</head>
           <pb ed="perry" n="P6"/>
           <p><milestone unit="recitprose"/>Ἐν σπηλαίῳ τινὶ ἐρήμῳ αἰπόλος ἐν χειμῶνι τὰς ἑαυτοῦ αἶγας ἤγαγεν. Εὑρὼν δὲ ἐκεῖ ἀγρίους πλείους τῶν ἑαυτοῦ καὶ μεγίστας, καὶ τερφθεὶς ἐπὶ ταύταις, ταύτας τοῖς φύλλοις [τῶν φύλων] διέτρεφε, τῶν ἑαυτοῦ ἀμελήσας παντάπασι. Τοῦ χειμῶνος δὲ παρελθόντος, αἱ μὲν ἄγριαι ἐπὶ τοῖς ὄρεσιν ἔφυγον, τὰς δὲ ἰδίας ζητῶν εὗρε πάσας τεθνηκυίας, καὶ στενάξας ἔφη· « Ὦ μάταιος ἐγὼ, ὃς τῶν ἐμῶν [μὲν] ἀμελήσας ἐπὶ ταῖς ἀγρίαις αἰξὶ τὴν πᾶσαν φροντίδα ἐποιησάμην. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 17.</p>
+          <bibl>Cod. Bd 17.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-18">
@@ -543,7 +542,7 @@
         <pb ed="perry" n="P301"/>
         <p><milestone unit="recitprose"/>Αἰσχρᾶς καὶ κακοτρόπου δούλης ἤρα δεσπότης. Ἡ δὲ χρυσίον λαμϐάνουσα λαμπρῶς ἑαυτὴν ἐκόσμει καὶ τῇ ἰδίᾳ δεσποίνῃ μάχας συνῆπτε· τῇ δὲ Ἀφροδίτῃ ἔθυεν συνεχῶς καὶ ηὔχετο ὡς ὡραίαν αὐτὴν ποιούσῃ. Ἡ δὲ καθ’ ὕπνου φανεῖσα τῇ δούλῃ ἔφη μὴ ἔχειν αὐτῇ χάριν ὡς καλὴν αὐτὴν ποιούσῃ, « ἀλλ’ ἐκείνῳ θυμοῦμαι καὶ ὀργίζομαι ᾧ σὺ φαίνῃ καλή. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τυφοῦσθαι τοὺς δι’ αἰσχρὰ πλουτοῦντας καὶ μάλιστα, εἰ ἀγενεῖς εἰσι καὶ ἄμορφοι [πρὸς αἰσχύνην μείζονα].</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 6.</p>
+        <bibl>Cod. Ba 6.</bibl>
         <p><milestone unit="traduction"/>Une esclave laide et méchante était aimée de son maître. Avec l’argent qu’elle recevait de lui, elle s’ornait de brillantes parures et rivalisait avec sa propre maîtresse. Elle faisait de continuels sacrifices à Aphrodite et lui rendait grâces de la rendre belle. Mais Aphrodite apparut en songe à l’esclave et lui dit : « Ne me sache pas gré de te faire belle, car je suis fâchée et en colère contre cet homme à qui tu parais belle. »</p>
         <p><milestone unit="traduction"/>Il ne faut pas se laisser aveugler par l’orgueil, quand on s’enrichit par des moyens honteux, surtout quand on est sans naissance et sans beauté.</p>
       </div>
@@ -553,7 +552,7 @@
         <pb ed="perry" n="P8"/>
         <p><milestone unit="recitprose"/>Αἴσωπος ὁ λογοποιὸς σχολὴν ἄγων εἰς ναυπήγιον εἰσῆλθε. Τῶν δὲ ναυπηγῶν σκωπτώντων τε αὐτὸν καὶ ἐκκαλουμένων εἰς ἀπόκρισιν, ὁ Αἴσωπος ἔλεγε τὸ παλαιὸν χάος καὶ ὕδωρ γενέσθαι, τὸν δὲ Δία βουλόμενον καὶ τὸ τῆς γῆς στοιχεῖον ἀναδεῖξαι παραινέσαι αὐτῇ ὅπως ἐπὶ τρὶς ἐκροφήσῃ τὴν θάλασσαν. Κἀκείνη ἀρξαμένη τὸ μὲν πρῶτον τὰ ὄρη ἐξέφηνεν, ἐκ δευτέρου δὲ ἐκροφήσασα καὶ τὰ πεδία ἀπεγύμνωσεν· « ἐὰν δὲ δόξῃ αὐτῇ καὶ τὸ τρίτον ἐκπιεῖν τὸ ὕδωρ, ἄχρηστος ὑμῶν ἡ τέχνη γενήσεται. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὁτι οἱ τοὺς κρείττονας χλευάζοντες λανθάνουσι μείζονας ἑαυτοῖς τὰς ἀνίας ἐξ αὐτῶν ἐπισπώμενοι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 18 Pb 8 Pd 9 Pe 13 Mb 44.</p>
+        <bibl>Codd. Pa 18 Pb 8 Pd 9 Pe 13 Mb 44.</bibl>
         <p><milestone unit="traduction"/>Un jour Esope le fabuliste étant de loisir entra dans un chantier de construction navale. Les ouvriers le raillèrent et le provoquèrent à la réplique. Alors Esope leur dit : « Autrefois il n’y avait que le chaos et l’eau ; mais Zeus voulant faire apparaître un autre élément, la terre, l’engagea à avaler la mer par trois fois. La terre se mit à l’œuvre une première fois, et elle dégagea les montagnes ; puis elle avala la mer une deuxième fois et mit à nu les plaines ; si elle se décide à absorber l’eau une troisième fois, votre art deviendra sans usage. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’à railler plus fin que soi, on s’attire imprudemment des répliques d’autant plus cuisantes.</p>
       </div>
@@ -565,7 +564,7 @@
           <pb ed="perry" n="P281"/>
           <p><milestone unit="recitprose"/>Ἀλεκτόρων δύο μαχομένων περὶ θηλειῶν ὀρνίθων, ὁ εἷς τὸν ἕτερον κατετροπώσατο. Καὶ ὁ μὲν ἡττηθεὶς εἰς τόπον κατάσκιον ἀπιὼν ἐκρύϐη· ὁ δὲ νικήσας εἰς ὕψος ἀρθεὶς καὶ ἐφ’ ὑψηλοῦ τοίχου στὰς μεγαλοφώνως ἐϐόησε. Καὶ παρευθὺς ἀετὸς καταπτὰς ἥρπασεν αὐτόν. Ὁ δ’ ἐν σκότῳ κεκρυμμένος ἀδεῶς ἔκτοτε ταῖς θηλείαις ἐπέϐαινε.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι Κύριος ὑπερηφάνοις ἀντιτάσσεται, ταπεινοῖς δὲ δίδωσι χάριν.</p>
-          <p><milestone unit="manuscrits"/>Cod. T 1.</p>
+          <bibl>Cod. T 1.</bibl>
           <p><milestone unit="traduction"/>Deux coqs se battaient pour des poules ; l’un mit l’autre en fuite. Alors le vaincu se retira dans un fourré où il se cacha, et le vainqueur s’élevant en l’air se percha sur un mur élevé et se mit à chanter à plein gosier. Aussitôt un aigle fondant sur lui l’enleva ; et le coq caché dans l’ombre couvrit dès lors les poules tout à son aise.</p>
           <p><milestone unit="traduction"/>Cette fable montre que le Seigneur se range contre les orgueilleux et donne la grâce aux humbles.</p>
         </div>
@@ -575,7 +574,7 @@
           <pb ed="perry" n="P281"/>
           <p><milestone unit="recitprose"/>Ἀλέκτορες δύο δι’ ὄρνεις ἐμάχοντο, οὓς λέγουσι θυμὸν ἔχειν οἷον ἀνθρώπων. Τούτων ὁ ἡττηθεὶς κατεκρύϐη ἐν γωνίᾳ· ὁ δὲ ἕτερος ἀνακράξας καὶ ἐπὶ τὸ δῶμα ἀναπετάσας διὰ τὴν νίκην εὐθὺς ἡρπάγη ὑπὸ ἀετοῦ. Ὁ δὲ ἕτερος ταῖς ὄρνισιν ἀφόϐως συνῆν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα ἐπὶ τύχῃ καὶ ἀνδρείᾳ μέγα καυχᾶσθαι· πολλοὺς γὰρ ἔσωσε καὶ τὸ μὴ καλῶς πράττειν [· αὐτοὺς δὲ πολλάκις καὶ ἀπώλεσεν].</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 7 Bb 4 Mg 22.</p>
+          <bibl>Codd. Ba 7 Bb 4 Mg 22.</bibl>
         </div>
         <div>
           <head>Chambry 20.3</head>
@@ -583,7 +582,7 @@
           <pb ed="perry" n="P281"/>
           <p><milestone unit="recitprose"/>Ἀλέκτορες δύο δι’ ὄρνεις ἐμάχοντο· τούτους δὲ ἱστοροῦσι θύμον ἔχειν ἀνθρώποις παρόμοιον. Ὁ τῇ μάχῃ οὖν ἡττηθεὶς διὰ τῆς ἑτέρου στερρότητος, ἐν γωνίᾳ τινὶ καθυποδὺς τὴν λόχμην ἐκρύϐη. Ὁ δὲ ἕτερος βρενθυόμενος διάτορον ἐξεϐόησε τοῦ δώματος ὑπερϐάς. Τοῦτον οὖν ἀετὸς καταπτὰς ἀφήρπασε καὶ ἐπεθοινήσατο. Ἔμεινεν οὖν ὁ δειλότερός τε καὶ ἀσθενέστερος ταῖς θηλείαις ἔκτοτε ἄμαχός τε καὶ ἄφθονος.</p>
           <p><milestone unit="epimythiumprose"/>Ἐπὶ τύχῃ καὶ ἀνδρείᾳ οὐ δεῖ τινα μέγα καυχᾶσθαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 6.</p>
+          <bibl>Cod. Bc 6.</bibl>
         </div>
         <div>
           <head>Chambry 20.4</head>
@@ -609,7 +608,7 @@
           <l><milestone unit="recitvers"/>τοῦ ἐκπορθοῦντος καὶ τροπώσαντος τοῦτον</l>
           <l><milestone unit="recitvers"/>καὶ καυχωμένου ὡς ὄντος νικηφόρου.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρας θεομάχους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 119 Cb 70 Cd 84 Ce 81 Cf 85 Cg 9 Ch 84 Mc 70.</p>
+          <bibl>Codd. Ca 119 Cb 70 Cd 84 Ce 81 Cf 85 Cg 9 Ch 84 Mc 70.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-21">
@@ -620,7 +619,7 @@
           <pb ed="perry" n="P23"/>
           <p><milestone unit="recitprose"/>Ἀλεκτρυόνας τις ἐπὶ τῆς οἰκίας ἔχων, ὡς περιέτυχε πέρδικι τιθασῷ πωλουμένῳ, τοῦτον ἀγοράσας ἐκόμισεν οἴκαδε ὡς συντραφησόμενον. Τῶν δὲ τυπτόντων αὐτὸν καὶ ἐκδιωκόντων, ὁ πέρδιξ ἐϐαρυθύμει, νομίζων διὰ τοῦτο αὐτὸν καταφρονεῖσθαι ὅτι ἀλλόφυλός ἐστι. Μικρὸν δὲ διαλιπών, ὡς ἐθεάσατο τοὺς ἀλεκτρυόνας πρὸς ἑαυτοὺς μαχομένους καὶ οὐ πρότερον ἀποστάντας πρὶν ἢ ἀλλήλους αἱμάξαι, ἔφη πρὸς ἑαυτόν· « Ἀλλ’ ἔγωγε οὐκέτι ἄχθομαι ὑπ’ αὐτῶν τυπτόμενος· ὁρῶ γὰρ αὐτοὺς οὐδὲ αὑτῶν ἀπεχομένους. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ῥᾴδιον φέρουσι τὰς τῶν πέλας ὕϐρεις οἱ φρόνιμοι, ὅταν ἴδωσιν αὐτοὺς μηδὲ τῶν οἰκείων ἀπεχομένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 26 Pb 23 Pf 6 Ph 6 Ma 20 Me 6 Mf 6.</p>
+          <bibl>Codd. Pa 26 Pb 23 Pf 6 Ph 6 Ma 20 Me 6 Mf 6.</bibl>
           <p><milestone unit="traduction"/>Un homme qui avait des coqs dans sa maison, ayant trouvé une perdrix privée à vendre, l’acheta et la rapporta chez lui pour la nourrir avec les coqs. Mais ceux-ci la frappant et la pourchassant, elle avait le cœur gros, s’imaginant qu’on la rebutait, parce qu’elle était de race étrangère. Mais peu de temps après ayant vu que les coqs se battaient entre eux et ne se séparaient pas qu’ils ne se fussent mis en sang, elle se dit en elle-même : « Je ne me plains plus d’être frappée par ces coqs ; car je vois qu’ils ne s’épargnent pas même entre eux. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes sensés supportent facilement les outrages de leurs voisins, quand ils voient que ceux-ci n’épargnent même pas leurs parents.</p>
         </div>
@@ -630,7 +629,7 @@
           <pb ed="perry" n="P23"/>
           <p><milestone unit="recitprose"/>Ἀλεκτρυόνας τις ἐν τῇ οἰκίᾳ ἔχων αὐτοῦ, περιτυχὼν πέρδικι καὶ τοῦτον ἐπαγοράσας, εἰσήνεγκεν ἐν τῇ οἰκίᾳ αὐτοῦ τοῦ συνανατραφῆναι τοῖς ὄρνισι. Τῶν δὲ τυπτόντων αὐτὸν καὶ ἐκδιωκόντων, ὁ πέρδιξ ἐλυπεῖτο σφόδρα, νομίζων διὰ τὸ εἶναι αὐτὸν ἀλλόφυλον, τούτου χάριν διώκεσθαι παρὰ τῶν ἀλεωκτρυόνων. Μικρὸν δὲ ὅσον ὑποχωρήσας, θεωρεῖ τοὺς ἀλεκτρυόνας μαχομένους καὶ ἀλλήλους συγκόπτοντας. Ταῦτα ὁ πέρδιξ ὁρῶν ἀποθεραπευθεὶς ἔφη· « Ἀλλ’ ἔγωγε ἀπὸ τοῦ νῦν οὐ λυποῦμαι· ὁρῶ γὰρ αὐτοὺς καὶ ὑπ’ ἀλλήλων μαχομένους. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὁ μῦθος δηλοῖ ὅτι] ὁ λόγος πρὸς φρονίμους ἀνθρώπους οἵτινες ῥᾳδίως φέρουσι τὰς ἐκ τῶν πέλας ὕϐρεις, ὅταν ἴδωσιν αὐτοὺς μηδὲ τῶν οἰκείων ἀπεχομένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 16 Cb 13 Cc 10 Cd 13 Ce 13 Cf 14 Ch 13 Mh 11.<space rend="tab">    </space></p>
+          <bibl>Codd. Ca 16 Cb 13 Cc 10 Cd 13 Ce 13 Cf 14 Ch 13 Mh 11.</bibl>
         </div>
         <div>
           <head>Chambry 21.3</head>
@@ -639,7 +638,7 @@
           <p/>
           <p><milestone unit="recitprose"/>Ἀλεκτρυόνας τις ἔχων ἐπὶ τῆς οἰκίας, πριάμενος καὶ πέρδικα, σὺν ἐκείνοις ἀφῆκε νέμεσθαι. Τῶν δὲ τυπτόντων αὐτὸν καὶ ἀπελαυνόντων, ἐκεῖνος ἠθύμει σφόδρα, νομίζων ὡς ἀλλόφυλος ταῦτα πάσχειν ὑπὸ τῶν ἀλεκτρυόνων. Ὡς δὲ μετὰ μικρὸν κἀκείνους ἑώρακε μαχομένους καὶ ἀλλήλους κόπτοντας, τῆς λύπης ἀπολυθεὶς εἶπεν· « Ἀλλ’ ἔγωγε ἀπὸ τοῦ νῦν οὐ λυπήσομαι, ὁρῶν καὶ αὐτοὺς μαχομένους ἀλλήλοις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φρόνιμοι ῥᾳδίως φέρουσι τὰς παρὰ τῶν ἀλλοτρίων ὕϐρεις, ὅταν αὐτοὺς ἴδωσι μηδὲ τῶν οἰκείων ἀπεχομένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 10 Lb 9 Lc 5 Ld 3 Le 9 Lf 10 Lg 5 Mc 11 Md 9 Mi 44 Mj 11 Mk 12 Ml 9 Mm 9 Mn 3.</p>
+          <bibl>Codd. La 10 Lb 9 Lc 5 Ld 3 Le 9 Lf 10 Lg 5 Mc 11 Md 9 Mi 44 Mj 11 Mk 12 Ml 9 Mm 9 Mn 3.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-22">
@@ -650,7 +649,7 @@
           <pb ed="perry" n="P21"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς ἐπ’ ἄγραν ἐξελθόντες καὶ πολὺν χρόνον κακοπραθήσαντες οὐδὲν συνέλαϐον· καθεζόμενοι δὲ ἐν τῇ νηῒ ἠθύμουν. Ἐν τοσοῦτῳ δὲ θύννος διωκόμενος καὶ πολλῷ τῷ ῥοίζῳ φερόμενος ἔλαθεν εἰς τὸ σκάφος ἐναλλόμενος. Οἱ δὲ συλλαϐόντες αὐτὸν καὶ εἰς τὴν πόλιν ἐλάσαντες ἀπημπόλησαν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις ἃ μὴ τέχνη παρέσχε, ταῦτα τύχη διεϐράϐευσεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 7 Pb 21 Pc 6 Pd 17 Pf 8 Ph 8 Ma 7 Me 8 Mf 8.</p>
+          <bibl>Codd. Pa 7 Pb 21 Pc 6 Pd 17 Pf 8 Ph 8 Ma 7 Me 8 Mf 8.</bibl>
           <p><milestone unit="traduction"/>Des pêcheurs étant allés à la pêche avaient peiné longtemps sans rien prendre ; assis dans leur barque, ils s’abandonnaient au découragement. Juste à ce moment un thon qui était poursuivi et se sauvait à grand bruit, sauta par mégarde dans leur barque. Ils le prirent et l’emportèrent à la ville, où ils le vendirent.</p>
           <p><milestone unit="traduction"/>Ainsi souvent ce que l’art nous refuse, le hasard nous le donne gratuitement.</p>
         </div>
@@ -660,15 +659,15 @@
           <pb ed="perry" n="P21"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς ἐπὶ ἄγραν ἐξελθόντες καὶ πολὺν χρόνον κακοπαθήσαντες, καθεζόμενοι ἐτήκοντο τῷ λιμῷ, μηδέν τι πέρας δυνάμενοι ἐκτελέσαι. Λυπούμενοι δὲ ἐϐούλοντο ἀναχωρῆσαι ἄπρακτοι. Καὶ ἰδοῦ θύννος, διωκόμενος παρὰ μεγίστου ἰχθύος, ἀναπηδήσας εἰσῆλθε ἐν τῷ πλοίῳ αὐτῶν. Λαϐόντες δὲ αὐτὸν οἱ ἁλιεῖς μετὰ χαρᾶς εἰσῆλθον ἐν τῇ πόλει καὶ ἐπώλησαν αὐτίκα.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἃ μὴ τέχνη παρέσχε, ταῦτα τύχη διεϐράϐευσεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 35 Cb 22 Cc 26 Cd 22 Ce 24 Cf 27 Ch 29 Mc 26 Mh 29 Mk 27.</p>
+          <bibl>Codd. Ca 35 Cb 22 Cc 26 Cd 22 Ce 24 Cf 27 Ch 29 Mc 26 Mh 29 Mk 27.</bibl>
         </div>
         <div>
           <head>Chambry 22.3</head>
           <head type="sub">Aliter — Autre version</head>
           <pb ed="perry" n="P21"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς ἐξελθόντες εἰς ἄγραν, ἐπειδὴ πολὺν χρόνον ταλαιπωρήσαντες οὐδὲν εἷλον, σφόδρα τε ἠθύμουν καὶ ἀναχωρῆσαι παρεσκευάζοντο. Εὐθὺς δὲ θύννος ὑπό του τῶν μεγίστων διωκόμενος ἰχθύων, εἰς τὸ πλοῖον αὐτῶν εἰσήλατο. Οἱ δὲ τοῦτον λαϐόντες μεθ’ ἡδονῆς ἀνεχώρησαν.</p>
-          <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἃ μὴ τέχνη παρέσχε, ταῦτα τύχη ἐδωρήσατο.<space rend="tab">    </space></p>
-          <p><milestone unit="manuscrits"/>Codd. La 17 Lc 9 Le 16 Lf 17 Lg 9 Lh 8 Mg 8 Mi 51 Mj 19 Mm 16.</p>
+          <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἃ μὴ τέχνη παρέσχε, ταῦτα τύχη ἐδωρήσατο.</p>
+          <bibl>Codd. La 17 Lc 9 Le 16 Lf 17 Lg 9 Lh 8 Mg 8 Mi 51 Mj 19 Mm 16.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-23">
@@ -679,7 +678,7 @@
           <pb ed="perry" n="P13"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς σαγήνην εἷλκον· βαρείας δὲ αὐτῆς οὔσης, ἔχαιρον καὶ ὠρχοῦντο, πολλὴν εἶναι νομίζοντες τὴν ἄγραν. Ὡς δὲ ἀφελκύσαντες ἐπὶ τὴν ἠιόνα τῶν μὲν ἰχθύων ὀλίγους εὗρον, λίθων δὲ καὶ ἄλλης ὕλης μεστὴν τὴν σαγήνην, οὐ μετρίως ἐϐαρυθύμουν, οὐ τοσοῦτον ἐπὶ τῷ συμϐεϐηκότι δυσφοροῦντες ὅσον ὅτι καὶ τὰ ἐναντία προειλήφεισαν. Εἷς δέ τις ἐν αὐτοῖς γηραιὸς ὢν εἶπεν· « Ἀλλὰ παυσώμεθα, ὦ ἑταῖροι· χαρᾶς γάρ, ὡς ἔοικεν, ἀδελφή ἐστιν ἡ λύπη, καὶ ἡμᾶς ἔδει τοσαῦτα προησθέντας πάντως παθεῖν τι καὶ λυπηρόν. »</p>
           <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς δεῖ τοῦ βίου τὸ εὐμετάϐλητον ὁρῶντας μὴ τοῖς αὐτοῖς πράγμασιν ἀεὶ ἐπαγάλλεσθαι, λογιζομένους ὅτι ἐκ πολλῆς εὐδίας ἀνάγκη καὶ χειμῶνα γενέσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 21 Pb 13 Pd 12 Pf 7 Pg 10 Ph 7 Me 7 Mf 7.</p>
+          <bibl>Codd. Pa 21 Pb 13 Pd 12 Pf 7 Pg 10 Ph 7 Me 7 Mf 7.</bibl>
           <p><milestone unit="traduction"/>Des pêcheurs traînaient une seine ; comme elle était lourde, ils se réjouissaient et dansaient, s’imaginant que la pêche était bonne. Mais quand ils eurent tiré la seine sur le rivage, ils y trouvèrent peu de poisson : c’étaient des pierres et autres matières qui la remplissaient. Ils en furent vivement contrariés, moins pour le désagrément qui leur arrivait que pour avoir préjugé le contraire. Mais l’un d’eux, un vieillard, leur dit : « Cessons de nous affliger, mes amis ; car la joie parait-il, a pour sœur le chagrin ; et il fallait qu’après nous être tant réjouis à l’avance, nous eussions de toute façon quelque contrariété. »</p>
           <p><milestone unit="traduction"/>Or donc nous non plus nous ne devons pas, si nous considérons combien la vie est changeante, nous flatter d’obtenir toujours les mêmes succès, mais nous dire qu’il n’y a si beau temps qui ne soit suivi de l’orage.</p>
         </div>
@@ -689,7 +688,7 @@
           <pb ed="perry" n="P13"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς σαγήνην εἷλκον. Βαρείας δὲ αὐτῆς οὔσης, ἔχαιρον καὶ ὠρχοῦντο, πολλὴν εἶναι νομίζοντες τὴν ἄγραν. Ὡς δὲ εἷλκυσαν αὐτήν, ἰχθύας μὲν εὗρον ὀλίγους, λίθον δὲ μέγιστον ἐν τῇ σαγήνῃ ἀνήγαγον. Οἱ δὲ ἁλιεῖς οὐ μετρίως ἐϐαρυθύμουν, οὐ τοσοῦτον ἐπὶ τῇ τῶν ἰχθύων ὀλιγότητι ὅσον ὅτι καὶ τὰ ἐναντία προειλήφασιν. Εἷς δέ τις ἐξ αὐτῶν γηραιὸς ἐξεῖπε· « Μὴ ἀχθώμεθα, ὦ ἑταῖροι· χαρᾶς γάρ, ὡς ἔοικεν, ἀδελφή ἐστιν ἡ λύπη, καὶ ἡμᾶς ἔδει τοσαῦτα προηδυνθέντας πάντως τι λυπηθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ λυπεῖσθαι ἐπὶ ταῖς ἀποτυχίαις, γινώσκοντας τὰς τοῦ βίου τύχας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 28 Cb 25 Cc 19 Cd 25 Ce 17 Cf 19 Ch 32 Mc 28 Mh 22 Mk 29.</p>
+          <bibl>Codd. Ca 28 Cb 25 Cc 19 Cd 25 Ce 17 Cf 19 Ch 32 Mc 28 Mh 22 Mk 29.</bibl>
         </div>
         <div>
           <head>Chambry 23.3</head>
@@ -697,7 +696,7 @@
           <pb ed="perry" n="P13"/>
           <p><milestone unit="recitprose"/>Ἁλιεῖς εἷλκον σαγήνην. Βαρείας δὲ αὐτῆς οὔσης, ἔχαιρον καὶ ἐσκίρτων, πολλὴν εἶναι τὴν ἄγραν νομίζοντες. Ὡς δ’ ἐπὶ τῆς ἠιόνος ταύτην ἑλκύσαντες τῶν μὲν ἰχθύων εὗρον ὀλίγους, λίθον δ’ ἐν αὐτῇ παμμεγέθη, ἀθυμεῖν ἤρξαντο καὶ ἀλύειν, οὐ τοσοῦτον ἐπὶ τῇ τῶν ἰχθύων ὀλιγότητι ὅσον ὅτι καὶ τὰ ἐναντία προυπειλήφασιν. Εἷς δέ τις ἐν αὐτοῖς πρεσϐύτερος εἶπε· « Μὴ ἀχθώμεθα, ὦ ἑταῖροι· τῇ γὰρ ἡδονῇ, ὡς ἔοικεν, ἀδελφή ἐστιν ἡ λύπη· καὶ ἡμᾶς οὖν ἔδει τοσαῦτα προηδυνθέντας πάντως τι καὶ λυπηθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ λυπεῖσθαι ἐπὶ ταῖς ἀποτυχίαις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 13 Lb 12 Le 12 Lf 13 Lh 6 Ma 147 Md 12 Mi 47 Mj 14 Ml 12 Mm 12.</p>
+          <bibl>Codd. La 13 Lb 12 Le 12 Lf 13 Lh 6 Ma 147 Md 12 Mi 47 Mj 14 Ml 12 Mm 12.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-24">
@@ -706,7 +705,7 @@
         <pb ed="perry" n="P11"/>
         <p><milestone unit="recitprose"/>Ἁλιεὺς αὐλητικῆς ἔμπειρος, ἀναλαϐὼν αὐλοὺς καὶ τὰ δίκτυα, παρεγένετο εἰς τὴν θάλασσαν καὶ στὰς ἐπί τινος προϐλῆτος πέτρας, τὸ μὲν πρῶτον ᾖδε, νομίζων αὐτομάτους πρὸς τὴν ἡδυφωνίαν τοὺς ἰχθύας ἐξαλεῖσθαι πρὸς αὐτὸν. Ὡς δὲ, αὐτοῦ ἐπὶ πολὺ διατεινομένου, οὐδὲν πέρας ἠνύετο, ἀποθέμενος τοὺς αὐλοὺς ἀνείλετο τὸ ἀμφίϐληστρον καὶ βαλὼν κατὰ τοῦ ὕδατος πολλοὺς ἰχθύας ἤγρευσεν. Ἐκϐαλὼν δὲ αὐτοὺς ἀπὸ τοῦ δικτύου ἐπὶ τὴν ἠιόνα, ὡς ἐθεάσατο σπαίροντας, ἔφη· « Ὦ κάκιστα ζῷα, ὑμεῖς, ὅτε μὲν ηὔλουν, οὐκ ὠρχεῖσθε, νῦν δὲ, ὅτε πέπαυμαι, τοῦτο πράττετε. »</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς παρὰ καιρόν τι πράττοντας ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 19 Pb 11 Pd 10 Pe 16 Pg 8 Ma 16 — Ca 34 Cb 21 Cc 25 Cd 21 Ce 23 Cf 26 Ch 28 Md 30 Mh 28 Mi 65 Mk 26 Ml 28 Mm 30 (C = hi 13) — La 133 Lf 134 Mc 25 Mg 21 (L = hi 4).</p>
+        <bibl>Codd. Pa 19 Pb 11 Pd 10 Pe 16 Pg 8 Ma 16 — Ca 34 Cb 21 Cc 25 Cd 21 Ce 23 Cf 26 Ch 28 Md 30 Mh 28 Mi 65 Mk 26 Ml 28 Mm 30 (C = hi 13) — La 133 Lf 134 Mc 25 Mg 21 (L = hi 4).</bibl>
         <p><milestone unit="traduction"/>Un pêcheur, habile à jouer de la flûte, prenant avec lui ses flûtes et ses filets, se rendit à la mer, et, se postant sur un rocher en saillie, il se mit d’abord à jouer, pensant que les poissons, attirés par la douceur de ses accords allaient d’eux-mêmes sauter hors de l’eau pour venir à lui. Mais comme, en dépit de longs efforts, il n’en était pas plus avancé, il mit de côté ses flûtes, prit son épervier, et, le jetant à l’eau, attrapa beaucoup de poissons. Il les sortit du filet et les jeta sur le rivage ; et, comme il les voyait frétiller, il s’écria : « Maudites bêtes, quand je jouais de la flûte, vous ne dansiez pas ; à présent que j’ai fini, vous vous mettez en branle. »</p>
         <p><milestone unit="traduction"/>Cette fable s’applique à ceux qui agissent à contretemps.</p>
       </div>
@@ -718,7 +717,7 @@
           <pb ed="perry" n="P282"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς ἐκ τῆς θαλάσσης τὸ πρὸς ἄγραν δίκτυον ἐκϐαλὼν τῶν μὲν μεγάλων ἰχθύων ἐγκρατὴς γέγονε καὶ τούτους ἐν τῇ γῇ ἥπλωσεν· οἱ δὲ βραχύτεροι τῶν ἰχθύων διὰ τῶν τρυμαλιῶν διέδρασαν ἐν τῇ θαλάσσῃ.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι εὔκολον ἡ σωτηρία τοῖς μὴ μεγάλως εὐτυχοῦσιν, τὸν δὲ μέγαν ὄντα τῇ δόξῃ σπανίως ἴδοις ἂν ἐκφυγόντα τοὺς κινδύνους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 8 Bb 5.</p>
+          <bibl>Codd. Ba 8 Bb 5.</bibl>
           <p><milestone unit="traduction"/>Un pêcheur, ayant retiré de la mer son filet de pêche, put capturer les gros poissons, qu’il étala sur le sol ; mais les petits se glissant par les mailles, se sauvèrent dans la mer.</p>
           <p><milestone unit="traduction"/>Les gens d’une médiocre fortune se sauvent aisément ; mais on voit rarement un homme qui jouit d’une grande renommée échapper aux périls.</p>
         </div>
@@ -728,7 +727,7 @@
           <pb ed="perry" n="P282"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς τῇ θαλάσσῃ δίκτυον ἐμϐαλὼν ἰχθύων μεγίστων καὶ σμικροτάτων ἐγκρατὴς γέγονε. Τὸ δίκτυον οὖν οὗτος ὑφαπλώσας ἐν γῇ τῶν εὐτελῶν ἀπεστέρητο ταῖς τρυμαλιαῖς διαδράντων καὶ τῇ ὑγρᾷ προσφυγόντων· ἐφιλονείκει γὰρ οὗτος ἐπισυνάξαι τὰ μέγιστα, τῶν ἐλαχίστων ὑπερφρονῶν.</p>
           <p><milestone unit="epimythiumprose"/>Εὔκολον εἰς σωτηρίαν τὸ εὐτελές· οἱ λαμπροὶ δὲ τῇ δόξῃ μόλις ἂν διαφύγοιεν τοὺς κινδύνους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 7.</p>
+          <bibl>Cod. Bc 7.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-26">
@@ -739,7 +738,7 @@
           <pb ed="perry" n="P18"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς καθεὶς τὸ δίκτυον ἀνήνεγκε μαινίδα. Τῆς δὲ ἱκετευούσης αὐτὸν πρὸς τὸ παρὸν μεθεῖναι αὐτήν, ἐπειδὴ μικρὰ τυγχάνει, ὕστερον δὲ αὐξηθεῖσαν συλλαμϐάνειν εἰς μείζονα ὠφέλειαν, ὁ ἁλιεὺς εἶπεν· « Ἀλλ’ ἐγὼ εὐηθέστατος ἂν εἴην, εἰ τὸ ἐν χειρὶ παρεὶς κέρδος, ἄδηλον ἐλπίδα διώκοιμι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι αἱρετώτερόν ἐστι τὸ παρὸν κέρδος, κἂν μικρὸν ᾖ, &lt;ἢ&gt; τὸ προσδοκώμενον, κἂν μέγα ὑπάρχῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 4 Pb 18 Pi 3 Ma 4.</p>
+          <bibl>Codd. Pa 4 Pb 18 Pi 3 Ma 4.</bibl>
         </div>
         <div>
           <head>Chambry 26.2</head>
@@ -747,7 +746,7 @@
           <pb ed="perry" n="P18"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς τὸ δίκτυον καθεὶς ἀνήνεγκε σμαρίδα. Σμικρὰ δὲ οὖσα ἱκέτευεν αὐτὸν λέγουσα· « Μὴ λάϐῃς με πρὸς τὸ παρόν, ἀλλ’ ἔασον, ἐπειδήπερ σμικρὰ τυγχάνω· ὅτε δὲ αὐξηθῶ καὶ μεγάλη γένωμαι, λάϐῃς με, ἐπεὶ καὶ εἰς μείζονά σοι ὠφέλειαν τότε γενήσομαι. » Καὶ ὁ ἁλιεὺς εἶπεν· « Ἀλλ’ ἔγωγε μῶρος ἂν εἴην, εἰ τὸ ἐν χερσὶ κέρδος παρείς, κἂν μικρὸν ᾖ, τὸ ἐν ἐλπίσι διώκοιμι, κἂν μέγα ὑπάρχῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι αἱρετώτερόν ἐστι τὸ παρὸν κέρδος κρατεῖν, κἂν μικρὸν ᾖ, ἢ τὸ προσδοκώμενον, κἂν μέγα ὑπάρχῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 20 Cb 9 Cd 9 Ce 4 Cf 10 Ch 9 Mh 7 Ml 22.</p>
+          <bibl>Codd. Ca 20 Cb 9 Cd 9 Ce 4 Cf 10 Ch 9 Mh 7 Ml 22.</bibl>
         </div>
         <div>
           <head>Chambry 26.3</head>
@@ -755,7 +754,7 @@
           <pb ed="perry" n="P18"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς τὸ δίκτυον χαλάσας ἐν τῇ θαλάσσῃ ἀνήνεγκε σμαρίδα. Σμικρὰ δὲ οὖσα ἱκέτευεν αὐτὸν νῦν μὲν μὴ λαϐεῖν αὐτήν, ἀλλ’ ἐᾶσαι, διὰ τὸ σμικρὰν τυγχάνειν. « Ἀλλ’ ὅταν αὐξυνθῶ καὶ μεγάλη, φησί, γένωμαι, συλλαϐεῖν με δυνήσῃ, ἐπεὶ καὶ εἰς μείζονά σοι ὠφέλειαν ἔσομαι. » Καὶ ὁ ἁλιεὺς εἶπεν· « Ἀλλ’ ἔγωγε ἄνους ἂν εἴην, εἰ τὸ ἐν χερσὶ παρεὶς κέρδος, κἂν σμικρὸν ᾖ, τὸ προσδοκώμενον, κἂν μέγα ὑπάρχῃ, ἐλπίζοιμι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἀλόγιστος ἂν εἴη ὁ δι’ ἐλπίδα μείζονος τὰ ἐν χερσὶν ἀφεὶς σμικρὰ ὄντα.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 128 Ld 8 Lf 128 Mc 15 Md 18 Me 26 Mg 15 Mi 53 Mk 16 Mm 18 Mn 8.</p>
+          <bibl>Codd. La 128 Ld 8 Lf 128 Mc 15 Md 18 Me 26 Mg 15 Mi 53 Mk 16 Mm 18 Mn 8.</bibl>
           <p><milestone unit="traduction"/>Un pêcheur, ayant laissé couler son filet dans la mer, en retira un picarel. Comme il était petit, le picarel supplia le pêcheur de ne point le prendre pour le moment, mais de le relâcher en considération de sa petitesse. « Mais quand j’aurai grandi, continua-t-il, et que je serai un gros poisson, tu pourras me reprendre ; aussi bien je te ferai plus de profit. — Hé mais ! répartit le pêcheur, je serais un sot de lâcher le butin que j’ai dans la main, pour compter sur le butin à venir, si grand qu’il soit. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ce serait folie de lâcher, sans espoir d’un profit plus grand, le profit qu’on a dans la main, sous prétexte qu’il est petit.</p>
         </div>
@@ -768,7 +767,7 @@
           <pb ed="perry" n="P26"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς ἔν τινι ποταμῷ ἡλίευε. Καὶ δὴ κατατείνας τὰ δίκτυα, ὡς ἐμπεριέλαϐεν ἑκατέρωθεν τὸ ῥεῦμα, προσδήσας κάλῷ λινῷ λίθον, ἔτυπτε τὸ ὕδωρ, ὅπως οἱ ἰχθύες φεύγοντες ἀπροφυλάκτως τοῖς βρόχοις ἐμπέσωσι. Τῶν δὲ περὶ τὸν τόπον οἰκούντων τις θεασάμενος αὐτὸν τοῦτο ποιοῦντα, ἐμέμφετο ἐπὶ τῷ τὸν ποταμὸν θολοῦν καὶ μὴ ἐᾶν αὐτοὺς διαυγὲς ὕδωρ πίνειν. Ὁ δὲ ἀπεκρίνατο· « Ἀλλ’ ἐὰν μὴ οὕτως ὁ ποταμὸς ταράσσηται, ἐμὲ δεήσει λιμώττοντα ἀποθανεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν πόλεων οἱ δημαγωγοὶ τότε μάλιστα ἐνεργάζονται, ὅταν τὰς πατρίδας εἰς στάσεις περιαγάγωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 29 Pb 26 Pd 21 Pf 9 Ph 9 Me 9 Mf 9.</p>
+          <bibl>Codd. Pa 29 Pb 26 Pd 21 Pf 9 Ph 9 Me 9 Mf 9.</bibl>
           <p><milestone unit="traduction"/>Un pêcheur pêchait dans une rivière. Il avait tendu ses filets, et en avait barré le courant d’une rive à l’autre ; puis ayant attaché une pierre au bout d’une corde de lin, il en battait l’eau, pour que les poissons affolés se jetassent en fuyant dans les mailles du filet. Un des habitants du voisinage, le voyant faire, lui reprocha de troubler la rivière et de les forcer à boire de l’eau trouble. Il répondit : « Mais si la rivière n’est pas ainsi troublée, force me sera à moi de mourir de faim. »</p>
           <p><milestone unit="traduction"/>Il en est ainsi dans les États : les démagogues y font d’autant mieux leurs affaires qu’ils ont jeté leur pays dans la discorde.</p>
         </div>
@@ -778,7 +777,7 @@
           <pb ed="perry" n="P26"/>
           <p><milestone unit="recitprose"/>Ἁλιεὺς ἔν τινι ποταμῷ ἡλίευεν. Διατείνας δὲ τὰ δίκτυα καὶ τὸ ῥεῦμα περιλαϐὼν ἑκατέρωθεν, καλωδίῳ προσδήσας λίθον, τὸ ὕδωρ ἔτυπτεν, ὅπως οἱ ἰχθύες φεύγοντες ἀπαραφυλάκτως τοῖς βρόχοις ἐμπέσωσι. Τῶν δὲ περὶ τὸν τόπον οἰκούντων τις θεασάμενος τοῦτο ποιοῦντα ἐμέμφετο ὡς τὸν ποταμὸν θολοῦντα καὶ διειδὲς ὕδωρ μὴ συγχωροῦντα πίνειν. Καὶ ὃς ἀπεκρίνατο· « Ἀλλ’ εἰ μὴ οὕτως ὁ ποταμὸς ταράττεται, ἐμὲ δεήσει λιμώττοντα ἀποθανεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ τῶν πόλεων οἱ δημαγωγοὶ τότε μάλιστα ἐργάζονται, ὅταν τὰς πατρίδας εἰς στάσιν περιάγωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 91 Lc 27 Le 22 Lf 91 Lg 27 Mg 14 Mj 25 Ml 19.</p>
+          <bibl>Codd. La 91 Lc 27 Le 22 Lf 91 Lg 27 Mg 14 Mj 25 Ml 19.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-28">
@@ -787,7 +786,7 @@
         <pb ed="perry" n="P25"/>
         <p><milestone unit="recitprose"/>Ἁλκύων ὄρνεόν ἐστι φιλέρημον διὰ παντὸς ἐν θαλάττῃ διαιτώμενον. Ταύτην λέγεται τὰς τῶν ἀνθρώπων θήρας φυλαττομένην ἐν σκοπέλοις παραθαλαττίοις νεοττοποιεῖσθαι. Καὶ δή ποτε τίκτειν μέλλουσα παραγένετο εἴς τι ἀκρωτήριον καὶ θεασαμένη πέτραν ἐπὶ θαλάττῃ ἐνταῦθα ἐνεοττοποιεῖτο. Ἐξελθούσης δὲ αὐτῆς ποτε ἐπὶ νομήν, συνέϐη τὴν θάλασσαν ὑπὸ λαϐροῦ πνεύματος κυματωθεῖσαν ἐξαρθῆναι μέχρι τῆς καλιᾶς καὶ ταύτην ἐπικλύσασαν τοὺς νεοττοὺς διαφθεῖραι. Καὶ ἡ ἁλκύων ἐπανελθοῦσα, ὡς ἔγνω τὸ γεγονός, εἶπεν· « Ἀλλ’ ἔγωγε δειλαία, ἥτις τὴν γῆν ὡς ἐπίϐουλον φυλαττομένη, ἐπὶ ταύτην κατέφυγον, ἣ πολλῷ μοι γέγονεν ἀπιστοτέρα. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἔνιοι τοὺς ἐχθροὺς φυλαττόμενοι λανθάνουσιν πολλῷ χαλεπωτέροις τῶν ἐχθρῶν φίλοις ἐμπίπτοντες.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 28 Pb 25 Pd 20 Pf 10 Pg 17 Me 10 Mf 10 — La 90 Lb 21 Le 21 Lf 90 Lh 10 Mg 13 Mj 24 Ml 18.</p>
+        <bibl>Codd. Pa 28 Pb 25 Pd 20 Pf 10 Pg 17 Me 10 Mf 10 — La 90 Lb 21 Le 21 Lf 90 Lh 10 Mg 13 Mj 24 Ml 18.</bibl>
         <p><milestone unit="traduction"/>L’alcyon est un oiseau qui aime la solitude et qui vit constamment sur la mer. On dit que, pour se garder contre les hommes qui le chassent, il niche dans les rochers du rivage. Or un jour un alcyon qui allait couver monta sur un promontoire, et, apercevant un rocher qui surplombait la mer, y fit son nid. Mais un jour qu’il était sorti pour aller à la pâture, il arriva que la mer, soulevée par une bourrasque, s’éleva jusqu’au nid, le couvrit d’eau et noya les petits. Quand l’alcyon fut de retour et vit ce qui était arrivé, il s’écria : « Que je suis malheureux, moi qui, me méfiant des embûches de la terre, me suis réfugié sur cette mer, pour y trouver encore plus de perfidie ! »</p>
         <p><milestone unit="traduction"/>C’est ainsi que certains hommes, qui se tiennent en garde contre leurs ennemis, tombent, sans qu’ils s’en doutent, sur des amis beaucoup plus dangereux que leurs ennemis.</p>
       </div>
@@ -797,7 +796,7 @@
         <pb ed="perry" n="P232"/>
         <p><milestone unit="recitprose"/>Ποτὲ ἀλώπεκες ἐπὶ τὸν Μαίανδρον ποταμὸν συνηθροίσθησαν, πιεῖν ἐξ αὐτοῦ θέλουσαι. Διὰ δὲ τὸ ῥοιζηδὸν φέρεσθαι τὸ ὕδωρ, ἀλλήλας προτρεπόμεναι οὐκ ἐτόλμων εἰσελθεῖν. Μιᾶς δὲ αὐτῶν διεξιούσης, ἐπὶ τῷ εὐτελίζειν τὰς λοιπὰς καὶ δειλίαν καταγελώσης, ἑαυτὴν ὡς γενναιοτέραν προκρίνασα θαρσαλέως εἰς τὸ ὕδωρ ἐπήδησεν. Τοῦ δὲ ῥεύματος ταύτην εἰς μέσον κατασύραντος, καὶ τῶν λοιπῶν παρὰ τὴν ὄχθην τοῦ ποταμοῦ ἑστηκυιῶν, πρὸς αὐτὴν εἰπουσῶν· « Μὴ ἐάσῃς ἡμᾶς, ἀλλὰ στραφεῖσα ὑπόδειξον τὴν εἴσοδον δι’ ἧς ἀκινδύνως δυνησόμεθα πιεῖν, » ἐκείνη ἀπαγομένη ἔλεγεν· « Ἀπόκρισιν ἔχω εἰς Μίλητον, καὶ ταύτην ἐκεῖσε ἀποκομίσαι βούλομαι· ἐν δὲ τῷ ἐπανιέναι με ὑποδείξω ὑμῖν. »</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς κατὰ ἀλαζονείαν ἑαυτοῖς κίνδυνον ἐπιφέροντας.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pf 118 Me 152 Mf 127.</p>
+        <bibl>Codd. Pf 118 Me 152 Mf 127.</bibl>
         <p><milestone unit="traduction"/>Un jour des renards se rassemblèrent sur les bords du Méandre, dans l’intention de s’y désaltérer. Mais, comme l’eau coulait en grondant, ils avaient beau s’exciter les uns les autres, ils n’osaient s’y aventurer. Alors l’un d’eux, prenant la parole pour humilier les autres, se moqua de leur couardise. Quant à lui, se vantant d’être plus brave que les autres, il sauta hardiment dans l’eau. Comme le courant l’entraînait vers le milieu, les autres, postés sur la berge, lui crièrent : « Ne nous abandonne pas, reviens, et montre-nous le passage par où nous pourrons boire sans danger. » Et lui, emporté par le courant, répondit : « J’ai un message pour Milet, et je veux l’y porter ; à mon retour je vous ferai voir le passage. »</p>
         <p><milestone unit="traduction"/>Ceci s’applique à ceux qui par fanfaronnade se mettent eux-mêmes en danger.</p>
       </div>
@@ -809,7 +808,7 @@
           <pb ed="perry" n="P24"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ λιμώττουσα, ὡς ἐθεάσατο ἔν τινι δρυὸς κοιλώματι ἄρτους καὶ κρέα ὑπό τινων ποιμένων καταλελειμμένα, ταῦτα εἰσελθοῦσα κατέφαγεν. Ἐξογκωθεῖσα δὲ τὴν γαστέρα, ἐπειδὴ οὐκ ἠδύνατο ἐξελθεῖν, ἐστέναζε καὶ ὠδύρετο. Ἑτέρα δὲ ἀλώπηξ τῇδε παριοῦσα, ὡς ἤκουσεν αὐτῆς τὸν στεναγμόν, προσελθοῦσα ἐπυνθάνετο τὴν αἰτίαν. Μαθοῦσα δὲ τὰ γεγενημένα ἔφη πρὸς αὐτήν· « Ἀλλὰ μένε τέως σὺ ἐνταῦθα, ἕως ἂν τοιαύτη γένῃ ὁποία οὖσα εἰσῆλθες, καὶ οὕτω ῥᾳδίως ἐξελεύσῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὰ χαλεπὰ τῶν πραγμάτων ὁ χρόνος διαλύει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 27 Pb 24 Pc 8 Pd 19 Ma 21.</p>
+          <bibl>Codd. Pa 27 Pb 24 Pc 8 Pd 19 Ma 21.</bibl>
           <p><milestone unit="traduction"/>Un renard affamé, ayant aperçu dans le creux d’un chêne des morceaux de pain et de viande que des bergers y avaient laissés, y pénétra et les mangea. Mais son ventre s’étant gonflé, il ne put sortir et se mit à gémir et à se lamenter. Un autre renard, qui passait par là, entendit ses plaintes et s’approchant lui en demanda la cause. Quand il sut ce qui était arrivé : « Eh bien ! dit-il, reste ici jusqu’à ce que tu redeviennes tel que tu étais en y entrant, et alors tu en sortiras facilement. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que le temps résout les difficultés.</p>
         </div>
@@ -819,7 +818,7 @@
           <pb ed="perry" n="P24"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ λιμὼττουσα [ἐν πείνῃ] ἐθεάσατο ἐπί τινα καλύϐην βοσκοῦ κρέα καὶ ἄρτον ὑπ’ αὐτοῦ καταλειφθέντα, καὶ εἰσελθοῦσα διὰ στενοτάτης ὀπῆς ἔφαγεν αὐτὰ ἡδέως. Ἐξογκωθείσης δὲ αὐτῆς τῆς γαστρὸς καὶ διὰ τοῦτο μὴ δυναμένη ἐξελθεῖν τῆς καλύϐης ἔστενε καὶ ἐπωδύρετο. Ἑτέρα δὲ ἀλώπηξ διερχομένη ἤκουσεν αὐτῆς τῶν στεναγμῶν καὶ προσελθοῦσα ἐπυνθάνετο δι’ ἣν αἰτίαν τοῦτο ποιεῖ. Μαθοῦσα δὲ τὸ γεγονὸς ἡ ἀλώπηξ ἔφη· « Ἀλλὰ μένε τέως ἐνταῦθα σύ, ἕως ἂν τοιαύτη γένῃ ὁποία οὖσα εἰσῆλθες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὰ χαλεπὰ τῶν πραγμάτων ὁ χρόνος διαλύει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 12 Cb 20 Cd 20 Ce 16 Cf 17 Ch 27 Mc 24 Md 26 Mh 20 Mi 61 Mk 25 Ml 25 Mm 26.</p>
+          <bibl>Codd. Ca 12 Cb 20 Cd 20 Ce 16 Cf 17 Ch 27 Mc 24 Md 26 Mh 20 Mi 61 Mk 25 Ml 25 Mm 26.</bibl>
         </div>
         <div>
           <head>Chambry 30.3</head>
@@ -827,7 +826,7 @@
           <pb ed="perry" n="P24"/>
           <p><milestone unit="recitprose"/>&lt;Ἐν&gt; κοιλώματι δρυὸς στενωτάτῳ ποιμένος ἔκειτο πήρα μεθ’ ὧν εἶχε βρωμάτων. Ἀλώπηξ δὲ μαθοῦσα, νῆστις οὖσα καὶ λεπτοτάτη, εἰσελθοῦσα ἐνεπλήσθη κρεῶν. Ὀγκωθείσης δὲ τῆς γαστρός, ἐξελθεῖν τῆς στενῆς ὀπῆς οὐκ ἠδύνατο. Ἑτέρα δὲ αὐτῇ ἀλώπηξ γελῶσα ἔφη· « Οὐκ ἐξελεύσῃ, ἕως ἂν τὴν γαστέρα ποιήσῃς οἵαν ὅτε εἰσῆλτες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα δολίως ἢ ἀπλήστως πλεονεκτεῖν· ἐν ὑστέρῳ γάρ, κἂν μὴ θέλῃ, πάντα κακῶς ἀποδώσει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 64 Bb 40.</p>
+          <bibl>Codd. Ba 64 Bb 40.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-31">
@@ -838,7 +837,7 @@
           <pb ed="perry" n="P19"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ φραγμὸν ἀναϐαίνουσα, ἐπειδὴ ὀλισθαίνειν ἔμελλε, βάτου ἐπελάϐετο. Ξυσθεῖσα δὲ τὸ πέλμα καὶ δεινῶς διατεθεῖσα, ᾐτιᾶτο αὐτὴν ὅτι καταφυγοῦσα ἐπ’ αὐτὴν ὡς ἐπὶ βοηθὸν χείρονι αὐτῇ ἐχρήσατο. Καὶ ἡ βάτος ὑποτυχοῦσα εἶπεν· « Ἀλλ’ ἐσφάλης τῶν φρενῶν, ὦ αὕτη, ἐμοῦ ἐπιλαϐέσθαι βουληθεῖσα, ἥτις αὐτὴ πάντων ἐπιλαμϐάνεσθαι εἴωθα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ τῶν ἀνθρώπων μάταιοί εἰσιν ὅσοι τούτοις ὡς βοηθοῖς προσφεύγουσιν οἷς τὸ ἀδικεῖν μᾶλλόν ἐστιν ἔμφυτον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 5 Pb 19 Pc 4 Pd 15 Pf 14 Pg 14 Ph 14 Pi 4 Ma 5 Mb 7 Me 14 Mf 14.</p>
+          <bibl>Codd. Pa 5 Pb 19 Pc 4 Pd 15 Pf 14 Pg 14 Ph 14 Pi 4 Ma 5 Mb 7 Me 14 Mf 14.</bibl>
         </div>
         <div>
           <head>Chambry 31.2</head>
@@ -846,7 +845,7 @@
           <pb ed="perry" n="P19"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ φραγμὸν ἀναϐαίνουσα, ἐπειδὴ ὀλισθαίνειν ἤμελλεν, βάτου ἐπελάϐετο πρὸς βοήθειαν. Ξυσθεῖσα δὲ τὸ πέλμα καὶ δεινῶς πληγωθεῖσα εἶπε πρὸς αὐτήν· « Αἶ ἐμέ· καταφυγοῦσα γὰρ ἐπὶ σὲ ὡς ἐπὶ βοηθόν, χεῖρόν μοι ἐχρήσω. – Ἀλλ’ ἐσφάλης, ὦ φίλη, φησὶν ἡ βάτος, ἐμοῦ ἐπιλαϐέσθαι βουληθεῖσα, ἥτις πάντων ἐπιλαμϐάνεσθαι εἴωθα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων μάταιοί εἰσιν ὅσοι βοηθοῖς προστρέχουσιν οἷς τὸ ἀδικεῖν μᾶλλον ἔμφυτον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 8 Cb 10 Cc 7 Cd 10 Ce 10 Cf 11 Ch 10 Mc 7 Mh 8 Mk 8.</p>
+          <bibl>Codd. Ca 8 Cb 10 Cc 7 Cd 10 Ce 10 Cf 11 Ch 10 Mc 7 Mh 8 Mk 8.</bibl>
         </div>
         <div>
           <head>Chambry 31.3</head>
@@ -854,7 +853,7 @@
           <pb ed="perry" n="P19"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ φραγμὸν ἀναϐαίνουσα, ἐπειδὴ ὀλισθήσασα καταπίπτειν ἔμελλεν, ἐπελάϐετο πρὸς βοήθειαν βάτου. Καὶ δὴ τοὺς πόδας ἐπὶ ταῖς ἐκείνης κέντροις αἱμάξασα καὶ ἀλγήσασα πρὸς αὐτὴν εἶπεν· « Οἴμοι· καταφυγοῦσάν με γὰρ ἐπὶ σὲ ὡς ἐπὶ βοηθὸν σὺ χεῖρον διέθηκας. - Ἀλλ’ ἐσφάλης, ὦ αὕτη, φησὶν ἡ βάτος, ἐμοῦ βουληθεῖσα ἐπιλαϐέσθαι, ἥτις πάντων ἐπιλαμϐάνεσθαι εἴωθα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων μάταιοι ὅσοι βοηθοῖς προστρέχουσιν οἷς τὸ ἀδικεῖν μᾶλλον ἔμφυτον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 8 Lb 7 Le 7 Lf 8 Md 7 Mi 42 Mj 8 Ml 7 Mm 7.</p>
+          <bibl>Codd. La 8 Lb 7 Le 7 Lf 8 Md 7 Mi 42 Mj 8 Ml 7 Mm 7.</bibl>
           <p><milestone unit="traduction"/>Un renard, franchissant une clôture, glissa, et se voyant sur le point de tomber, saisit une ronce pour s’aider de son secours. Les épines de la ronce lui ayant mis les pattes en sang, il eut mal et lui dit : « Hélas ! j’ai eu recours à toi pour m’aider, et tu m’as mis plus mal en point. — Eh bien ; tu t’es fourvoyé, l’ami, dit la ronce, en voulant t’accrocher à moi qui ai l’habitude d’accrocher tout le monde. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que chez les hommes aussi ceux-là sont des sots qui ont recours à l’aide de ceux que leur instinct porte plutôt à faire du mal.</p>
         </div>
@@ -867,7 +866,7 @@
           <pb ed="perry" n="P15"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ λιμώττουσα, ὡς ἐθεάσατο ἀπό τινος ἀναδενδράδος βότρυας κρεμαμένους, ἠϐουλήθη αὐτῶν περιγενέσθαι καὶ οὐκ ἠδύνατο. Ἀπαλλαττομένη δὲ πρὸς ἑαυτὴν εἶπεν· « Ὄμφακές εἰσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἔνιοι τῶν πραγμάτων ἐφικέσθαι μὴ δυνάμενοι δι’ ἀσθένειαν τοὺς καιροὺς αἰτιῶνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 23 Pb 15 Pc 2 Pg 11 Ca 5.</p>
+          <bibl>Codd. Pa 23 Pb 15 Pc 2 Pg 11 Ca 5.</bibl>
           <p><milestone unit="traduction"/>Un renard affamé, voyant des grappes de raisin pendre à une treille, voulut les attraper ; mais ne pouvant y parvenir, il s’éloigna en se disant à lui-même : « C’est du verjus. »</p>
           <p><milestone unit="traduction"/>Pareillement certains hommes, ne pouvant mener à bien leurs aflaires, à cause de leur incapacité, en accusent les circonstances.</p>
         </div>
@@ -881,7 +880,7 @@
           <l><milestone unit="recitvers"/>« Τί κάμνω ; ὄμφακες γάρ εἰσιν &lt;ἐκεῖνοι&gt;·</l>
           <l><milestone unit="recitvers"/>λήψομαι αὐτούς, ὅταν πέπειροι ὦσι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ ἀποτυχόντες τῶν πραγμάτων σπουδάζουσι διὰ ψεύδους καλύψαι τὴν ἀλήθειαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 97 Cf 103.</p>
+          <bibl>Codd. Ce 97 Cf 103.</bibl>
         </div>
         <div>
           <head>Chambry 32.3</head>
@@ -889,7 +888,7 @@
           <pb ed="perry" n="P15"/>
           <p><milestone unit="recitprose"/>Βότρυας πεπείρους ἀλώπηξ κρεμαμένους ἰδοῦσα, τούτους ἐπειρᾶτο καταφαγεῖν· πολλὰ δὲ καμοῦσα καὶ μὴ δυνηθεῖσα ψαῦσαι, τὴν λύπην παραμυθουμένη ἔλεγεν· « Ὄμφακες ἔτι εἰσίν. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς δι’ ἀδυναμίαν τινὸς ἀποτυγχάνοντας πράγματος καὶ θέλοντας τοῦτο διὰ ψεύδους καλύψαι ἐλέγχει ὁ μῦθος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 18 Bb 12 Mg 31.</p>
+          <bibl>Codd. Ba 18 Bb 12 Mg 31.</bibl>
         </div>
         <div>
           <head>Chambry 32.4</head>
@@ -897,7 +896,7 @@
           <pb ed="perry" n="P15"/>
           <p><milestone unit="recitprose"/>Βότρυας πεπείρους ἀλώπηξ ἀπῃωρημένους ἰδοῦσα, κατάξαι τούτους καὶ ἔδεσθαι πολυτρόπως ἐμηχανᾶτο. Πολλὰ δὲ καμοῦσα καὶ ὅλως ψαῦσαι τούτων μὴ δυνηθεῖσα παρεμυθεῖτο τὴν ἑαυτῆς ἀτυχίαν καὶ ἔλεγεν· « Ὄμφακες εἰσιν ἔτι καὶ ἄμαχοι τοῖς ὀδοῦσι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐν τοῖς ἀδυνάτοις τινὲς αἰδούμενοι ἑτέρας κενὰς προφασίζονται ἀφορμάς.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 15.</p>
+          <bibl>Cod. Bc 15.</bibl>
         </div>
         <div>
           <head>Chambry 32.5</head>
@@ -912,7 +911,7 @@
           <l><milestone unit="recitvers"/>εὐθὺς τὸ πένθος εἰς χαρὰν μεταϐάλλει,</l>
           <l><milestone unit="recitvers"/>ἀναϐοῶσα· « Ὄμφακές εἰσι ταῦτα. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ τῶν ἀνθρώπων ἀποτυχόντες τῶν πραγμάτων σπουδάζουσι διὰ τοῦ ψεύδους συγκαλύψαι τὴν ἧτταν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 170 Cb 88 Cd 102 Cg 33 Ch 108.</p>
+          <bibl>Codd. Ca 170 Cb 88 Cd 102 Cg 33 Ch 108.</bibl>
         </div>
         <div>
           <head>Chambry 32.6</head>
@@ -920,7 +919,7 @@
           <pb ed="perry" n="P15"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ ἐν κρεϐαττινᾷ βότρυας πεπείρους ἰδοῦσα ἤμελλε φαγεῖν μέν, ἐν ὕψει δὲ ὄντας οὐκ ηὐπόρει φαγεῖν. Μῦς δὲ ἰδὼν ταύτην ἐμειδίασεν εἰπών· « Οὐδὲν τρώγεις. » Ἡ δὲ ἀλώπηξ μὴ θέλουσα ἡττηθῆναι παρὰ τοῦ μυὸς ἔφη· « Ὄμφακές εἰσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς πονηροὺς καὶ μὴ βουλομένους πείθεσθαι τῷ λόγῳ ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 158.</p>
+          <bibl>Cod. Ma 158.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-33">
@@ -929,7 +928,7 @@
         <pb ed="perry" n="P268"/>
         <p><milestone unit="recitprose"/>[Συκέα παρ’ ὁδὸν ἦν.] Ἀλώπηξ [δὲ] θεασαμένη δράκοντα κοιμώμενον ἐζήλωσεν αὐτοῦ τὸ μῆκος· βουλομένη δὲ αὐτῷ ἐξισωθῆναι παραναπεσοῦσα ἐπειρᾶτο ἑαυτὴν ἐκτείνειν, μέχρις οὗ ὑπερϐιαζομένη ἔλαθε ῥαγεῖσα.</p>
         <p><milestone unit="epimythiumprose"/>Τοῦτο πάσχουσιν οἱ τοῖς κρείττοσιν ἀνθαμιλλώμενοι· θᾶττον γὰρ αὐτοὶ διαρρήγνυνται ἢ ἐκείνων ἐφικέσθαι δύνανται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 216 Pc 115.</p>
+        <bibl>Codd. Pa 216 Pc 115.</bibl>
         <p><milestone unit="traduction"/>[Il y avait un figuier près d’une route.] Un renard, ayant aperçu un dragon endormi, envia sa longueur, et, voulant l’égaler, il se coucha près de lui et essaya de s’allonger, jusqu’à ce que, outrant son effort, l’imprévoyant animal creva.</p>
         <p><milestone unit="traduction"/>C’est le cas de, ceux qui rivalisent avec de plus forts qu’eux : ils crèvent eux-mêmes, avant de pouvoir les atteindre.</p>
       </div>
@@ -941,7 +940,7 @@
           <pb ed="perry" n="P22"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ κυνηγοὺς φεύγουσα, ὡς ἐθεάσατό τινα δρυτόμον, τοῦτον ἱκέτευσε κατακρύψαι αὐτήν. Ὁ δὲ αὐτῇ παρῄνεσεν εἰς τὴν ἑαυτοῦ καλύϐην εἰσελθοῦσαν κρυϐῆναι. Μετ’ οὐ πολὺ δὲ παραγενομένων τῶν κυνηγῶν καὶ τοῦ δρυτόμου πυνθανομένων εἰ τεθέαται ἀλώπεκα τῇδε παριοῦσαν, ἐκεῖνος τῇ μὲν φωνῇ ἠρνεῖτο ἑωρακέναι, τῇ δὲ χειρὶ νεύων ἐσήμαινεν ὅπου κατεκρύπτετο. Τῶν δὲ οὐχ οἷς ἔνευε προσσχόντων, οἷς δὲ ἔλεγε πιστευσάντων, ἡ ἀλώπηξ ἰδοῦσα αὐτοὺς ἀπαλλαγέντας ἐξελθοῦσα ἀπροσφωνητὶ ἐπορεύετο. Μεμφομένου δὲ αὐτὴν τοῦ δρυτόμου, εἴγε διασωθεῖσα ὑπ’ αὐτοῦ, ἀλλ’ οὐδὲ διὰ φωνῆς αὐτῷ ἐμαρτύρησεν, ἔφη· « Ἀλλ’ ἔγωγε ηὐχαρίστησα ἄν σοι, εἰ τοῖς λόγοις ὅμοια τὰ ἔργα τῆς χειρὸς καὶ τοὺς τρόπους εἶχες. »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἐκείνους τοὺς ἀνθρώπους τοὺς χρηστὰ μὲν σαφῶς ἐπαγγελλομένους, δι’ ἔργων δὲ φαῦλα δρῶντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 25 Pb 22 Pc 7 Pd 18 Pg 16 Ma 19.</p>
+          <bibl>Codd. Pa 25 Pb 22 Pc 7 Pd 18 Pg 16 Ma 19.</bibl>
           <p><milestone unit="traduction"/>Un renard qui fuyait devant des chasseurs aperçut un bûcheron, et le supplia de lui trouver une cachette. Celui-ci l’engagea à entrer dans sa cabane et à s’y cacher. Quelques instants après les chasseurs arrivèrent et demandèrent au bûcheron s’il n’avait pas vu un renard passer par là. De la voix il répondit qu’il n’en avait pas vu ; mais de la main il fit un geste pour indiquer où il était caché. Les chasseurs ne prirent pas garde au geste, mais s’en rapportèrent aux paroles ; et le renard, les voyant s’éloigner, sortit et s’en alla sans mot dire. Comme le bûcheron lui reprochait que, sauvé par lui, il ne lui témoignait même pas d’un mot sa reconnaissance, le renard répondit : « Je t’aurais dit merci, si tes gestes et tes procédés s’accordaient avec tes discours. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable aux hommes qui font hautement profession de vertu et en fait se conduisent en coquins.</p>
         </div>
@@ -951,7 +950,7 @@
           <pb ed="perry" n="P22"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ κυνηγοὺς φεύγουσα καὶ ἐν ἐρήμῳ πολλῇ τὸν δρόμον ἀνύουσα, αὐτίκα ἄνδρα εὑρίσκει δρυοτόμον ἐνταῦθα, ὃν καὶ καθικέτευε τοῦ κρύψαι αὐτήν. Ὁ δὲ ὑπέδειξεν αὐτῇ τὴν ἑαυτοῦ καλύϐην. Ἡ δὲ εἰσελθοῦσα ἐκρύπτετο ἐν γωνίᾳ. Τῶν δὲ κυνηγῶν ἐλθόντων καὶ ἐρωτώντων τὸν ἄνδρα, τῇ μὲν φωνῇ ἠρνεῖτο μηδὲν εἰδέναι, τῇ δὲ χειρὶ αὐτοῦ τὸν τόπον ὑπεδείκνυεν. Αὐτοὶ δὲ μὴ προσέχοντες ἀπῆλθον παραχρῆμα. Ὡς οὖν εἶδεν αὐτοὺς ἡ ἀλώπηξ ἀπελθόντας, ἐξῆλθεν &lt;οὐ&gt; προσφωνοῦσα. Ἐμέμφετο δὲ αὐτὴν ὁ ἄνθρωπος ἐκεῖνος, λέγων· « Δι’ ἐμοῦ πάντως ἐσώθης καὶ χάριν μοι οὐκ ἔχεις. » Ἡ δὲ ἀλώπηξ ἐπαναστραφεῖσα εἶπε πρὸς αὐτόν· « Ὦ οὗτος, ἀλλ’ ἔγωγε ηὐχαρίστησα ἄν σοι, εἰ τοῖς λόγοις ὅμοια καὶ τὰ ἔργα τῆς χειρὸς καὶ τοὺς τρόπους εἶχες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἐκείνους τοὺς ἀνθρώπους, τοὺς χρηστὰ μὲν ἐπαγγελλομένους διὰ λόγων, δι’ ἔργων δὲ φαῦλα ποιοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 10 Cb 12 Cc 9 Cd 12 Ce 12 Cf 13 Ch 12 Mc 19 Md 19 Me 29 Mf 27 Mh 10 Mi 54 Mk 20 Ml 20 Mm 19 Lf 131.</p>
+          <bibl>Codd. Ca 10 Cb 12 Cc 9 Cd 12 Ce 12 Cf 13 Ch 12 Mc 19 Md 19 Me 29 Mf 27 Mh 10 Mi 54 Mk 20 Ml 20 Mm 19 Lf 131.</bibl>
         </div>
         <div>
           <head>Chambry 34.3</head>
@@ -959,7 +958,7 @@
           <pb ed="perry" n="P22"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ κυνηγοὺς φεύγουσα καὶ ἐν ἐρημίᾳ πολὺν δρόμον ἀνύουσα ἄνδρα δρυοτόμον εὑρίσκει ἐν ταύτῃ, ὃν καθικέτευε τοῦ κρύψαι αὐτήν. Τοῦ δὲ ὑποδείξαντος αὐτῇ τὴν ἑαυτοῦ καλύϐην, εἰσελθοῦσα ἐκρύπτετο εἰς τὰς γωνίας. Τῶν δὲ κυνηγετῶν ἐλθόντων καὶ ἐρωτώντων τὸν ἄνδρα, οὗτος τῇ μὲν φωνῇ ἠρνεῖτο μηδὲν εἰδέναι, τῇ δὲ χειρὶ αὐτοῦ τὸν τόπον ὑπεδείκνυ. Οἱ δὲ μὴ προσσχόντες ἀπῆλθον παραχρῆμα. Ὡς οὖν εἶδεν αὐτοὺς ἡ ἀλώπηξ παρελθόντας, ἐξῆλθεν οὐ προσφωνοῦσα. Μεμφομένου δὲ αὐτὴν ἐκείνου ὡς σωθεῖσαν μὲν δι’ αὐτοῦ, χάριτας δὲ αὐτῷ οὐχ ὁμολογοῦσαν, ἡ ἀλωπήξ ἐπιστραφεῖσα ἔφη· « Ὦ οὗτος, ἀλλ’ ἔγωγε ᾔδειν ἄν σοι χάριτας, εἰ τοῖς λόγοις ὅμοια καὶ τὰ ἔργα τῆς χειρὸς καὶ τοὺς τρόπους εἶχες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς χρηστὰ μὲν ἐπαγγελλομένους τοῖς λόγοις, ἐναντία δὲ ποιοῦντας τοῖς ἔργοις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 131 Mg 18.</p>
+          <bibl>Codd. La 131 Mg 18.</bibl>
         </div>
         <div>
           <head>Chambry 34.4</head>
@@ -967,14 +966,14 @@
           <pb ed="perry" n="P22"/>
           <p><milestone unit="recitprose"/>Ἔφευγεν ἀλώπηξ, κυνηγὸς δὲ ἐπεδιωκεν. Ἡ δὲ δρυτόμον ἰδοῦσα ἐδυσώπει καὶ ὥρκησε κρύψαι αὐτὴν ἐν τοῖς κλάδοις καὶ μὴ προδῶσαι τῷ κυνηγῷ. Ὁ δὲ συνέθετο· ἡ δὲ ἐκρύϐη. Ἐλθὼν δὲ ὁ κυνηγὸς ἠρώτα τὸν δρυτόμον μὴ ἀλώπηξ ὧδε εἰσῆλθεν. Ὁ δὲ· « Οὐκ εἶδον », εἶπεν, τῷ δὲ δακτύλῳ τὸν τόπον ὑπέδειξεν. Ὁ δὲ τῷ λόγῳ πιστεύσας, τῷ δὲ δακτύλῳ μὴ προσσχών, παρῆλθεν. Ἡ δὲ ἀλώπηξ γελῶσα ἐξῆλθεν. Εἶπεν δὲ αὐτῇ ὁ δρυτόμος· « Ἔχε μοι τὴν χάριν ὅτι ἔσωσά σε. » Ἡ δὲ εἶπεν· « Ἠκροασάμην πάντα· ἵνα δὲ ἐκφύγῃς τὸν ὅρκον, τῇ φωνῇ με ἔσωσας, τῷ δακτύλῳ δὲ ἀπεκτείνας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ τῶν κολάκων λόγοι πιθανοὶ μέν εἰσι, οἱ δὲ τρόποι σκολιοὶ καὶ δόλου πλήρεις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 41 Bb 27.</p>
+          <bibl>Codd. Ba 41 Bb 27.</bibl>
         </div>
         <div>
           <head>Chambry 34.5</head>
           <head type="sub">Aliter — Autre version</head>
           <pb ed="perry" n="P22"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ κυνηγοὺς φεύγουσα εἰς δρυμῶνα κατήντησε. Δρυτόμον δὲ ἰδοῦσα παρεκάλει τοῦτον ὁρκίζουσα μὴ προδώσειν τοῖς κυνηγοῖς. Ὁ δὲ συνέθετο τοῦτο ποιῆσαι. Τῶν δὲ κυνηγῶν ἐλθόντων καὶ τοῦτον διερωτώντων περὶ τῆς ἀλώπεκος, τῷ μὲν στόματι μὴ ἰδεῖν ταύτην ἔλεγε, τῷ δὲ δακτύλῳ τὸν τόπον ὑπεδείκνυ ἔνθα ἐκρύπτετο. Τῶν δὲ μὴ συνιέντων, ἡ ἀλώπηξ μετὰ ταῦτα ἐξῆλθεν ἐκφυγοῦσα τὸν κίνδυνον. Ὁ δὲ δρυτόμος εἶπε πρὸς ταύτην· « Ἄπελθε τὸ ζῆν παρ’ ἐμοῦ ἔχουσα. » Ἡ δ’ ἀλώπηξ ἔφη· « Οὐκ ἔχω σοι χάριν· τῷ μὲν στόματι ἔσωσας, τῷ δὲ δακτύλῳ ἀπέκτεινας. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 20.</p>
+          <bibl>Cod. Bd 20.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-35">
@@ -985,7 +984,7 @@
           <pb ed="perry" n="P20"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ κροκόδειλος περὶ εὐγενείας ἤριζον. Πολλὰ δὲ τοῦ κροκοδείλου διεξιόντος περὶ τῆς τῶν προγόνων λαμπρότητος καὶ τὸ τελευταῖον λέγοντος ὡς γεγυμνασιαρχηκότων ἐστὶ πατέρων, ἡ ἀλώπηξ ἔφη· « Ἀλλὰ κἂν σὺ μὴ εἴπῃς, ἀπὸ τοῦ δέρματος φαίνῃ ὅτι ἀπὸ πολλῶν ἐτῶν εἶ γεγυμνασμένος. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ τῶν ψευδολόγων ἀνθρώπων ἔλεγχός ἐστι τὰ πράγματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 6 Pb 20 Pc 5 Pd 16 Pf 11 Pg 15 Ph 10 Ma 6 Mb 8 Me 11 Mf 11.</p>
+          <bibl>Codd. Pa 6 Pb 20 Pc 5 Pd 16 Pf 11 Pg 15 Ph 10 Ma 6 Mb 8 Me 11 Mf 11.</bibl>
           <p><milestone unit="traduction"/>Le renard et le crocodile contestaient de leur noblesse. Le crocodile s’étendit longuement sur l’illustration de ses aïeux et finit par dire que ses pères avaient été gymnasiarques. « Tu peux t’épargner la peine de le dire, répliqua le renard : ta peau fait assez voir que depuis de longues années tu es rompu aux exercices du gymnase. »</p>
           <p><milestone unit="traduction"/>Il en est de même chez les hommes : les menteurs sont confondus par les faits.</p>
         </div>
@@ -995,7 +994,7 @@
           <pb ed="perry" n="P20"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ κροκόδειλος περὶ εὐγενείας ἤριζον. Πολλὰ δὲ τοῦ κροκοδείλου διεξιόντος καὶ ὑπερηφανευομένου περὶ τῆς τῶν προγόνων λαμπρότητος, ἡ ἀλώπηξ ὑπολαϐοῦσα ἔφη· « Ὦ οὗτος, ἀλλὰ κἂν σὺ μὴ εἴπῃς, τὸ γοῦν δέρμα σοῦ δείκνυσιν ὅτι ἀπὸ πολλῶν ἐτῶν εἶ γεγυμνασμένος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν ψευδομένων ἀνδρῶν ἔλεγχός ἐστι τὰ πράγματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 9 Cb 11 Cc 8 Cd 11 Ce 11 Cf 12 Ch 11 Mc 8 Mh 9 Mk 9.</p>
+          <bibl>Codd. Ca 9 Cb 11 Cc 8 Cd 11 Ce 11 Cf 12 Ch 11 Mc 8 Mh 9 Mk 9.</bibl>
         </div>
         <div>
           <head>Chambry 35.3</head>
@@ -1003,7 +1002,7 @@
           <pb ed="perry" n="P20"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ κροκόδειλος ἠμφισϐήτουν περὶ εὐγενείας· πολλὰ δὲ τοῦ κροκοδείλου ὑπερήφανα περὶ τῆς τῶν προγόνων διεξιόντος λαμπρότητος, ὡς γεγυμνασιαρχηκότων, ἡ ἀλώπηξ ὑπολαϐοῦσα· « Ὦ τᾶν, εἶπεν, ἀλλὰ κἂν μὴ σὺ λέγῃς, ἀλλ’ ἀπὸ τοῦ δέρματός γε φαίνῃ ὡς ἐκ παλαιῶν ἐτῶν εἶ γεγυμνασμένος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν ψευδομένων ἀνδρῶν ἔλεγχος τὰ πράγματα γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 9 Lb 8 Le 8 Lf 9 Md 8 Mi 43 Mj 10 Ml 8 Mm 8.</p>
+          <bibl>Codd. La 9 Lb 8 Le 8 Lf 9 Md 8 Mi 43 Mj 10 Ml 8 Mm 8.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-36">
@@ -1012,7 +1011,7 @@
         <pb ed="perry" n="P41"/>
         <p><milestone unit="recitprose"/>Ἀλώπηξ εἰς ἀγέλην προϐάτον εἰσελθοῦσα, θηλαζόντων τῶν ἀρνίων ἓν ἀναλαϐομένη, προσεποιεῖτο καταφιλεῖν. Ἐρωτηθεῖσα δὲ ὑπὸ κυνὸς τί τοῦτο ποιεῖ· « Tιθηνοῦμαι αὐτό, ἔφη, καὶ προσπαίζω. » Καὶ ὁ κύων ἔφη· « Καὶ νῦν, ἐὰν μὴ ἀφῇς τὸ ἀρνίον ἀφ’ ἑαυτῆς, τὰ κυνῶν σοι προσοίσω. »</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ῥᾳδιουργὸν καὶ μῶρον κλέπτην ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 42 Pb 41 Pc 14 Pf 16 Pg 20 Ph 16 — Ca 18 Mb 5 Me 16 Mf 16.</p>
+        <bibl>Codd. Pa 42 Pb 41 Pc 14 Pf 16 Pg 20 Ph 16 — Ca 18 Mb 5 Me 16 Mf 16.</bibl>
         <p><milestone unit="traduction"/>Un renard s’étant glissé dans un troupeau de moutons, prit un des agneaux à la mamelle et fit semblant de le caresser. Un chien lui demanda : « Que fais-tu là ? — Je le cajole, dit-il, et je joue avec lui. — Lâche-le tout de suite, s’écria le chien ; sinon, je vais te faire des caresses de chien. »</p>
         <p><milestone unit="traduction"/>La fable s’applique au fourbe et au voleur maladroit.</p>
       </div>
@@ -1024,7 +1023,7 @@
           <pb ed="perry" n="P12"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ πάρδαλις περὶ κάλλους ἤριζον. Τῆς δὲ παρδάλεως παρ’ ἕκαστα τὴν τοῦ σώματος ποικιλίαν προϐαλλομένης, ἡ ἀλώπηξ ὑποτυχοῦσα ἔφη· « Καὶ πόσον ἐγὼ σοῦ καλλίων ὑπάρχω, ἥτις οὐ τὸ σῶμα, τὴν δὲ ψύχην πεποίκιλμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοῦ σωματικοῦ κάλλους ἀμείνων ἐστὶν ὁ τῆς διανοίας κόσμος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 20 Pb 12 Pd 11 Pg 9 Ma 17 Mc 18 — Ca 13 Cb 24 Cd 24 Cf 18 Ch 31 Md 27 Mh 21 Mi 62 Mk 19 Ml 26 Mm 27 Mn 11 Ld 11.</p>
+          <bibl>Codd. Pa 20 Pb 12 Pd 11 Pg 9 Ma 17 Mc 18 — Ca 13 Cb 24 Cd 24 Cf 18 Ch 31 Md 27 Mh 21 Mi 62 Mk 19 Ml 26 Mm 27 Mn 11 Ld 11.</bibl>
           <p><milestone unit="traduction"/>Le renard et la panthère contestaient de leur beauté. La panthère vantait à tous coups la variété de son pelage. Le renard prenant la parole dit : « Combien je suis plus beau que toi, moi qui suis varié, non de corps, mais d’esprit. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les ornements de l’esprit sont préférables à la beauté du corps.</p>
         </div>
@@ -1034,7 +1033,7 @@
           <pb ed="perry" n="P12"/>
           <p><milestone unit="recitprose"/>Τῆς παρδάλεως ἐριζούσης περὶ κάλλους καὶ τὴν ἑαυτῆς ποικιλίαν προϐαλλομένης, ἡ ἀλώπηξ εἶπε· « Καὶ πόσον ἐγὼ καλλίων ὑπάρχω, ἥτις οὐ τὸ σῶμα, τὴν δὲ ψύχην πεποικιλμένη τυγχάνω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος λέγει ὡς ὁ τῆς διανοίας κόσμος ἀμείνων ἐστὶ τοῦ σωματικοῦ κάλλους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cc 18.</p>
+          <bibl>Cod. Cc 18.</bibl>
         </div>
         <div>
           <head>Chambry 37.3</head>
@@ -1042,7 +1041,7 @@
           <pb ed="perry" n="P12"/>
           <p><milestone unit="recitprose"/>Στικτή ποτε πάρδαλις ἐκαυχᾶτο φορεῖν ἁπάντων ζῴων ποικιλωτέραν δέρριν. Πρὸς ἣν ἀλώπηξ εἶπεν· « Ἐγώ σου τῆς δορᾶς κρείττονα καὶ ποικιλωτέραν γνώμην ἔχω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς συνετοῖς καὶ ποικίλα φρονοῦσιν μᾶλλον ἔπαινός ἐστιν ἢ τῇ φύσει εὐπρεπέσι καὶ μὴ τῇ γνώμῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 132.</p>
+          <bibl>Cod. Ba 132.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-38">
@@ -1053,7 +1052,7 @@
           <pb ed="perry" n="P81"/>
           <p><milestone unit="recitprose"/>Ἐν συνόδῳ τῶν ἀλόγων ζῴων πίθηκος ὀρχησάμενος καὶ εὐδοκιμήσας βασιλεὺς ὑπ’ αὐτῶν ἐχειροτονήθη. Ἀλώπηξ δὲ αὐτῷ φθονήσασα, ὡς ἐθεάσατο ἔν τινι πάγῃ κρέας κείμενον, ἀγαγοῦσα αὐτὸν ἐνταῦθα ἔλεγεν ὡς εὑροῦσα θησαυρὸν αὐτὴ μὲν οὐκ ἐχρήσατο, γέρας δὲ αὐτῷ τῆς βασιλείας τετήρηκε, καὶ παρῄνει αὐτῷ λαμϐάνειν. Τοῦ δὲ ἀτημελήτως ἐπελθόντος καὶ ὑπὸ τῆς πάγης συλληφθέντος, αἰτιωμένου τε τὴν ἀλώπεκα ὡς ἐνεδρεύσασαν αὐτῷ, ἐκείνη ἔφη· « Ὦ πίθηκε, σὺ δὲ τοιαύτην μωρίαν ἔχων τῶν ἀλόγων ζῴων βασιλεύεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοῖς πράγμασιν ἀπερισκέπτως ἐπιχειροῦντες ἐπὶ τῷ δυστυχεῖν καὶ γέλωτα ὀφλισκάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 78 Pb 82 Pc 42 Pe 46 Pf 40 Ph 42 Ma 61 Mb 47.</p>
+          <bibl>Codd. Pa 78 Pb 82 Pc 42 Pe 46 Pf 40 Ph 42 Ma 61 Mb 47.</bibl>
           <p><milestone unit="traduction"/>Le singe, ayant dansé dans une assemblée des bêtes et gagné leur faveur, fut élu roi par elles. Le renard en fut jaloux et, ayant vu un morceau de viande dans un lacs, il y mena le singe en lui disant qu’il avait trouvé un trésor, mais qu’au lieu d’en user lui-même, il le lui avait gardé, comme étant un apanage de la royauté, et il l’engagea à le prendre. Le singe s’en approcha étourdiment et fut pris au lacs. Comme il accusait le renard de lui avoir tendu un piège, celui-ci répliqua : « O singe, sot comme tu es, tu veux régner sur les bêtes ! »</p>
           <p><milestone unit="traduction"/>C’est ainsi que ceux qui se lancent inconsidérément dans une entreprise, non seulement échouent, mais encore prêtent à rire.</p>
         </div>
@@ -1063,7 +1062,7 @@
           <pb ed="perry" n="P81"/>
           <p><milestone unit="recitprose"/>Ἐν συνόδῳ τῶν ἀλόγων ζῴων ὠρχήσατο πίθηκος καὶ εὐδοκιμήσας βασιλεὺς ὑπ’ αὐτῶν ἐχειροτονήθη. Ἀλώπηξ δὲ αὐτῷ φθονήσασα ἐθεάσατο ἔν τινι πάγῃ κρέας κείμενον. Ἀγαγοῦσα οὖν αὐτὸν ἐνταῦθα ἔλεγεν ὡς εὑροῦσα θησαυρὸν αὐτὴ κατὰ τὸν νόμον οὐκ ἐχρήσατο διὰ τὴν βασιλείαν, τὸ γέρας δὲ αὐτῷ τῆς βασιλείας τετήρηκε· καὶ παρῄνει αὐτῷ ὡς ἂν τοῦτο αὐτὸς λάϐῃ. Τοῦ δὲ ἀμεταμελήτως ἐλθοντος καὶ ὑπὸ τῆς πάγης συλληφθέντος, ᾐτιᾶτο παρ’ αὐτοῦ ἡ ἀλώπηξ ὡς δελεάσασα καὶ ἐνενδρεύσασα αὐτῷ. Ἐκείνη δὲ πρὸς αὐτὸν ἔφη· « Ὦ πίθηκε, σὺ τοιαύτην μωρίαν ἔχων, τῶν ἀλόγων ζῴων βασιλεύεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ οἱ τοῖς πράγμασιν ἀπερισκέπτως ἐπιχειροῦντες ἐπὶ τῷ δυστυχεῖν καὶ γέλωτα ὀφλισκάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 69 Cb 45 Cd 42 Ce 47 Cf 51 Ch 52 Mc 44 Mh 45 Mk 48.</p>
+          <bibl>Codd. Ca 69 Cb 45 Cd 42 Ce 47 Cf 51 Ch 52 Mc 44 Mh 45 Mk 48.</bibl>
         </div>
         <div>
           <head>Chambry 38.3</head>
@@ -1071,7 +1070,7 @@
           <pb ed="perry" n="P81"/>
           <p><milestone unit="recitprose"/>Ἐν συνόδῳ ποτὲ τῶν ἀλόγων ζῴων ὠρχήσατο πίθηκος καὶ εὐδοκιμήσας βασιλεὺς ὑπ’ αὐτῶν ἐχειροτονήθη. Ἀλώπηξ δ’ αὐτῷ φθονήσασα, ὡς ἔν τινι παγίδι κρέας ἐθεάσατο, τὸν πίθηκον λαϐοῦσα ἐνταῦθα ἤγαγεν, ὡς εὕροι μὲν αὐτὴ λέγουσα θησαυρὸν τοῦτον, μὴ μέντοι καὶ χρήσασθαι αὐτῷ· τῷ βασιλεῖ γὰρ τοῦτον ὁ νόμος δίδωσι, καὶ προὐτρέπετο αὐτόν, ἅτε δὴ βασιλέα, τὸν θησαυρὸν ἀνελέσθαι. Ὁ δὲ ἀπερισκέπτως προσελθὼν καὶ συλληφθεὶς ὑπὸ τῆς παγίδος, ὡς ἐξαπατήσασαν ἐμέμφετο τὴν ἀλώπεκα. Ἡ δὲ πρὸς αὐτὸν· « Ὦ πίθηκε, τοιαύτην σὺ μωρίαν ἔχων, τῶν ἀλόγων βασιλεύσεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πράξεσί τισιν ἀπερισκέπτως ἐπιχειροῦντες δυστυχήμασι περιπίπτουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 29 Lb 42 Le 42 Lf 29 Me 49 Mf 44 Mg 57 Mi 85 Mj 50 Ml 60 Mm 63.</p>
+          <bibl>Codd. La 29 Lb 42 Le 42 Lf 29 Me 49 Mf 44 Mg 57 Mi 85 Mj 50 Ml 60 Mm 63.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-39">
@@ -1080,7 +1079,7 @@
         <pb ed="perry" n="P14"/>
         <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ πίθηκος ἐν ταὐτῷ ὁδοιποροῦντες περὶ εὐγενείας ἤριζον. Πολλὰ δὲ ἑκατέρου διεξιόντος, ἐπειδὴ ἐγένοντο κατά τινα τόπον, ἐνταῦθα ἀποϐλέψας ἀνεστέναξεν ὁ πίθηκος. Τῆς δὲ ἀλώπεκος ἐρομένης τὴν αἰτίαν, ὁ πίθηκος ἐπιδείξας αὐτῇ τὰ μνήματα, εἶπεν· « Ἀλλ’ οὐ μέλλω κλάειν, ὁρῶν τὰς στήλας τῶν πατρικῶν μου ἀπελευθέρων καὶ δούλων ; » Κἀκείνη πρὸς αὐτὸν ἔφη· « Ἀλλὰ ψεύδου ὅσα βούλει· οὐδεὶς γὰρ τούτων ἀναστὰς ἐλέγξει σε. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ ψευδολόγοι τότε μάλιστα καταλαζονεύονται, ὅταν τοὺς ἐλέγχοντας μὴ ἔχωσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 22 Pb 14 Pc 1.</p>
+        <bibl>Codd. Pa 22 Pb 14 Pc 1.</bibl>
         <p><milestone unit="traduction"/>Le renard et le singe voyageant de compagnie disputaient de leur noblesse. Tandis que chacun d’eux détaillait ses titres tout au long, ils arrivèrent en un certain endroit. Le singe y tourna ses regards et se mit à soupirer. Le renard lui en demanda la cause. Alors le singe lui montrant les tombeaux répondit : « Comment ne pas pleurer, en voyant les cippes funéraires des affranchis et des esclaves de mes pères ? — Oh ! dit le renard, tu peux mentir à ton aise : aucun d’eux ne se lèvera pour te démentir ».</p>
         <p><milestone unit="traduction"/>Il en est ainsi des hommes : les menteurs ne se vantent jamais plus que quand il n’y a personne pour les confondre.</p>
       </div>
@@ -1092,7 +1091,7 @@
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ πεσοῦσα εἰς φρέαρ ὑπ’ ἀνάγκης ἔμεινε. Τράγος δὲ δίψει συνεχόμενος ἐγένετο κατὰ τὸ αὐτὸ φρέαρ· θεασάμενος δὲ αὐτὴν ἐπυνθάνετο εἰ καλόν ἐστι τὸ ὕδωρ· ἡ δὲ τὴν συντυχίαν ἀσμενισαμένη εἰς ἔπαινον τοῦ ὕδατος κατέτεινε, λέγουσα ὡς χρηστὸν εἴη τὸ ὕδωρ, καὶ καταϐαίνειν αὐτὸν παρῄνει. Ἐπεὶ δὲ ἀμελετήτως κατῆλθε διὰ τὴν ἐπιθυμίαν, ἅμα τῷ τὴν δίψαν σϐέσαι μετὰ τῆς ἀλώπεκος ἐσκόπει τὴν ἄνοδον. Καὶ ἡ ἀλώπηξ ὑποτυχοῦσα εἶπε· « Χρήσιμον οἶδα, ἐὰν μόνον θελήσῃς τὴν ἀμφοτέρων σωτηρίαν. Θέλησον οὖν τοὺς ἐμπροσθίους πόδας ἐρεῖσαι τῷ τοίχῳ, ὀρθῶσαι δὲ τὰ κέρατα, ἀναδραμοῦσα δὲ ἐγὼ καὶ σὲ ἀνασπάσω. » Τοῦ δὲ πρὸς τὴν παραίνεσιν αὐτῆς ἑτοίμως ἐπακούσαντος, ἡ ἀλώπηξ ἀναλομένη διὰ τῶν σκελῶν αὐτοῦ καὶ τῶν ὤμων καὶ τῶν κεράτων ἐπὶ τὸ στόμα τοῦ φρέατος εὑρέθη καὶ ἀνελθοῦσα ἀπηλλάττετο. Τοῦ δὲ τράγου μεμφομένου αὐτὴν ὡς τὰς ὁμολογίας ἀθετήσασαν, ἐπιστραφεῖσα εἶπε τῷ τράγῳ· « Ὦ οὗτος, εἰ τοσαύτας φρένας εἶχες ὅσας ἐν τῷ πώγωνί σου τρίχας, οὐ πρότερον &lt;ἂν&gt; κατεϐηϐήκεις πρὶν τὴν ἄνοδον ἐσκέψω. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ τῶν ἀνθρώπων τοὺς φρονίμους δεῖ πρότερον τὰ τέλη τῶν πραγμάτων σκοπεῖν, εἶθ’ οὕτως αὐτοῖς ἐγχειρεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 2 Pi 1 Ma 2.</p>
+          <bibl>Codd. Pa 2 Pi 1 Ma 2.</bibl>
           <p><milestone unit="traduction"/>Un renard étant tombé dans un puits se vit forcé d’y rester. Or un bouc pressé par la soif étant venu au même puits, aperçut le renard et lui demanda si l’eau était bonne. Le renard, faisant contre mauvaise fortune bon cœur, fit un grand éloge de l’eau, affirmant qu’elle était excellente, et il l’engagea à descendre. Le bouc descendit à l’étourdie, n’écoutant que son désir. Quand il eut étanché sa soif, il se consulta avec le renard sur le moyen de remonter. Le renard prit la parole et dit : « J’ai un moyen, pour peu que tu désires notre salut commun. Veuille bien appuyer tes pieds de devant contre le mur et dresser tes cornes en l’air ; je remonterai par là, après quoi je te reguinderai, toi aussi ». Le bouc se prêta avec complaisance à sa proposition, et le renard, grimpant lestement le long des jambes, des épaules et des cornes de son compagnon, se trouva à l’orifice du puits, et aussitôt s’éloigna. Comme le bouc lui reprochait de violer leurs conventions, le renard se retourna et dit : « Hé ! camarade, si tu avais autant d’idées que de poils au menton, tu ne serais pas descendu avant d’avoir examiné le moyen de remonter. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que les hommes sensés ne doivent entreprendre aucune action, avant d’en avoir examiné la fin.</p>
         </div>
@@ -1102,14 +1101,14 @@
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ πεσοῦσα εἰς φρέαρ ἐπάναγκες ἔμενε πρὸς τὴν ἀνάϐασιν ἀμηχανοῦσα. Τράγος δὲ δίψῃ συνεχόμενος, ὡς ἐγένετο κατὰ τὸ αὐτὸ φρέαρ, θεασάμενος αὐτὴν ἐπυνθάνετο εἰ καλὸν εἴη τὸ ὕδωρ· ἡ δὲ τὴν δυστυχίαν ἀσμενισαμένη, πολὺν ἔπαινον τοῦ ὕδατος κατέτεινε, λέγουσα ὡς χρηστὸν εἴη, καὶ καταϐῆναι αὐτὸν παρῄνει. Ὁ δὲ ἀμελετήτως κατῆλθε διὰ μόνην ἐπιθυμίαν καὶ ἅμα τῷ τὴν δίψαν σϐέσαι μετὰ τῆς ἀλώπεκος ἐσκόπει τὴν ἄνοδον· καὶ ἡ ἀλώπηξ χρήσιμόν τι ἔφη ἐπινενοηκέναι εἰς τὴν ἀμφοτέρων σωτηρίαν· « εἰ γὰρ θελήσεις τοὺς ἐμπροσθίους πόδας τῷ τοίχῳ προσερεῖσαι ἐγκλίνας τὰ κέρατα, ἀναδραμοῦσα αὐτὴ διὰ τοῦ σοῦ νώτου καὶ σὲ ἀναϐιϐάσω. » Τοῦ δέ καὶ πρὸς τὴν δευτέραν παραίνεσιν ἑτοίμως ὑπηρετήσαντος, ἡ ἀλώπηξ ἁλλομένη διὰ τῶν σκελῶν αὐτοῦ ἐπὶ τὸν νῶτον ἀνέϐη, καὶ ἀπ’ ἐκείνου ἐπὶ τὰ κέρατα διερεισαμένη, ἐπὶ τὸ στόμα τοῦ φρέατος ἀνελθοῦσα ἀπηλλάττετο. Τοῦ δὲ τράγου μεμφομένου αὐτὴν ὡς τὰς ὁμολογίας παραϐαίνουσαν, ἐπιστραφεῖσα εἶπεν· « Ὦ οὗτος, ἀλλ’ εἰ τοσαύτας φρένας εἶχες ὅσας ἐν τῷ πώγωνι τρίχας, οὐ πρότερον δὴ &lt;ἂν&gt; κατεϐεϐήκεις πρὶν ἢ τὴν ἄνοδον ἐσκέψω. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων τοὺς φρονίμους δεῖ πρότερον τὰ τέλη τῶν πραγμάτων σκοπεῖν, εἰθ’ οὕτως αὐτοῖς ἐπιχειρεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 9 Pd 2 Pg 6 Ph 11.</p>
+          <bibl>Codd. Pb 9 Pd 2 Pg 6 Ph 11.</bibl>
         </div>
         <div>
           <head>Chambry 40.3</head>
           <head type="sub">Aliter — Autre version</head>
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ πεσοῦσα εἰς φρέαρ ἐπάναγκες ἔμεινε, πρὸς τὴν ἀνάϐασιν ἀμηχανοῦσα. Τράγος δὲ δίψῃ συνεχόμενος, ὡς ἐγένετο παρὰ τὸ φρέαρ, θεασάμενος αὐτὴν ἐπυνθάνετο εἰ καλὸν εἴη τὸ ὕδωρ. Ἡ δὲ τὴν συντυχίαν ἀσμενισαμένη, πολὺν ἔπαινον τοῦ ὕδατος παρέτεινε λέγουσα ὡς χρηστὸν εἴη τὸ ὕδωρ καὶ καταϐῆναι αὐτὸν παρῄνει. Ἐπεὶ δὲ καθαλλόμενος διὰ τὸ μόνην ὁρᾶν τὴν ἐπιθυμίαν καθῆκεν αὑτὸν ἐπὶ τὸ φρέαρ εὐθὺς καὶ ἤρξατο ἀποδύρεσθαι μετὰ τῆς ἀλώπεκος τὸ πῶς ἀναϐῶσι. Σκοπουμένη οὖν ἡ ἀλώπηξ ἔφη αὐτῷ· « Ἐπινενόηκά τι εἰς τὴν ἀμφοτέρων σωτηρίαν. Ἐὰν γὰρ θελήσῃς τοὺς ἐμπροσθίους σου πόδας ἐπὶ τὸν τοῖχον προσερεῖσαι, ἐγκλίνεσθαι δὲ καὶ τὰ κέρατα, ἀναδραμοῦσα ἐγὼ διὰ τοῦ σοῦ νώτου πρώτη, καὶ σὲ ἀνασπάσω ἐνθένδε. » Ὁ δὲ τράγος τὴν παραίνεσιν τῆς ἀλώπεκος ἀκούσας καὶ ὑπερετήσας, ἡ ἀλώπηξ ἁλομένη διὰ τῶν σκελῶν αὐτοῦ ἐπὶ τῶν νώτων αὐτοῦ ἀνέϐη καὶ ἀπ’ ἐκείνου ἐπὶ τὰ κέρατα. Καὶ οὕτως ἐξέϐη τοῦ φρέατος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 14.</p>
+          <bibl>Cod. Pe 14.</bibl>
         </div>
         <div>
           <head>Chambry 40.4</head>
@@ -1117,7 +1116,7 @@
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ πεσοῦσα εἰς φρέαρ βαθὺ ἔμενε πρὸς τὴν ἀνάϐασιν ἀμηχανοῦσα. Τράγος δὲ δίψει συνεχόμενος, ὡς ἐγένετο κατὰ τὸ αὐτὸ φρέαρ, θεασάμενος αὐτὴν ἐπυνθάνετο εἰ καλὸν εἴη τὸ ὕδωρ. Ἡ δὲ τὴν δυστυχίαν ἀσμενισαμένη πολὺν ἔπαινον τοῦ ὕδατος κατέτεινε, λέγουσα ὡς χρηστὸν εἴη καὶ διειδὲς πάνυ, καταϐῆναί τε παρῄνει. Τοῦ δὲ ἀμεταμελήτως καθαλομένου διὰ τὸ εἰς μόνην ὁρᾶν τότε τὴν ἐπιθυμίαν καὶ τὸ τὴν δίψαν σϐέσαι, ἅμα τῷ κορεσθῆναι τοῦ ὕδατος σκοπουμένου τὴν ἄνοδον, χρήσιμόν τι ἡ ἀλώπηξ ἔφη ἐπινενοηκέναι εἰς τὴν ἀμφοτέρων σωτηρίαν. Ὁ δὲ τράγος ἔφη· « Πῶς ; » Ἡ ἀλώπηξ εἶπε· « Τοὺς ἐμπροσθίους σου πόδας τῷ τοίχῳ προσέρεισον καὶ στῆθι ὀρθός, ἔγκλινον δὲ καὶ τὰ κέρατα. Ἀναδραμοῦσα τοίνυν ἐγὼ διὰ τοῦ σοῦ νώτου καὶ ἀρθεῖσα ἄνωθεν, εὐθέως καὶ παραχρῆμα καὶ σὲ ἀνελκύσω ἔξω. » Τοῦ δὲ πρὸς ταῦτα ἑτοίμως τὴν παραίνεσιν ὑπηρετήσαντος, ἡ ἀλώπηξ ἁλλομένη διὰ τῶν σκελῶν αὐτοῦ ἐπὶ τὰ νῶτα ἀνέϐη, καὶ ἀπ’ ἐκείνου ἐπὶ τὰ κέρατα διερεισαμένη, καὶ γενναίως ἐκτιναχθεῖσα, ἐπὶ τοῦ στόματος τοῦ φρέατος εὑρέθη καὶ ἀνελθοῦσα ἀπηλλάττετο. Ὀρχουμένης δὲ αὐτῆς καὶ παιζούσης, ὁ τράγος μυκτηρίζων αὐτὴν καὶ ὀνειδίζων, ὡς τὰς ὁμολογίας καὶ ὑποσχέσεις παραϐαίνουσαν, ἐπιστραφεῖσα εἶπεν· « Ὦ οὗτος, ἀλλ’ εἰ τοσαύτας φρένας εἶχες ὁπόσας ἐν τῷ πώγωνί σου τρίχας, οὐ πρότερον &lt;ἂν&gt; κατεϐεϐήκεις πρὶν τὴν ἄνοδον διεσκέψω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τὸν φρόνιμον ἄνθρωπον δεῖ πρότερον τὰ τέλη τῶν πραγμάτων σκοπεῖν, εἶθ’ οὕτως αὐτοῖς ἐγχειρεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 4 Cb 5 Cc 3 Cd 5 Ce 5 Cf 5 Ch 5 Mh 3.</p>
+          <bibl>Codd. Ca 4 Cb 5 Cc 3 Cd 5 Ce 5 Cf 5 Ch 5 Mh 3.</bibl>
         </div>
         <div>
           <head>Chambry 40.5</head>
@@ -1125,7 +1124,7 @@
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ καὶ τράγος διψῶντες εἰς φρέαρ κατέϐησαν· μετὰ δὲ τὸ πιεῖν, τοῦ τράγου σκεπτομένου τὴν ἄνοδον, ἡ ἀλώπηξ ἔφη· « Θάρσει, χρήσιμόν τι καὶ εἰς τὴν ἀμφοτέρων σωτηρίαν ἐπινενόηκα. Εἰ γὰρ ὄρθιος σταθεὶς τοὺς ἐμπροσθίους τῶν ποδῶν τῷ τοίχῳ προσερείσεις, καὶ τὰ κέρατα ὁμοίως εἰς τοὔμπροσθεν κλινεῖς, ἀναδραμοῦσα διὰ τῶν σῶν αὐτὴ νώτων καὶ κεράτων, καὶ ἔξω τοῦ φρέατος ἐκεῖθεν πηδήσασα, καὶ σὲ μετὰ τοῦτο ἀνασπάσω ἐντεῦθεν. » Τοῦ δὲ τράγου πρὸς τοῦτο ἑτοίμως ὑπηρετησαμένου, ἐκείνη τοῦ φρέατος οὕτως ἐκπηδήσασα ἐσκίρτα περὶ τὸ στόμιον ἡδομένη. Ὁ δὲ τράγος αὐτὴν ἐμέμφετο, ὡς παραϐαίνουσαν τὰς συνθήκας. Ἡ δ’· « Ἀλλ’ εἰ τοσαύτας, εἶπε, φρένας ἐκέκτησο, ὁπόσας ἐν τῷ πώγωνι τρίχας, οὐ πρότερον ἂν κατέϐης, πρὶν ἢ τὴν ἄνοδον σκέψασθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τὸν φρόνιμον ἄνθρωπον δεῖ πρότερον τὰ τέλη σκοποῦντα τῶν πραγμάτων, εἶθ’ οὕτως αὐτοῖς ἐγχειρεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 4 Lb 3 Lc 1 Ld 1 Le 3 Lf 4 Lg 1 Mc 4 Md 3 Me 21 Mf 21 Mg 4 Mi 38 Mj 4 Mk 5 Ml 3 Mm 3 Mn 1.</p>
+          <bibl>Codd. La 4 Lb 3 Lc 1 Ld 1 Le 3 Lf 4 Lg 1 Mc 4 Md 3 Me 21 Mf 21 Mg 4 Mi 38 Mj 4 Mk 5 Ml 3 Mm 3 Mn 1.</bibl>
         </div>
         <div>
           <head>Chambry 40.6</head>
@@ -1133,7 +1132,7 @@
           <pb ed="perry" n="P9"/>
           <p><milestone unit="recitprose"/>Τράγος ἐν θέρει σφοδρῶς διψήσας κατῆλθεν εἰς βαθύκρημνον ὕδωρ πιεῖν. Πιὼν δὲ καὶ χορτασθεὶς οὐκ ἠδύνατο ἀνελθεῖν καὶ μετενόει καὶ βοηθὸν ἐζήτει. Ἀλώπηξ δὲ τοῦτον ἰδοῦσα ἔφη· « Ὦ ἀνόητε, εἰ τόσας φρένας εἶχες ὅσας ἐν τῷ πώγωνι τρίχας, πρότερον οὐκ ἂν κατέϐης, εἰ μὴ τὴν ἄνοδον ἐσκέψω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δεῖ πρότερον προσκοποῦντα τὰ τέλη τῶν πραγμάτων οὕτω ποιεῖσθαι τὰς τούτων ἐγχειρήσεις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 134 Bb 81.</p>
+          <bibl>Codd. Ba 134 Bb 81.</bibl>
         </div>
         <div>
           <head>Chambry 40.7</head>
@@ -1150,7 +1149,7 @@
           <l><milestone unit="recitvers"/>εἰ εἶχες φρένας ὡς ἐν πώγωνι τρίχας,</l>
           <l><milestone unit="recitvers"/>οὐκ ἂν κατῄεις, εἰ μὴ ἄνοδον ᾔδεις. »</l>
           <p><milestone unit="epimythiumprose"/>Οὕτω τῶν ἀνθρώπων τοὺς φρονίμους δεῖ πρῶτον τὰ τέλη τῶν πραγμάτων σκοπεῖν, εἶθ’ οὕτως αὐτοῖς ἐπιχειρεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 205.</p>
+          <bibl>Cod. Mb 205.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-41">
@@ -1161,7 +1160,7 @@
           <pb ed="perry" n="P17"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ ὑπό τινος πάγης τὴν οὐρὰν ἀποκοπεῖσα, ἐπειδὴ δι’ αἰσχύνην ἀϐίωτον ἡγεῖτο τὸν βίον ἔχειν, ἔγνω δεῖν καὶ τὰς ἄλλας ἀλώπεκας εἰς τὸ αὐτὸ προαγαγεῖν, ἵνα τῷ κοινῷ πάθει τὸ ἴδιον ἐλάττωμα συγκρύψῃ. Καὶ δὴ ἁπάσας ἀθροίσασα παρῄνει αὐταῖς τὰς οὐρὰς ἀποκόπτειν, λέγουσα ὡς οὐκ ἀπρεπὲς μόνον τοῦτο, ἀλλὰ καὶ περισσόν τι αὐταῖς βάρος προσήρτηται. Τούτων δέ τις ὑποτυχοῦσα ἔφη· « Ὦ αὕτη, ἀλλ’ εἰ &lt;μή&gt; σοι τοῦτο συνέφερεν, οὐκ ἂν ἡμῖν τοῦτο συνεϐούλευσας. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόττει πρὸς ἐκείνους οἳ τὰς συμϐουλίας ποιοῦνται τοῖς πέλας οὐ δι’ εὔνοιαν, ἀλλὰ διὰ τὸ ἑαυτοῖς συμφέρον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 24 Pb 17 Pd 14 Pf 13 Pg 13 Ph 13 Ma 18 Me 13 Mf 13 — Ca 6 Cb 8 Cc 6 Cd 8 Ce 8 Cf 8 Ch 8 Mc 6 Mh 6 Mk 7.</p>
+          <bibl>Codd. Pa 24 Pb 17 Pd 14 Pf 13 Pg 13 Ph 13 Ma 18 Me 13 Mf 13 — Ca 6 Cb 8 Cc 6 Cd 8 Ce 8 Cf 8 Ch 8 Mc 6 Mh 6 Mk 7.</bibl>
           <p><milestone unit="traduction"/>Un renard, ayant eu la queue coupée par un piège, en était si honteux qu’il jugeait sa vie impossible ; aussi résolut-il d’engager les autres renards à s’écourter de même, afin de cacher dans la mutilation commune son infirmité personnelle. En conséquence il les assembla tous et les engagea à se couper la queue, disant que c’était non seulement un enlaidissement, mais encore un poids inutile que cet appendice. Mais un des renards prenant la parole dit : « Hé ! camarade, si ce n’était pas ton intérêt, tu ne nous aurais pas donné ce conseil. »</p>
           <p><milestone unit="traduction"/>Cette fable convient à ceux qui donnent des conseils à leur prochain, non par bienveillance, mais par intérêt personnel.</p>
         </div>
@@ -1171,7 +1170,7 @@
           <pb ed="perry" n="P17"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ ἐν παγίδι ληφθεῖσα καί ἀποκοπείσης τῆς οὐρᾶς διαδρᾶσα, ἀϐίωτον ὑπ’ αἰσχύνης ἡγεῖτο τὸν βίον. Ἔγνω οὖν καὶ τὰς ἄλλας ἀλώπεκας τοῦτ’ αὐτὸ νουθετῆσαι ὡς ἂν τῷ κοινῷ πάθει τὸ ἴδιον συγκαλύψειεν αἶσχος. Καὶ δὴ πάσας ἀθροίσασα παρῄνει τὰς οὐρὰς ἀποκόπτειν, ὡς οὐκ ἀπρεπὲς μόνον τοῦτο τὸ μέλος ὄν, ἀλλὰ καὶ περιττὸν βάρος προσηρτημένον. Ὑπολαϐοῦσα δέ τις αὐτῶν εἶπεν· « Ὠ αὕτη, ἀλλ’ εἰ οὔ σοι τοῦτο συνέφερεν, οὐκ ἂν ἡμῖν αὐτὸ συνεϐούλευες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πονηροὶ τῶν ἀνθρώπων οὐ δι’ εὔνοιαν τὰς πρὸς τοὺς πέλας ποιοῦνται συμϐουλίας, διὰ δὲ τὸ αὐτοῖς συμφέρον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 7 Lb 6 Le 6 Lf 7 Lh 4 Md 6 Mi 41 Mj 7 Ml 6 Mm 6.</p>
+          <bibl>Codd. La 7 Lb 6 Le 6 Lf 7 Lh 4 Md 6 Mi 41 Mj 7 Ml 6 Mm 6.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-42">
@@ -1182,7 +1181,7 @@
           <pb ed="perry" n="P10"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ μηδέποτε θεασαμένη λέοντα, ἐπειδὴ κατά τινα συντυχίαν ὑπήντησε, τὸ μὲν πρῶτον ἰδοῦσα οὕτως διεταράχθη ὡς μικροῦ καὶ ἀποθανεῖν. Ἐκ δευτέρου δὲ αὐτῷ περιτυχοῦσα ἐφοϐήθη μέν, ἀλλ’ οὐχ οὕτως ὡς τὸ πρότερον. Ἐκ τρίτου δὲ θεασαμένη οὕτω κατεθάρρησεν ὡς καὶ προσελθοῦσα αὐτῷ διελέχθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ συνήθεια καὶ τὰ φοϐερὰ τῶν πραγμάτων καταπραΰνει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 1 Pb 10 Pd 3 Pe 15 Pf 12 Pg 7 Ph 12 Ma 1 Mb 6 Me 12 Mf 12.</p>
+          <bibl>Codd. Pa 1 Pb 10 Pd 3 Pe 15 Pf 12 Pg 7 Ph 12 Ma 1 Mb 6 Me 12 Mf 12.</bibl>
           <p><milestone unit="traduction"/>Un renard n’avait jamais vu de lion. Or le hasard le mit un jour en face de ce fauve. Comme il le voyait pour la première fois, il eut une telle frayeur qu’il faillit en mourir. L’ayant rencontré une deuxième fois, il eut peur encore, mais pas autant que la première fois. Mais à la troisième fois qu’il le vit, il s’enhardit jusqu’à s’en approcher et à causer avec lui.</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’accoutumance adoucit même les choses effrayantes.</p>
         </div>
@@ -1192,7 +1191,7 @@
           <pb ed="perry" n="P10"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ μηδέποτε θεασαμένη λέοντα, ἐπειδὴ κατά τινα τύχην ὑπήντησεν αὐτῷ, τὸ μὲν πρῶτον ἰδοῦσα αὐτὸν οὕτως ἐφοϐήθη ὡς μικροῦ καὶ ἀποθανεῖν. Ἐκ δευτέρου δὲ αὐτῷ περιτυχοῦσα ἐφοϐήθη μέν, ἀλλὰ οὐκ ὡς τὸ πρότερον. Ἐκ τρίτου δὲ θεασαμένη αὐτὸν οὕτως κατεθάρσησεν ὡς προσελθοῦσα αὐτῷ διαλεχθῆναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ συνήθεια καὶ τὰ φοϐερὰ τῶν πραγμάτων καταπραΰνει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 7 Cb 6 Cc 4 Cd 6 Ce 6 Cf 6 Ch 6 Mh 4.<space rend="tab">    </space></p>
+          <bibl>Codd. Ca 7 Cb 6 Cc 4 Cd 6 Ce 6 Cf 6 Ch 6 Mh 4.</bibl>
         </div>
         <div>
           <head>Chambry 42.3</head>
@@ -1200,7 +1199,7 @@
           <pb ed="perry" n="P10"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ μήπω θεασαμένη λέοντα, ἐπειδὴ κατά τινα τύχην αὐτῷ συνήντησε, τὸ μὲν πρῶτον οὕτως ἐφοϐήθη ὡς μικροῦ καὶ ἀποθανεῖν. Ἔπειτα τὸ δεύτερον θεασαμένη, ἐφοϐήθη μέν, οὐ μὴν ὡς τὸ πρότερον. Ἐκ τρίτου δὲ τοῦτον θεασαμένη οὕτως αὐτοῦ κατεθάρσησεν ὡς καὶ προσελθοῦσα διαλεχθῆναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἡ συνήθεια καὶ τὰ φοϐερὰ τῶν πραγμάτων εὐπρόσιτα ποιεῖ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 5 Lb 4 Lc 2 Ld 2 Le 4 Lf 5 Lg 2 Mc 10 Md 4 Mg 5 Mi 39 Mj 5 Mk 11 Ml 4 Mm 4 Mn 2.</p>
+          <bibl>Codd. La 5 Lb 4 Lc 2 Ld 2 Le 4 Lf 5 Lg 2 Mc 10 Md 4 Mg 5 Mi 39 Mj 5 Mk 11 Ml 4 Mm 4 Mn 2.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-43">
@@ -1211,7 +1210,7 @@
           <pb ed="perry" n="P27"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ εἰσελθοῦσα εἰς πλάστου ἐργαστήριον καὶ ἕκαστον τῶν ἐνόντων διερευνῶσα, ὡς περιέτυχε τραγῳδοῦ προσωπείῳ, τοῦτο ἐπάρασα εἶπεν· « Οἵα κεφαλὴ ἐγκέφαλον οὐκ ἔχει. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα μεγαλοπρεπῆ μὲν σώματι, κατὰ ψυχὴν δὲ ἀλόγιστον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 8 et 29bis Pb 27 Pc 9 Pf 15 Ph 15 Ma 8 Me 15.</p>
+          <bibl>Codd. Pa 8 et 29bis Pb 27 Pc 9 Pf 15 Ph 15 Ma 8 Me 15.</bibl>
         </div>
         <div>
           <head>Chambry 43.2</head>
@@ -1219,7 +1218,7 @@
           <pb ed="perry" n="P27"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ εἰσελθοῦσα εἰς οἰκίαν κιθαρῳδοῦ καὶ ἕκαστον τῶν αὐτοῦ σκευῶν ἐρευνησαμένη, εὗρε κεφαλὴν μορμολυκείου εὐφυῶς κατεστευασμένην. Ἀναλαϐοῦσα δὲ αὐτὴν ταῖς οἰκείαις χερσὶν ἔφη· « Ὢ οἵα κεφαλή, καὶ ἔγκεφαλον οὐκ ἔχει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρας μεγαλοπρεπεῖς μὲν τὸ σῶμα, ἀλογίστους δὲ τὴν ψυχήν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 11 Cb 14 Cc 11 Cd 14 Ce 14 Cf 15 Ch 14 Mh 12.</p>
+          <bibl>Codd. Ca 11 Cb 14 Cc 11 Cd 14 Ce 14 Cf 15 Ch 14 Mh 12.</bibl>
         </div>
         <div>
           <head>Chambry 43.3</head>
@@ -1227,7 +1226,7 @@
           <pb ed="perry" n="P27"/>
           <p><milestone unit="recitprose"/>Ἀλώπηξ εἰς οἰκίαν ἐλθοῦσα ὑποκριτοῦ καὶ ἕκαστα τῶν αὐτοῦ σκευῶν διερευνωμένη, εὗρε καὶ κεφαλὴν μορμολυκείου εὐφυῶς κατεσκευασμένην, ἣν καὶ ἀναλαϐοῦσα ταῖς χερσὶν ἔφη· « Ὢ οἵα κεφαλή, καὶ ἔγκεφαλον οὐκ ἔχει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας μεγαλοπρεπεῖς μὲν τῷ σώματι, κατὰ ψυχὴν δὲ ἀλογίστους.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 11 Lb 10 Lc 6 Ld 4 Le 10 Lf 11 Lg 6 Mc 12 Md 10 Me in margine 15 Mf 15 Mi 45 Mj 12 Mk 13 Ml 10 Mm 10 Mn 4.</p>
+          <bibl>Codd. La 11 Lb 10 Lc 6 Ld 4 Le 10 Lf 11 Lg 6 Mc 12 Md 10 Me in margine 15 Mf 15 Mi 45 Mj 12 Mk 13 Ml 10 Mm 10 Mn 4.</bibl>
           <p><milestone unit="traduction"/>Un renard s’étant glissé dans la maison d’un acteur, fouilla successivement toutes ses hardes, et trouva, entre autres objets, une tête de masque artistement travaillée. Il la prit dans ses pattes et dit : « Oh ! quelle tête ! mais elle n’a pas de cervelle. »</p>
           <p><milestone unit="traduction"/>Cette fable convient aux hommes magnifiques de corps, mais pauvres de jugement.</p>
         </div>
@@ -1238,7 +1237,7 @@
         <pb ed="perry" n="P278"/>
         <p><milestone unit="recitprose"/>Ἄνδρες δύο ἐμάχοντο τίνες τῶν θεῶν μείζους, Θησεὺς ἢ Ἡρακλῆς. Οἱ δὲ θεοὶ ὀργισθέντες αὐτοῖς ἑκάτερος τὴν ἑτέρου χώραν ἠμύνατο.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι τῶν ὑπεξουσίων ἡ ἔρις τοὺς δεσπότας πείθει ὀργίλους εἶναι κατὰ τῶν ὑπηκόων.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 10.</p>
+        <bibl>Cod. Ba 10.</bibl>
         <p><milestone unit="traduction"/>Deux hommes disputaient qui des deux dieux, Thésée ou Hercule, était le plus grand. Mais les dieux, s’étant mis en colère contre eux, se vengèrent chacun sur le pays de l’autre.</p>
         <p><milestone unit="traduction"/>Les querelles des subordonnés excitent les maîtres à la colère contre leurs sujets.</p>
       </div>
@@ -1250,7 +1249,7 @@
           <pb ed="perry" n="P32"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπόν τις ἀποκτείνας ὑπὸ τῶν ἐκείνου συγγενῶν ἐδιώκετο· γενόμενος δὲ κατὰ τὸν Νεῖλον ποταμόν, λύκου αὐτῷ ἀπαντήσαντος, φοϐηθεὶς ἀνέϐη ἐπὶ δένδρου τῷ ποταμῷ παρακειμένου καὶ ἐκεῖ ἐκρύπτετο. Θεασάμενος δὲ ἐνταῦθα δράκοντα κατ’ αὐτοῦ διαιρόμενον, ἑαυτὸν εἰς τὸν ποταμὸν καθῆκεν· ἐν δὲ τῷ ποταμῷ κροκόδειλος αὐτὸν κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοῖς ἐναγέσι τῶν ἀνθρώπων οὔτε γῆς, οὔτε ἀέρος, οὔτε ὕδατος στοιχεῖον ἀσφαλές ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 9 Pb 32 Pc 12 Pg 18 Ma 10.</p>
+          <bibl>Codd. Pa 9 Pb 32 Pc 12 Pg 18 Ma 10.</bibl>
           <p><milestone unit="traduction"/>Un homme qui venait de commettre un assassinat était poursuivi par les parents de sa victime. Etant arrivé au bord du Nil, il rencontra un loup ; il eut peur et monta sur un arbre de la rive, ou il se cacha. Mais là il aperçut un dragon qui montait vers lui ; alors il se laissa choir dans le fleuve ; mais dans le fleuve un crocodile le dévora.</p>
           <p><milestone unit="traduction"/>La fable montre qu’aucun élément, ni la terre, ni l’air, ni l’eau, n’offre de sûreté aux criminels poursuivis par les dieux.</p>
         </div>
@@ -1260,7 +1259,7 @@
           <pb ed="perry" n="P32"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις φόνον ποιήσας ἐδιώκετο ὑπὸ τῶν συγγενῶν τοῦ φονευθέντος. Γενομένου δὲ αὐτοῦ κατὰ τὸν ποταμὸν τὸν Νεῖλον, λέοντα ἰδὼν καὶ φοϐηθεὶς ἀνέϐη εἰς δένδρον. Εὗρε δὲ δράκοντα ἐπάνω τοῦ δένδρου, καὶ πάλιν τοῦτον φοϐηθεὶς ἔρριψεν ἑαυτὸν εἰς τὸν ποταμὸν. Ἐν δὲ τῷ ποταμῷ κροκόδειλος αὐτὸν κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθοι δηλοῖ ὅτι τοὺς φονεῖς τῶν ἀνθρώπων οὔτε γῆ, οὔτε ἀήρ, οὔτε ὕδατος στοιχεῖον, οὔτε ἄλλος τόπος φυλάττει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 29 Ce 18 Cf 20 Ch 20 Md 28 Mh 23 Mi 63 Ml 27 Mm 28.</p>
+          <bibl>Codd. Ca 29 Ce 18 Cf 20 Ch 20 Md 28 Mh 23 Mi 63 Ml 27 Mm 28.</bibl>
         </div>
         <div>
           <head>Chambry 45.3</head>
@@ -1268,7 +1267,7 @@
           <pb ed="perry" n="P32"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις φόνον ποιήσας καὶ διωκόμενος ὑπὸ τῶν συγγενῶν τοῦ φονευθέντος κατὰ τὸν Νεῖλον ποταμὸν ἐγένετο καὶ λέοντα εὑρὼν ἀνέϐη εἰς δένδρον φοϐηθείς, κἀκεῖσε ἰδὼν δράκοντα καὶ ἡμιθνὴς γενόμενος ἔρριψεν ἑαυτὸν εἰς τὸν ποταμόν. Ἐν δὲ τῷ ποταμῷ κροκόδειλος τοῦτον κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς τοὺς τῶν ἀνθρώπων φονεῖς ὡς οὔτε γῆ, οὔτε ἀήρ, οὔτε ὕδατος στοιχεῖον, οὔτε ἄλλος τις τόπος φυλάσσει αὐτούς.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cc 20.</p>
+          <bibl>Cod. Cc 20.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-46">
@@ -1279,7 +1278,7 @@
           <pb ed="perry" n="P34"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένης νοσῶν καὶ κακῶς διακείμενος, ἐπειδὴ ἀπὸ τῶν ἰατρῶν ἀπηλπίσθη, τοῖς θεοῖς ηὔχετο ἑκατόμϐην ποιήσειν ἐπαγγελλόμενος καὶ ἀναθήματα καθιερώσειν, ἐὰν ἐξαναστῇ. Τῆς δὲ γυναικὸς (ἐτύγχανε γὰρ αὐτῷ παρεστῶσα) πυνθανομένης· « Καὶ πόθεν αὐτὰ ἀποδώσεις ; » ἔφη· « Νομίζεις γάρ με ἐξαναστήσεσθαι, ἵνα καὶ ταῦτά με οἱ θεοὶ ἀπαιτήσωσιν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ταῦτα ῥᾴδιον ἄνθρωποι κατεπαγγέλλονται ἃ τελέσειν ἔργῳ οὐ προσδοκῶσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 35 Pb 34 Pc 13 Pe 2 Pf 18 Ph 19 Ma 26 Me 18 Mf 18.</p>
+          <bibl>Codd. Pa 35 Pb 34 Pc 13 Pe 2 Pf 18 Ph 19 Ma 26 Me 18 Mf 18.</bibl>
           <p><milestone unit="traduction"/>Un homme pauvre était malade et mal en point. Comme les médecins désespéraient de le sauver, il s’adressa aux dieux, promettant de leur offrir une hécatombe et de leur consacrer des ex-voto, s’il se rétablissait. Sa femme, qui se trouvait justement près de lui, lui demanda : « Et où prendras-tu de quoi payer tout cela ? — Penses-tu donc, répondit-il, que je vais me rétablir pour que les dieux me le réclament ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes font facilement des promesses qu’ils n’ont pas l’intention de tenir effectivement.</p>
         </div>
@@ -1289,7 +1288,7 @@
           <pb ed="perry" n="P34"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις πένης νοσῶν καὶ κακῶς διακείμενος, ἐπειδὴ ἀπηλπίσθη παρὰ τῶν ἰατρῶν, διὰ τὸ μηδὲν ἔχειν δοῦναι αὐτοῖς, τοὺς θεοὺς παρεκάλει καὶ ὑπισχνεῖτο αὐτοῖς λέγων· « Ὦ θεοὶ λαμπροί τε καὶ μέγιστοι, ἐὰν τὴν ὑγείαν μοι παράσχητε, ἑκατὸν βόας προσάξω ὑμῖν εἰς θυσίαν. » Τῆς δὲ γυναικὸς αὐτοῦ πυνθανομένης· « Πόθεν σοι ταῦτα, ἐὰν συμϐῇ ὑγιᾶναί σε ; » πρὸς αὐτὴν ἐκεῖνος ἔφη· « Καὶ νομίζεις &lt;ἂν&gt; ἀναστῆναί με, ἵνα με ταῦτα οἱ θεοὶ ἀπαιτήσωσιν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ ῥᾳδίως κατεπαγγέλλονται, ἀποτελέσαι δὲ ἔργῳ οὐ προσδοκῶσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 31 Ce 20 Cf 23 Ch 22 Mh 25.</p>
+          <bibl>Codd. Ca 31 Ce 20 Cf 23 Ch 22 Mh 25.</bibl>
         </div>
         <div>
           <head>Chambry 46.3</head>
@@ -1297,7 +1296,7 @@
           <pb ed="perry" n="P34"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις πένης νοσῶν καὶ κακῶς διακείμενος τοὺς θεοὺς παρεκάλει καὶ ὑπισχνεῖτο αὐτοῖς ὡς, ἐὰν τὴν ὑγείαν αὐτῷ παράσχωσι, ἑκατὸν εἰς θυσίαν βόας προσάξει. Τῆς δὲ γυναικὸς πυνθανομένης· « Πόθεν ταῦτα ἕξομεν ἡμεῖς ; » ἐκεῖνος ἔφη· « Καὶ δοκεῖς &lt;ἂν&gt; ἀναστῆναί με, ἵνα ταῦτα οἱ θεοὶ ἀπαιτήσωσι ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὡς πολλοὶ ῥᾳδίως κατεπαγγέλλονται, ἀποτελοῦσι δὲ οὐδὲν ἔργῳ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cc 22.</p>
+          <bibl>Cod. Cc 22.</bibl>
         </div>
         <div>
           <head>Chambry 46.4</head>
@@ -1305,7 +1304,7 @@
           <pb ed="perry" n="P34"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένης νοσῶν κακῶς διακείμενος, ἐπειδὴ πρὸς τῶν ἰατρῶν ἀπεγνώσθη, τῶν θεῶν ἐδεῖτο ὡς, εἰ τὴν ὑγείαν αὐτῷ πάλιν ἐπανελθεῖν ποιήσειαν, ἑκατὸν βόας αὐτοῖς προσοίσειν ὑπισχνούμενος εἰς θυσίαν. Τῆς δὲ γυναικὸς αὐτοῦ πυθομένης· « Καὶ ποῦ σοι ταῦτα, ἢν ὑγιάνῃς ; » ἐκεῖνος ἔφη· « Οἴει γὰρ ἂν ἀναστῆναί με ἐντεῦθεν, ἵν’ οἱ θεοὶ ταῦτά με ἀπαιτήσωσιν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὡς πολλοὶ ῥᾳδίως κατεπαγγέλλονται ἅπερ τελέσαι ἔργῳ οὐ προσδοκῶσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 15 Lb 14 Le 14 Lf 15 Md 14 Mi 49 Mj 17 Mm 14.</p>
+          <bibl>Codd. La 15 Lb 14 Le 14 Lf 15 Md 14 Mi 49 Mj 17 Mm 14.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-47">
@@ -1314,7 +1313,7 @@
         <pb ed="perry" n="P245"/>
         <p><milestone unit="recitprose"/>Ἀνὴρ δειλὸς ἐπὶ πόλεμον ἐξῄει. Φθεγξαμένων δὲ κοράκων, τὰ ὅπλα θεὶς ἡσύχαζεν, εἶτ’ ἀναλαϐὼν αὖθις ἐξῄει, καὶ φθεγγομένων πάλιν, ὑπέστη καὶ τέλος εἶπεν· « Ὑμεῖς κεκράξεσθε μὲν ὡς δύνασθε μέγιστον· ἐμοῦ δὲ οὐ γεύσεσθε. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος περὶ τῶν σφόδρα δειλῶν.</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 13.</p>
+        <bibl>Cod. Mb 13.</bibl>
         <p><milestone unit="traduction"/>Un homme lâche partait pour la guerre ; mais ayant entendu croasser des corbeaux, il posa ses armes et ne bougea plus ; puis il les reprit et se remit en marche. Mais les corbeaux croassant de nouveau, il s’arrêta, et à la fin il leur dit : « Libre à vous de crier aussi fort que vous pourrez ; mais vous ne goûterez pas à ma chair. »</p>
         <p><milestone unit="traduction"/>Cette fable vise les poltrons.</p>
       </div>
@@ -1324,7 +1323,7 @@
         <pb ed="perry" n="P306"/>
         <p><milestone unit="recitprose"/>Ναῦν ποτε μετὰ τῶν ἀνδρῶν βυθισθεῖσαν ἰδών τις ἀδίκως ἔλεγε τοὺς θεοὺς κρίνειν· δι’ ἕνα γὰρ ἀσεϐῆ συναπώλοντο καὶ ἀναίτιοι. Ταῦτα αὐτοῦ λέγοντος, μυρμήκων πολλῶν ὄντων ἐν τῷ τόπῳ ἐν ᾧ ἔτυχεν ἱστάμενος, συνέϐη ὑφ’ ἑνὸς δηχθῆναι τοῦτον. Ὁ δὲ ὑφ’ ἑνὸς δηχθεὶς συνεπάτησε τοὺς πάντας. Ἑρμῆς δὲ ἐπιστὰς αὐτῷ καὶ τῇ ῥάϐδῳ παίων εἶπεν· « Εἶτα οὐκ ἀνέχῃ σὺ τοὺς θεοὺς δικαστὰς εἶναι οἷος εἶ σὺ τῶν μυρμήκων ; »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι μηδεὶς θεοῦ βλασφημείτω, συμφορᾶς ἐπελθούσης, μᾶλλον δὲ σκοπείτω τὰς οἰκείας ἁμαρτίας.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 95.</p>
+        <bibl>Cod. Ba 95.</bibl>
         <p><milestone unit="traduction"/>Un jour un vaisseau ayant coulé à fond avec ses passagers, un homme, témoin du naufrage, prétendait que les arrêts des dieux étaient injustes, puisque, pour perdre un seul impie, ils avaient fait périr aussi des innocents. Tandis qu’il parlait ainsi, comme il y avait beaucoup de fourmis à l’endroit où il se trouvait, il arriva qu’une d’elles le mordit, et lui, pour avoir été mordu par une seule, les écrasa toutes. Alors Hermès lui apparut, et le frappant de son caducée, lui dit : « Et maintenant tu n’admettras pas, toi, que les dieux jugent les hommes comme tu juges les fourmis ? »</p>
         <p><milestone unit="traduction"/>Ne blasphémez pas contre les dieux, quand il arrive un malheur ; examinez plutôt vos propres fautes.</p>
       </div>
@@ -1336,7 +1335,7 @@
           <pb ed="perry" n="P95"/>
           <p><milestone unit="recitprose"/>Ἔχων τις γυναῖκα πρὸς πάντας τοὺς οἰκείους λίαν τὸ ἦθος ἀργαλέαν ἠϐουλήθη γνῶναι εἰ καὶ πρὸς τοὺς πατρῴους οἰκέτας ὁμοίως διάκειται· ὅθεν μετὰ προφάσεως εὐλόγου πρὸς τὸν πατέρα αὐτὴν ἔπεμψε. Μετὰ δὲ ὀλίγας ἡμέρας ἀνελθούσης αὐτῆς ἐπυνθάνετο πῶς αὐτὴν οἱ οἰκεῖοι προσεδέξαντο. Τῆς δὲ εἰπούσης· « Οἱ βουκόλοι καὶ οἱ ποιμένες με ὑπεϐλέποντο, » ἔφη πρὸς αὐτήν· « Ἀλλ’ ὦ γύναι, εἰ τούτοις ἀπήχθου οἱ ὄρθρου μὲν τὰς ποίμνας ἐξελαύνουσιν, ὀψὲ δὲ εἰσίασι, τί χρὴ προσδοκᾶν περὶ τούτων οἷς πᾶσαν τὴν ἡμέραν συνδιέτριϐες ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις ἐκ τῶν μικρῶν τὰ μεγάλα καὶ ἐκ τῶν προδήλων τὰ ἄδηλα γνωρίζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 96 Pc 48 Pf 48 Pg 64 Ph 50 Mb 27.</p>
+          <bibl>Codd. Pb 96 Pc 48 Pf 48 Pg 64 Ph 50 Mb 27.</bibl>
           <p><milestone unit="traduction"/>Un homme avait une femme qui était rude à l’excès envers tous les gens de la maison. Il voulut savoir si elle avait la même humeur envers les domestiques de son père, et il l’envoya chez lui sous un prétexte spécieux. Quand, après quelques jours, elle fut de retour, il lui demanda comment les gens de sa maison l’avaient reçue. « Les bouviers, répondit-elle, et les bergers me regardaient de travers. — Eh bien ! femme, reprit-il, si tu étais mal vue de ceux qui sortent les troupeaux au point du jour et ne rentrent que le soir, que devait-ce être de ceux avec qui tu passais tout le jour ? »</p>
           <p><milestone unit="traduction"/>C’est ainsi que souvent les petites choses font connaître les grandes, et les choses visibles, les choses cachées.</p>
         </div>
@@ -1346,7 +1345,7 @@
           <pb ed="perry" n="P95"/>
           <p><milestone unit="recitprose"/>Ἔχων τις γυναῖκα πρὸς τοὺς κατ’ οἶκον ἅπαντας ἀπεχθῶς ἔχουσαν, ἠϐουλήθη γνῶναι εἰ καὶ πρὸς τοὺς πατρῴους οἰκέτας οὕτω διάκειται. Διὸ δὴ καὶ μετ’ εὐλόγου προφάσεως πρὸς τὸν αὐτῆς αὐτὴν ἀποστέλλει πατέρα. Μετὰ δ’ ὀλίγας ἡμέρας ἐπανελθούσης αὐτῆς, ἐπυνθάνετο πῶς πρὸς τοὺς ἐκεῖ διεγένετο. Τῆς δὲ φαμένης ὡς οἱ βουκόλοι καὶ οἱ ποιμένες με ὑπεϐλέποντο, πρὸς αὐτὴν ἔφη· « Ἀλλ’, ὦ γύναι, εἰ τούτοις ἀπεχθάνῃ οἳ ὄρθρου μὲν τὰς ποίμνας ἐξελαύνουσιν, ὄψε δὲ εἰσίασι, τί χρὴ προσδοκᾶν περὶ τούτων οἷς πᾶσαν συνδιέτριϐες τὴν ἡμέραν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω πολλάκις ἐκ τῶν μικρῶν τὰ μεγάλα κἀκ τῶν προδήλων τὰ ἄδηλα γνωρίζεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 97 Lb 52 Le 52 Lf 97 Me 59 Mf 53 Mg 75 Mj 62 Ml 63.</p>
+          <bibl>Codd. La 97 Lb 52 Le 52 Lf 97 Me 59 Mf 53 Mg 75 Mj 62 Ml 63.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-50">
@@ -1357,7 +1356,7 @@
           <pb ed="perry" n="P36"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ κακοπράγμων συνορισάμενος πρός τινα ψευδὲς ἐπιδείξειν τὸ ἐν Δελφοῖς μαντεῖον, ὡς ἐνέστη ἡ προθεσμία, λαϐὼν στρουθίον εἰς τὴν χεῖρα καὶ τοῦτο τῷ ἱματίῳ σκεπάσας, ἧκεν εἰς τὸ ἱερὸν καὶ στὰς ἀντικρὺς ἐπηρώτα πότερόν τι ἔμπνουν ἔχει μετὰ χεῖρας ἢ ἄψυχον, βουλόμενος, ἐὰν μὲν ἄψυχον εἴπῃ, ζωὸν τὸ στρουθίον ἐπιδείξαι, ἐὰν δὲ ἔμπνουν, ἀποπνίξας προενεγκεῖν. Καὶ ὁ θεὸς συνεὶς αὐτοῦ τὴν κακότεχνον γνώμην εἶπεν· « Ἀλλ’ ὦ οὗτος, πέπαυσο· ἐν σοὶ γάρ ἐστι τοῦτο ὃ ἔχεις ἢ νεκρὸν εἶναι ἢ ἔμψυχον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὸ θεῖον ἀπαρεγχείρητόν ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 37 Pb 36 Pe 4 Pf 19 Me 19 Mf 19.</p>
+          <bibl>Codd. Pa 37 Pb 36 Pe 4 Pf 19 Me 19 Mf 19.</bibl>
           <p><milestone unit="traduction"/>Un fourbe s’était engagé envers quelqu’un à prouver que l’oracle de Delphes était menteur. Au jour fixé, il prit dans sa main un petit moineau, et, le cachant sous son manteau, se rendit au temple. Là, se plaçant en face de l’oracle, il demanda si l’objet qu’il tenait dans sa main était vivant ou inanimé. Il voulait, si le dieu répondait « inanimé », faire voir le moineau vivant ; s’il disait « vivant », présenter le moineau, après l’avoir étranglé. Mais le dieu, reconnaissant son artificieuse intention, répondit : « Assez, l’homme ; car il dépend de toi que ce que tu tiens soit mort ou vivant. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que la divinité défie toute surprise.</p>
         </div>
@@ -1367,7 +1366,7 @@
           <pb ed="perry" n="P36"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ κακοπράγμων πρὸς τὴν γνῶσιν τοῦ ἐν Δελφοῖς μαντείου ἧκε, βουλόμενος τὸν θεὸν ἐκπειρᾶσαι. Καὶ δὴ λαϐὼν στρουθίον ἐν τῇ χειρὶ καὶ τοῦτο σκεπάσας τῷ ἱματίῳ αὐτοῦ καὶ ἀντικρὺ αὐτοῦ στὰς ἐν τῷ ἱερῷ, ἐπηρώτησεν αὐτόν· « Τί ἔχω εἰς τὰς χεῖράς μου ἔμπνουν ἢ ἄπνουν ; » βουλόμενος [ὅτι], ἐὰν ἄπνουν εἴπῃ, ζῶν τὸ στρουθίον ὑποδεῖξαι· εἰ δὲ ἔμπνουν, ἀποπνίξας προενεγκεῖν. Γνοὺς δὲ ὁ θεὸς τὴν κακότεχνον αὐτοῦ γνώμην, εἶπεν· « Ὡς θέλεις ποίησον, ὦ οὗτος· ἐν σοὶ γὰρ ἐστι τὸ πρᾶξαι· θέλεις νεκρόν, θέλεις ζῶν, ἀπόδειξον τοῦτο. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τὸ θεῖον ἀπαρεγχείρητον καὶ ἀλάθητόν ἐστιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 32 Cc 23 Ce 21 Cf 24 Ch 24 Mh 26.</p>
+          <bibl>Codd. Ca 32 Cc 23 Ce 21 Cf 24 Ch 24 Mh 26.</bibl>
         </div>
         <div>
           <head>Chambry 50.3</head>
@@ -1375,7 +1374,7 @@
           <pb ed="perry" n="P36"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ κακοπράγμων εἰς τὸν ἐν Δελφοῖς ἧκεν Ἀπόλλωνα, πειρᾶσαι τοῦτον βουλόμενος. Καὶ δὴ λαϐὼν στρουθίον ἐν τῇ χειρὶ καὶ τοῦτο τῇ ἔσθητι σκεπάσας, ἔστη τε τοῦ τρίποδος ἔγγιστα καὶ ἤρετο τὸν θεὸν λέγων· « Ἄπολλον, ὅ μετὰ χεῖρας φέρω, πότερον ἔμπνουν ἐστὶν ἢ ἄπνουν ; » βουλόμενος [ὡς], εἰ μὲν ἄπνουν εἴποι, ζῶν ἀναδεῖξαι τὸ στρουθίον· εἰ δ’ ἔμπνουν, εὐθὺς ἀποπνίξας νεκρὸν ἐκεῖνο προενεγκεῖν. Ὁ δέ γε θεὸς τὴν κακότεχνον αὐτοῦ γνοὺς ἐπίνοιαν, εἶπεν. « Ὁπότερον, ὦ οὗτος, βούλει ποιῆσαι, ποίησον· παρὰ σοὶ γὰρ κεῖται τοῦτο πρᾶξαι ἤτοι ζῶν ὃ κατέχεις ἢ νεκρὸν ὑποδεῖξαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τὸ θεῖον ἀπαραλόγιστον καὶ ἀλάθητον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 16 Lb 15 Lc 8 Ld 7 Le 15 Lf 16 Lg 8 Ma 148 Mc 14 Md 15 Mi 50 Mj 18 Mk 15 Mm 15 Mn 7.</p>
+          <bibl>Codd. La 16 Lb 15 Lc 8 Ld 7 Le 15 Lf 16 Lg 8 Ma 148 Mc 14 Md 15 Mi 50 Mj 18 Mk 15 Mm 15 Mn 7.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-51">
@@ -1386,7 +1385,7 @@
           <pb ed="perry" n="P33"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένταθλος ἐπὶ ἀνανδρίᾳ ἑκάστοτε ὑπὸ τῶν πολιτῶν ὀνειδιζόμενος, ἀποδημήσας ποτὲ καὶ μετὰ χρόνον ἐπανελθών, ἀλαζονευόμενος ἔλεγεν ὡς πολλὰ καὶ ἐν ἄλλαις πόλεσιν ἀνδραγαθήσας, ἐν τῇ Ῥόδῳ τοιοῦτον ἥλατο πήδημα ὡς μηδένα τῶν Ὀλυμπιονικῶν ἐφικέσθαι· καὶ τούτου μάρτυρας ἔφασκε παρέξεσθαι τοὺς παρατετυχηκότας, ἂν ἄρα ποτὲ ἐπιδημήσωσι. Τῶν δὲ παρόντων τις ὑποτυχὼν ἔφη πρὸς αὐτόν· « Ἀλλ’, ὦ οὗτος, εἰ τοῦτο ἀληθές ἐστι, οὐδὲν δεῖ σοι μαρτύρων· αὐτοῦ γὰρ καὶ Ῥόδος καὶ πήδημα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ὧν πρόχειρος ἡ δι’ ἔργων πεῖρα, περὶ τούτων πᾶς λόγος περιττός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 34 Pb 33 Pe 1 Ma 25.</p>
+          <bibl>Codd. Pa 34 Pb 33 Pe 1 Ma 25.</bibl>
           <p><milestone unit="traduction"/>Un pentathle, à qui ses concitoyens reprochaient en toute occasion son manque de vigueur, s’en fut un jour à l’étranger. Au bout d’un certain temps il revint, et il allait se vantant d’avoir accompli mainte prouesse en différents pays, mais surtout d’avoir fait à Rhodes un saut tel qu’aucun athlète couronné aux jeux olympiques n’était capable d’en faire un pareil ; et il ajoutait qu’il produirait comme témoins de son exploit ceux qui s’étaient trouvés là, s’ils venaient jamais en son pays. Alors un des assistants prenant la parole lui dit : « Mais, mon ami, si c’est vrai, tu n’as pas besoin de témoins ; voici Rhodes ici même : fais le saut. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que lorsqu’on peut prouver une chose par des faits, tout ce qu’on en peut dire est superflu.</p>
         </div>
@@ -1396,7 +1395,7 @@
           <pb ed="perry" n="P33"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις ἀποδημήσας ἧκε πάλιν εἰς τὴν ἰδίαν χώραν. Φρυαττόμενος δὲ ἐκαυχᾶτο μεγάλως, ὡς ἀνδραγαθήσας εἰς διαφόρους τόπους· ἐν δὲ τῇ Ῥόδῳ ἔφασκε πήδημα μέγα πηδῆσαι, ὅπερ οὐδεὶς τῶν ἀνθρώπων δύναται πηδῆσαι, καὶ μάρτυρας ἔφασκεν ἔχειν εἰς τοῦτο. Τῶ δὲ παρόντων τις ὑπολαϐὼν ἔφη αὐτῷ· « Ὦ οὗτος, εἰ τοῦτο ἀληθές ἐστιν, ἰδοῦ Ῥόδος, καὶ ἀποπήδησον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, ἐὰν μὴ πρόχειρος ᾖ πεῖρα τοῦ πράγματος, πᾶς λόγος ἀργός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 30 Cc 21 Ce 19 Cf 22 Ch 21 Mh 24.</p>
+          <bibl>Codd. Ca 30 Cc 21 Ce 19 Cf 22 Ch 21 Mh 24.</bibl>
         </div>
         <div>
           <head>Chambry 51.3</head>
@@ -1414,7 +1413,7 @@
           <pb ed="perry" n="P31"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ μεσοπόλιος δύο ἐρωμένας εἶχεν, ὧν ἡ μὲν νέα ὑπῆρχεν, ἡ δὲ πρεσϐῦτις. Καὶ ἡ μὲν προϐεϐηκυῖα αἰδουμένη νεωτέρῳ αὐτῆς πλησιάζειν, διετέλει, εἴ ποτε πρὸς αὐτὴν παρεγένετο, τὰς μελαίνας αὐτοῦ τρίχας περιαιρουμένη. Ἡ δὲ νεωτέρα ὑποστελλομένη γέροντα ἐραστὴν ἔχειν τὰς πολιὰς αὐτοῦ ἀπέσπα. Οὕτω τε συνέϐη αὐτῷ ὑπὸ ἀμφοτέρων ἐν μέρει τιλλομένῳ φαλακρὸν γενέσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πανταχοῦ τὸ ἀνώμαλον ἐπιϐλαϐές ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 33 Pb 31 Ma 24.</p>
+          <bibl>Codd. Pa 33 Pb 31 Ma 24.</bibl>
           <p><milestone unit="traduction"/>Un grison avait deux maîtresses, l’une jeune et l’autre vieille. Or celle qui était avancée en âge ayant honte d’avoir commerce avec un amant plus jeune qu’elle, ne manquait pas, chaque fois qu’il venait chez elle, de lui arracher ses poils noirs. La jeune, de son côté, reculant à l’idée d’avoir un vieux pour amant, lui enlevait ses poils blancs. Il arriva ainsi qu’épilé tour à tour par l’une et l’autre, il devint chauve.</p>
           <p><milestone unit="traduction"/>C’est ainsi que ce qui est mal assorti occasionne toujours des désagréments.</p>
         </div>
@@ -1424,7 +1423,7 @@
           <pb ed="perry" n="P31"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις μέσην ἔχων ἥϐην δύο ἔσχεν ἑταίρας, μίαν μὲν γραῦν, τὴν δὲ ἑτέραν νέαν. Τούτου ἡ μὲν γραῦς τὰς μελαίνας τρίχας ἔτιλλεν, ὡς γέροντα τοῦτον θέλουσα, ἡ δὲ νέα τὰς πολιάς, ἕως [ἂν] αὐτὸν φαλακρὸν ἐποίησαν καὶ ὄνειδος ἁπάντων.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐλεεινός ἐστιν ὃς εἰς γυναῖκας ἐμπίπτει· ἡ γὰρ γυνὴ θαλάσσῃ ὁμοιοῦται, ποτὲ μὲν  γαληνιῶσα καὶ προσμειδιῶσα, ποτὲ δὲ ἀποπνίγουσα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 15 Bb 10 Mg 26.</p>
+          <bibl>Codd. Ba 15 Bb 10 Mg 26.</bibl>
         </div>
         <div>
           <head>Chambry 52.3</head>
@@ -1432,7 +1431,7 @@
           <pb ed="perry" n="P31"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις μεσῆλιξ δύο ἔσχεν ἑταίρας. Ἡ μὲν οὖν αὐτῶν τῷ χρόνῳ προέκοπτεν, ἡ δὲ τῇ νεότητι ἤκμαζεν. Ἔτιλλεν οὖν ἡ μὲν γραῦς τὸ μελάγχρουν τῶν τριχῶν ἐκείνου τῆς κεφαλῆς καὶ τοῦ πώγωνος· ἡ τρυφερὰ δὲ πάλιν ἐθέριζε τὰς λευκάς. Οὕτω τοίνυν ποιοῦσαι ἀμφότεραι φαλακρὸν τὸν τρισάθλιον καὶ βρεφύλλιον ἀπειργάσαντο, οἷος δὴ καὶ ἦν ταῖς φρεσίν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὀλέθριον τὸ γυναιξὶ δουλοῦν ἑαυτόν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 13.</p>
+          <bibl>Cod. Bc 13.</bibl>
         </div>
         <div>
           <head>Chambry 52.4</head>
@@ -1451,7 +1450,7 @@
           <l><milestone unit="recitvers"/>ἐξέλεγε καὶ αὐτὴ τὰς λευκὰς τρίχας,</l>
           <l><milestone unit="recitvers"/>ἕως φαλακρὸν ἀπέδωκαν ἀλλήλαις.</l>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἀνόητός ἐστιν ὁ ἀνὴρ ὁ γυναιξὶν ἑαυτὸν ἐκδοῦναι θέλων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pd 41 Pg 152 Ma 144.</p>
+          <bibl>Codd. Pd 41 Pg 152 Ma 144.</bibl>
         </div>
         <div>
           <head>Chambry 52.5</head>
@@ -1472,7 +1471,7 @@
           <l><milestone unit="recitvers"/>ἕως φαλακρῶν ἐποίησαν οἱ δύο,</l>
           <l><milestone unit="recitvers"/>γέλιον ὅμου καὶ ὄνειδος ἁπάντων.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρείττων ἐστὶν τοὺς γεγηρακότας ἀπέχεσθαι τῶν νετέρων, ὅμως φεύγειν πάντας τὰς γυναῖκας· τὸ γὰρ γυναικῖον γένος θαλασσιωνιοῦνται, ποτὲ γαλὺν ἢ ἀμειδιῶσα, ποτὲ δὲ ἀπατοῦσα ἀπεπνήγει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cb 108 Ca 199.</p>
+          <bibl>Codd. Cb 108 Ca 199.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-53">
@@ -1483,7 +1482,7 @@
         <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς μετὰ τῆς τῶν θεῶν παρακλήσεως χρὴ καὶ αὐτούς τι ὑπὲρ αὑτῶν λογιζομένους δρᾶν.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι ἀγαπητόν ἐστι καὶ ἐνεργοῦντας θεῶν εὐνοίας τυγχάνειν ἢ ἑαυτῶν ἀμελοῦντας ὑπὸ τῶν δαιμόνων περισῴζεσθαι.</p>
         <p><milestone unit="epimythiumprose"/>Τοὺς εἰς συμφορὰς ἐμπίπτοντας χρὴ καὶ αὐτοὺς ὑπὲρ ἑαυτῶν κοπιᾶν καὶ οὕτω τοῦ θεοῦ περὶ βοηθείας δέεσθαι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 32 Pb 30 Pc 11 Pf 17 Ph 18 Ma 23 Me 17 Mf 17.</p>
+        <bibl>Codd. Pa 32 Pb 30 Pc 11 Pf 17 Ph 18 Ma 23 Me 17 Mf 17.</bibl>
         <p><milestone unit="traduction"/>Un riche Athénien naviguait avec d’autres passagers. Une tempête violente étant survenue, le vaisseau chavira. Or, tandis que les autres passagers cherchaient à se sauver à la nage, l’Athénien, invoquant à chaque instant Athéna, lui promettait offrandes sur offrandes, s’il parvenait à se sauver. Un des naufragés, qui nageait à côté de lui, lui dit : « Fais appel à Athéna, mais aussi à tes bras »</p>
         <p><milestone unit="traduction"/>Nous aussi invoquons les dieux ; mais n’oublions pas de travailler de notre côté pour nous sauver.</p>
         <p><milestone unit="traduction"/>Estimons-nous heureux, si en faisant effort nous-mêmes, nous obtenons la protection des dieux ; si nous nous abandonnons, les démons seuls peuvent nous sauver.</p>
@@ -1495,7 +1494,7 @@
         <pb ed="perry" n="P37"/>
         <p><milestone unit="recitprose"/>Ἀνὴρ πηρὸς εἰώθει πᾶν τὸ ἐπιτιθέμενον εἰς τὰς αὐτοῦ χεῖρας ζῷον ἐφαπτόμενος λέγειν ὁποῖόν τί ἐστι. Καὶ δή ποτε λυκιδίου αὐτῷ ἐπιδοθέντος, ψηλαφήσας καὶ ἀμφιγνοῶν εἶπεν· « Οὐκ οἶδα πότερον λύκου ἐστὶν ἢ ἀλώπεκος ἢ τοιούτου τινὸς ζῴου γέννημα· τοῦτο μέντοι σαφῶς ἐπίσταμαι ὅτι οὐκ ἐπιτήδειον τοῦτο τὸ ζῷον προϐάτων ποίμνῃ συνιέναι. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω τῶν πονηρῶν ἡ διάθεσις πολλάκις καὶ ἀπὸ τοῦ σώματος καταφαίνεται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 38 Pb 37 Pd 23 Pe 5 Pg 19 Ma 28 Ca 17.</p>
+        <bibl>Codd. Pa 38 Pb 37 Pd 23 Pe 5 Pg 19 Ma 28 Ca 17.</bibl>
         <p><milestone unit="traduction"/>Un aveugle avait l’habitude de reconnaître au toucher toute bête qu’on lui mettait entre les mains, et de dire de quelle espèce elle était. Or un jour on lui présenta un louveteau ; il le palpa et resta indécis. « Je ne sais pas, dit-il, si c’est le petit d’un loup, d’un renard ou d’un autre animal du même genre ; mais ce que je sais bien, c’est qu’il n’est pas fait pour aller avec un troupeau de moutons. »</p>
         <p><milestone unit="traduction"/>C’est ainsi que le naturel des méchants se reconnaît souvent à leur extérieur.</p>
       </div>
@@ -1507,7 +1506,7 @@
           <pb ed="perry" n="P28"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένης νοσῶν καὶ κακῶς διακείμενος ηὔξατο τοῖς θεοῖς ἑκατὸν βόας τελέσειν, εἰ περισώσειαν αὐτόν. Οἱ δὲ ἀπόπειραν αὐτοῦ ποιήσασθαι βουλόμενοι ῥαΐσαι τάχιστα αὐτὸν παρεσκεύασαν. Κἀκεῖνος ἐξαναστάς, ἐπειδὴ ἀληθινῶν βοῶν ἠπόρει, στεατίνους ἑκατὸν πλάσας ἐπί τινος βωμοῦ κατέκαυσεν εἰπών· « Ἀπέχετε τὴν εὐχήν, ὦ δαίμονες. » Οἱ δὲ θεοὶ βουλόμενοι αὐτὸν ἐν μέρει ἀντιϐουκολῆσαι ὄναρ αὐτῷ ἔπεμψαν, παραινοῦντες ἐλθεῖν εἰς τὸν αἰγιαλόν· ἐκεῖ γὰρ αὐτὸν εὑρήσειν ἀττικὰς χιλίας. Καὶ ὃς περιχαρὴς γενόμενος δρομαῖος ἧκεν ἐπὶ τὴν ἠιόνα. Ἔνθα δὴ λῃσταῖς περιπεσὼν ἀπήχθη, καὶ ὑπ’ αὐτῶν πωλούμενος εὗρε δράχμας χιλίας.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος εὔκαιρος πρὸς ἄνδρα ψευδολόγον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 30 Pb 28.</p>
+          <bibl>Codd. Pa 30 Pb 28.</bibl>
           <p><milestone unit="traduction"/>Un homme pauvre, étant malade et mal en point, promit aux dieux de leur sacrifier cent bœufs, s’ils le sauvaient de la mort. Les dieux, voulant le mettre à l’épreuve, lui firent très vite recouvrer la santé, et il se leva de son lit. Mais, comme il n’avait pas de vrais bœufs, il en modela cent avec du suif, et les consuma sur un autel, en disant : « Recevez mon vœu, Ô dieux. » Mais les dieux, voulant le mystifier à leur tour, lui envoyèrent un songe, et l’engagèrent à se rendre sur le rivage : il y trouverait mille drachmes attiques. Ne se tenant plus de joie, il courut à la grève, où il tomba sur des pirates, qui l’emmenèrent, et, vendu par eux, il trouva ainsi mille drachmes.</p>
           <p><milestone unit="traduction"/>Cette fable s’applique bien au menteur.</p>
         </div>
@@ -1517,7 +1516,7 @@
           <pb ed="perry" n="P28"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένης νοσῶν ηὔξατο τοῖς θεοῖς λέγων ὅτι « ἐὰν ὑγιάνω, ἑκατὸν βόας προσάξω ὑμῖν εἰς θυσίαν. » Οἱ δὲ πειράζειν αὐτὸν βουλόμενοι ῥᾴδιον ὑγιῆ αὐτὸν ἀποκατέστησαν. Ἐξαναστὰς οὖν ὁ ἄνθρωπος, ἐπειδὴ βοῶν ἠπόρει, στεατίνους ἑκατὸν ποιήσας βόας ἐπὶ τοῦ βωμοῦ κατέκαυσεν εἰπών· « Ὦ δαίμονες, ἰδοῦ τὴν εὐχὴν ἀπετέλεσα. » Οἱ δὲ θεοὶ βουλόμενοι αὐτὸν ἀνταμύνασθαι, ὄναρ ἐπιστάντες αὐτῷ εἶπον· « Ἄπελθε εἰς τὸν αἰγιαλόν, εἰς τόνδε τὸν τόπον, καὶ εὑρήσεις ἐκεῖσε χρυσίου τάλαντα ἑκατόν. » Ὁ δὲ, ἔξυπνος γενόμενος, μετὰ πολλῆς χαρᾶς κατῆλθεν εἰς τὸν ὑποδειχθέντα αὐτῷ τόπον δρομαῖος ψηλαφῶν τὸ χρυσίον. Περιπεσὼν δὲ ἐκεῖσε λῃσταῖς συνελήφθη ὑπ’ αὐτῶν. Ὁ δὲ παρεκάλει αὐτοὺς λέγων· « Ἄφετέ με, καὶ ἐπιδώσω ὑμῖν χρυσίου χίλια τάλαντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ ψευδεῖς τῶν ἀνθρώπων ἐχθραίνουσι τὸ θεῖον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 36 Cb 23 Cc 27 Cd 23 Cf 28 Ch 30 Mc 27 Mh 30 Mk 28.</p>
+          <bibl>Codd. Ca 36 Cb 23 Cc 27 Cd 23 Cf 28 Ch 30 Mc 27 Mh 30 Mk 28.</bibl>
         </div>
         <div>
           <head>Chambry 55.3</head>
@@ -1525,7 +1524,7 @@
           <pb ed="perry" n="P28"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ πένης νοσῶν ηὔξατο τοῖς θεοῖς, εἰ διασωθείη, βοῦς ἑκατὸν εἰς θυσίαν προσοίσειν. Οἱ δὲ θεοὶ πειρᾶσαι τοῦτον βουλόμενοι τοῦ πάθους ἀπήλλαξαν. Ὁ δ’ ἀναστάς, ἐπειδὴ βοῶν ἠπόρει, στεατίνους βοῦς ἑκατὸν πλάσας, ἐπὶ τοῦ βωμοῦ θεὶς ὡλοκαύτωσεν. Οἱ δὲ θεοὶ βουλόμενοι αὐτὸν ἀμύνασθαι, ὄναρ ἐπιστάντες αὐτῷ εἶπον· « Ἄπελθε εἰς τὸν αἰγιαλόν, εἰς τόνδε τὸν τόπον· ἐκεῖ δὲ ἀττικὰς χιλίας εὑρήσεις. » Ἐκεῖνος δὲ διυπνισθεὶς σὺν ἡδονῇ καὶ σπουδῇ πρὸς τὸν ὑποδειχθέντα τόπον ἀφίκετο τὸ χρυσίον διερευνῶν. Ἐκεῖ δὲ δὴ πειραταῖς περιτυχὼν ὑπ’ αὐτῶν συνελήφθη. Ἁλοὺς δὲ ἤδη ἀφεθῆναι τῶν πειρατῶν ἐδεῖτο, χιλία χρυσίου τάλαντα δώσειν αὐτοῖς ὑπισχνούμενος. Ὡς δ’ οὐκ ἐπιστεύετο, ἀπαχθεὶς ὑπ’ αὐτῶν ἀπημπολήθη χιλίων δραχμῶν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοῖς ψευδέσι τῶν ἀνθρώπων ἐχθραίνει τὸ θεῖον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 18 Lb 17 Lc 54 Le 17 Lf 18 Lg 54 Ma 149 Md 17 Me 24 Mf 24 Mg 9 Mi 52 Mj 20 Ml 14 Mm 17.</p>
+          <bibl>Codd. La 18 Lb 17 Lc 54 Le 17 Lf 18 Lg 54 Ma 149 Md 17 Me 24 Mf 24 Mg 9 Mi 52 Mj 20 Ml 14 Mm 17.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-56">
@@ -1535,8 +1534,8 @@
           <head type="sub">Ἀνθρακεὺς καὶ γναφεύς — Le charbonnier et le foulon.</head>
           <pb ed="perry" n="P29"/>
           <p><milestone unit="recitprose"/>Ἀνθρακεὺς ἐπί τινος οἰκίας ἐργαζόμενος, ὡς ἐθεάσατο γναφέα αὐτῷ παροικισθέντα, προσελθὼν παρεκάλει αὐτὸν, ὅπως αὐτῷ σύνοικος γένηται, διεξιὼν ὡς οἰκειότεροι ἀλλήλοις ἔσονται καὶ λυσιτελέστερον διάξουσι μίαν ἔπαυλιν οἰκοῦντες. Καὶ ὁ γναφεὺς ὑποτυχὼν ἔφη· « Ἀλλ’ ἔμοιγε τοῦτο παντελῶς ἀδύνατον· ἅ γὰρ ἐγὼ λευκανῶ, σὺ ασϐολώσεις. »</p>
-          <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πᾶν τὸ ἀνόμοιον ἀκοινώνητόν ἐστι. <space rend="tab">    </space></p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 31 Pb 29 Pc 10 Pd 22 Ph 17 Ma 22 Mb 10.</p>
+          <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πᾶν τὸ ἀνόμοιον ἀκοινώνητόν ἐστι. </p>
+          <bibl>Codd. Pa 31 Pb 29 Pc 10 Pd 22 Ph 17 Ma 22 Mb 10.</bibl>
           <p><milestone unit="traduction"/>Un charbonnier qui exerçait son métier dans une certaine maison, ayant vu un foulon établi près de lui, alla le trouver et l’engagea à venir habiter avec lui, lui remontrant qu’ils en seraient plus intimes et qu’ils vivraient à moins de frais, n’ayant qu’une seule demeure. Mais le foulon lui répondit : « C’est pour moi totalement impossible : car ce que je blanchirais, tu le noircirais de suie. »</p>
           <p><milestone unit="traduction"/>La fable montre qu’on ne peut associer des natures dissemblables.</p>
         </div>
@@ -1546,7 +1545,7 @@
           <pb ed="perry" n="P29"/>
           <p><milestone unit="recitprose"/>Ἀνθρακεὺς ἐπί τινος οἰκίας κατοικῶν, ὡς ἐθεάσατο γναφέα, παρεκάλει αὐτὸν ἐν τῷ ἅμα κατοικῆσαι ἀμφοτέρους. Καὶ ὁ γναφεὺς ὑπολαϐὼν ἔφη· « Ἀλλ’ ἔγωγε παντελῶς πρᾶξαι τοῦτο οὐ δύναμαι. » Τοῦ δὲ πυνθανομένου δι’ ἣν αἰτίαν, ἔφη· « Φοϐοῦμαι μήπως ἃ ἐγὼ λευκαίνω, σὺ ἀποτεφροῖς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πᾶν τὸ ἀνόμοιον ἀκοινώνητον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 27 Cb 19 Cd 19 Ce 55 Cf 59 Ch 26 Mh 19.</p>
+          <bibl>Codd. Ca 27 Cb 19 Cd 19 Ce 55 Cf 59 Ch 26 Mh 19.</bibl>
         </div>
         <div>
           <head>Chambry 56.3</head>
@@ -1554,7 +1553,7 @@
           <pb ed="perry" n="P29"/>
           <p><milestone unit="recitprose"/>Ἀνθρακεὺς ἐπί τινος οἰκῶν οἰκίας ἠξίου καὶ κναφέα παραγενόμενον αὐτῷ συνοικῆσαι. Ὁ δὲ κναφεὺς ὑπολαϐὼν ἔφη· « Ἀλλ’ οὐκ ἂν τοῦτο δυναίμην ἔγωγε πρᾶξαι· δέδια γὰρ μή πως ἅπερ ἐγὼ λευκαίνω, αὐτὸς ἀσϐόλης πληροῖς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶν τὸ ἀνόμοιον ἀκοινώνητον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 12 Lb 11 Lc 7 Ld 5 Le 11 Lf 12 Lg 7 Mc 13 Md 11 Me 22 Mf 22 Mi 46 Mk 14 Ml 11 Mm 11 Mn 5.</p>
+          <bibl>Codd. La 12 Lb 11 Lc 7 Ld 5 Le 11 Lf 12 Lg 7 Mc 13 Md 11 Me 22 Mf 22 Mi 46 Mk 14 Ml 11 Mm 11 Mn 5.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-57">
@@ -1563,7 +1562,7 @@
         <pb ed="perry" n="P311"/>
         <p><milestone unit="recitprose"/>Λέγουσι πρῶτον τὰ ζῷα πλασθῆναι καὶ χαρισθῆναι αὐτοῖς παρὰ θεοῦ, τῷ μὲν ἀλκήν, τῷ δὲ τάχος, τῷ δὲ πτερά, τὸν δὲ ἄνθρωπον γυμνὸν ἑστῶτα εἰπεῖν· « Ἐμὲ μόνον κατέλιπες ἔρημον χάριτος· » τὸν δὲ Δία εἰπεῖν· « Ἀνεπαίσθητος εἶ τῆς δωρεᾶς, καίτοι τοῦ μεγίστου τετυχηκώς· λόγον γὰρ ἔχεις λαϐών, ὃς παρὰ θεοῖς δύναται καὶ παρὰ ἀνθρώποις, τῶν δυνατῶν δυνατώτερος καὶ τῶν ταχίστων ταχύτερος. » Καὶ τότε ἐπιγνοὺς τὸ δῶρον ὁ ἄνθρωπος προσκυνήσας καὶ εὐχαριστήσας ᾤχετο.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι, ἐκ θεοῦ λόγῳ τιμηθέντων πάντων, ἀνεπαισθήτως ἔχουσί τινες τῆς τοιαύτης τιμῆς καὶ μᾶλλον ζηλοῦσι τὰ ἀναίσθητα καὶ ἄλογα ζῷα.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 87.</p>
+        <bibl>Cod. Ba 87.</bibl>
         <p><milestone unit="traduction"/>On dit que les animaux furent façonnés d’abord, et que Dieu leur accorda, à l’un la force, à l’autre la vitesse, à l’autre des ailes ; mais que l’homme resta nu et dit : « Moi seul, tu m’as laissé sans faveur. » Zeus répondit : « Tu ne prends pas garde au présent que je t’ai fait, et pourtant tu as obtenu le plus grand ; car tu as reçu la raison, puissante chez les dieux et chez les hommes, plus puissante que les puissants, plus rapide que les plus rapides. » Et alors reconnaissant le présent de Dieu, l’homme s’en alla, adorant et rendant grâce.</p>
         <p><milestone unit="traduction"/>Tous les hommes ont été favorisés de Dieu qui leur a donné la raison ; mais certains sont insensibles à une telle faveur et préfèrent envier les animaux privés de sentiment et de raison.</p>
       </div>
@@ -1575,7 +1574,7 @@
           <pb ed="perry" n="P283"/>
           <p><milestone unit="recitprose"/>Ἀλώπεκά τις ἐχθρὰν ἔχων ὡς βλάπτουσαν αὐτόν, κρατήσας καὶ θέλων ἐπὶ πολὺ τιμωρήσασθαι, στυππεῖα ἐλαίῳ βεϐρεγμένα τῆ οὐρᾷ προσδήσας ὑφῆψε. Ταύτην δὲ δαίμων εἰς τὰς ἀρούρας τοῦ βαλόντος ὡδήγει· ἦν δὲ καιρὸς τοῦ ἀμήτου. Ὁ δὲ ἠκολούθει θρηνῶν μηδὲν θερίσας.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πρᾷον εἶναι χρὴ καὶ μὴ ἀμέτρως θυμοῦσθαι· ἐξ ὀργῆς γὰρ πολλάκις βλάϐη γίνεται μεγάλη τοῖς δυσοργήτοις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 9 Bb 6 Mg 23.</p>
+          <bibl>Codd. Ba 9 Bb 6 Mg 23.</bibl>
           <p><milestone unit="traduction"/>Un homme avait de la rancune contre un renard qui lui causait des dommages. Il s’en empara, et pour en tirer une ample vengeance, il lui attacha à la queue de l’étoupe imbibée d’huile, et y mit le feu. Mais un dieu fit aller le renard dans les champs de celui qui l’avait lancé. Or c’était le temps de la moisson, et l’homme suivait, en déplorant sa récolte perdue.</p>
           <p><milestone unit="traduction"/>Il faut être indulgent, et ne pas s’emporter sans mesure ; car il arrive souvent que la colère cause de grands dommages aux gens irascibles.</p>
         </div>
@@ -1585,7 +1584,7 @@
           <pb ed="perry" n="P283"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις ἐχθραίνων ἀλώπεκι διά τινα ταύτης ῥᾳδιουργίαν, ἐπὶ πολὺ ταύτην, μετὰ τὸ κατασχεῖν, τιμωρῆσαι ἐμηχανήσατο καὶ στυππεῖον ἐλαίῳ βαπτίσας, τῇ κέρκῳ ταύτης προσδήσας ὑφῆψε πυρί. Ταύτην δὲ ὁ δαίμων εἰς τὰς ἀρούρας τοῦ ποινητῆρος καὶ τοὺς ἄγρους καθωδήγησεν, ἃ δὴ καὶ κατέκαυσεν· ὥρα γὰρ ἦν θέρους ἀκμαιότητος. Ἠκολούθει τοίνυν αὐτῇ βοῶν ὁ ταλαίπωρος ἑαυτόν τε ὁδυρόμενος καὶ τῆς οἰκείας ἐπινοίας καταμεμφόμενος.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πρᾷον εἶναι χρὴ καὶ μὴ ἀμέτρως θυμοῦσθαι· ἐξ ὀργῆς γὰρ πολλάκις μεγίστη βλάϐη τοῖς δυσοργίστοις ἐγγίνεται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 8.</p>
+          <bibl>Cod. Bc 8.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-59">
@@ -1606,7 +1605,7 @@
           <l><milestone unit="recitvers"/>εἰ γὰρ ᾔδεισαν λέοντες γλύφειν λίθους,</l>
           <l><milestone unit="recitvers"/>πολλοὺς ἂν εἶδες ὑποκάτω λεόντων. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ καυχώμενοι πειρῶνται ἐν λόγοις ἑαυτοὺς ἐπιφημίζειν, καίπερ μὴ ὄντες τοιοῦτοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 32 Ch 107 Ca 169 Cb 87 Cd 101.</p>
+          <bibl>Codd. Cg 32 Ch 107 Ca 169 Cb 87 Cd 101.</bibl>
         </div>
         <div>
           <head>Chambry 59.2</head>
@@ -1622,7 +1621,7 @@
           <l><milestone unit="recitvers"/>« Εἴπερ λέοντες ᾔδεσαν πάντως γλύφειν,</l>
           <l><milestone unit="recitvers"/>†πολλοὺς ἂν εἶδες ὄντας ἀνθρώπων λίθους.† »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ πειρῶνται καυχώμενοι ἐν λόγοις ἀνδρείους ἑαυτοὺς ποιεῖν καὶ μὴ ὄντες.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 101.</p>
+          <bibl>Cod. Mb 101.</bibl>
         </div>
         <div>
           <head>Chambry 59.3</head>
@@ -1630,7 +1629,7 @@
           <pb ed="perry" n="P284"/>
           <p><milestone unit="recitprose"/>Λέων σὺν ἀνθρώπῳ ὥδευον ὁμοῦ ἐν ὁδῷ. Ὁ δὲ ἄνθρωπος αὐτῷ ἐλάκει· « Δυνατώτερον ζῷον ὁ ἄνθρωπος παρὰ τὸν λέοντα. » Ὁ δὲ λέων· « Δυνατώτερον ζῷον ὁ λέων. » Καὶ ὁδευόντων αὐτῶν, ἐδείκνυεν ὁ ἄνθρωπος τὰς γεγλυμμένας στήλας ἃς οἱ ἄνθρωποι ἔγλυφον καὶ ἐποίουν λέοντας ὑποτασσομένους καὶ ὑποκάτω ὄντας ἀνθρώπων. Ὁ δὲ λέων ἔφη· « Εἰ ᾔδεσαν λέοντες γλύφειν, πολλοὺς ἀνθρώπους &lt;ἂν&gt; εἶδες ὑποκάτω λέοντων. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι εἰσί τινες &lt;οἳ&gt; ἐν οἷς οὐ δύνανται καυχῶνται [μηδὲ δυναμένους].</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 178.<space rend="tab">    </space></p>
+          <bibl>Cod. Ma 178.</bibl>
         </div>
         <div>
           <head>Chambry 59.4</head>
@@ -1638,7 +1637,7 @@
           <pb ed="perry" n="P284"/>
           <p><milestone unit="recitprose"/>Ὥδευέ ποτε λέων σὺν ἀνθρώπῳ. Ἕκαστος δὲ αὐτῶν τοῖς λόγοις ἐκαυχῶντο. Καὶ δὴ ἐν τῇ ὁδῷ ἦν ἀνδρὸς στήλη πετρίνη λέοντα πνίγοντος. Ὁ δὲ ἀνὴρ ὑποδείξας τῷ λέοντι ἔφη· « Ὁρᾷς σὺ πῶς ἐσμεν ὑμῶν κρείττονες. » Κἀκεῖνος εἶπεν ὑπομειδιάσας· « Εἰ λέοντες ᾔδεισαν γλύφειν, πολλοὺς ἂν ἄνδρας εἶδες ὑποκάτω λέοντος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ καυχῶνται διὰ λόγων ἀνδρεῖοι εἶναι καὶ θρασεῖς οὓς ἡ πεῖρα γυμνασθέντας ἐξελέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 148 Bb 91.</p>
+          <bibl>Codd. Ba 148 Bb 91.</bibl>
           <p><milestone unit="traduction"/>Un lion voyageait un jour avec un homme. Ils se vantaient à qui mieux mieux, lorsque sur le chemin ils rencontrèrent une stèle de pierre qui représentait un homme étranglant un lion. Et l’homme la montrant au lion dit : « Tu vois comme nous sommes plus forts que vous. » Le lion répondit en souriant : « Si les lions savaient sculpter, tu verrais beaucoup d’hommes sous la patte du lion. »</p>
           <p><milestone unit="traduction"/>Bien des gens se vantent en paroles d’être braves et hardis ; mais l’expérience les démasque et les confond.</p>
         </div>
@@ -1651,7 +1650,7 @@
           <pb ed="perry" n="P35"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπόν ποτε λέγεται πρὸς σάτυρον φιλίαν σπείσασθαι. Καὶ δὴ χειμῶνος καταλαϐόντος καὶ ψύχους γενομένου, ὁ ἄνθρωπος προσφέρων τὰς χεῖρας τῷ στόματι ἐπέπνει. Τοῦ δὲ σατύρου τὴν αἰτίαν ἐρομένου δι’ ἣν τοῦτο πράττει, ἔλεγεν ὅτι θερμαίνει τὰς χεῖρας διὰ τὸ κρύος. Ὕστερον δὲ παρατεθείσης αὐτοῖς τραπέζης καὶ προσφαγήματος θερμοῦ σφόδρα ὄντος, ὁ ἄνθρωπος ἀναιρούμενος κατὰ μικρὸν τῷ στόματι προσέφερε καὶ ἐφύσα. Πυνθανομένου δὲ πάλιν τοῦ σατύρου τί τοῦτο ποιεῖ, ἔφασκε καταψύχειν τὸ ἔδεσμα, ἐπεὶ λίαν θερμόν ἐστι. Κἀκεῖνος ἔφη πρὸς αὐτόν· « Ἀλλ’ ἀποτάσσομαί σου τῇ φιλίᾳ, ὦ οὗτος, ὅτι ἐκ τοῦ αὐτοῦ στόματος καὶ τὸ θερμὸν καὶ τὸ ψυχρὸν ἐξιεῖς. »</p>
           <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς περιφεύγειν δεῖ τὴν φιλίαν ὧν ἀμφίϐολός ἐστιν ἡ διάθεσις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 35 Pa 36 Ma 27.</p>
+          <bibl>Codd. Pb 35 Pa 36 Ma 27.</bibl>
           <p><milestone unit="traduction"/>Jadis un homme avait fait, dit-on, un pacte d’amitié avec un satyre. L’hiver étant venu et avec lui le froid, l’homme portait ses mains à sa bouche et soufflait dessus. Le satyre lui demanda pourquoi il en usait ainsi. Il répondit qu’il se chauffait les mains à cause du froid. Après, on leur servit à manger. Comme le mets était très chaud, l’homme le prenant par petits morceaux, les approchait de sa bouche et soufflait dessus. Le satyre lui demanda de nouveau pourquoi il agissait ainsi. Il répondit qu’il refroidissait son manger, parce qu’il était trop chaud. « Eh bien ! camarade, dit le satyre, je renonce à ton amitié, parce que tu souffles de la même bouche le chaud et le froid. »</p>
           <p><milestone unit="traduction"/>Concluons que nous aussi nous devons fuir l’amitié de ceux dont le caractère est ambigu.</p>
         </div>
@@ -1661,7 +1660,7 @@
           <pb ed="perry" n="P35"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις πρὸς σάτυρον φιλίαν ποιήσασθαι λέγεται. Καὶ δὴ χειμῶνος καταλαϐόντος καὶ ψύχους γενομένου, ὁ ἄνθρωπος τὰς χεῖρας προσφέρων τῷ στόματι ἐπέπνει θερμαίνων. Τοῦ δὲ σατύρου τὴν αἰτίαν ἐρομένου δι’ ἣν τοῦτο πράττει, ἔλεγεν ὅτι θερμαίνει τὰς χεῖρας διὰ τοῦ κρύους. Ὕστερον δὲ παρατεθείσης αὐτοῖς τραπέζης καὶ προσφαγήματος θερμοῦ ὄντος σφόδρα, πάλιν ὁ αὐτὸς αἰρόμενος τὰς χεῖρας ἐν τῷ στόματι κατὰ μικρὸν προσφέρων ἐφύσα. Λέγει δὲ πάλιν πρὸς αὐτὸν ὁ σάτυρος· « Τί τοῦτο ποιεῖς ; » Λέγει αὐτῷ· « Καταψύχω τὸ ἔδεσμα, ἐπεὶ λίαν ἐστὶ ζεστόν. » Κἀκεῖνος ἔφη πρὸς αὐτόν· « Ἀποστήσομαί σου ἐγὼ τῆς φιλίας, ἐπεὶ γὰρ οὕτως ποιεῖς· ἐκ τοῦ στόματός σου προσφέρεις ψυχρὸν καὶ θερμόν. »</p>
           <p><milestone unit="epimythiumprose"/>Τοιγαροῦν καὶ ἡμᾶς περιφεύγειν δεῖ ὧν ἀμφίϐολός ἐστιν ἡ διάθεσις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 3.</p>
+          <bibl>Cod. Pe 3.</bibl>
         </div>
         <div>
           <head>Chambry 60.3</head>
@@ -1669,7 +1668,7 @@
           <pb ed="perry" n="P35"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις καὶ σάτυρος φιλίαν πρὸς ἀλλήλους ποιησάμενοι ἐκάθισαν ἀμφότεροι τοῦ ἐσθίειν. Χειμῶνος δὲ καταλαϐόντος καὶ ψύχους γενομένου, ὁ ἄνθρωπος προσφέρων τὰς χεῖρας τῷ στόματι αὐτοῦ ἀπέπνει. Τοῦ δὲ σατύρου ἐπερωτήσαντος· « Δι’ ἣν αἰτίαν πράττεις τοῦτο, φίλε ; » ἔφη· « Τὰς χεῖρας θερμαίνω ἐκ τοῦ κρύους. » Μετὰ μικρὸν δὲ ἐδέσματος θερμοῦ προσενεχθέντος, ὁ ἄνθρωπος πάλιν ἐπιφέρων τῷ στόματι τὸ βρῶμα, ἐφύσα τοῦτο. Πυνθανομένου δὲ πάλιν τοῦ σατύρου· « Δι’ ἣν αἰτίαν τοῦτο πάλιν πράττεις ; » ἔφη· « Τὸ ἔδεσμα καταψύχω. » Ὑπολαϐὼν δὲ ἐκεῖνος ἔφη· « Ἀλλ’ ἔγωγε ἀπὸ τοῦ νῦν ἀποτάσσομαί σου τῇ φιλίᾳ, ὅτι ἐκ τοῦ αὐτοῦ στόματος τὸ ψυχρὸν καὶ τὸ θερμὸν ἐξάγεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω δεῖ καὶ ἡμᾶς ἀποφεύγειν τὰς φιλίας ὧν ἀμφίϐολός ἐστιν ἡ διάθεσις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 26 Cc 17 Ch 23 Ml 24.</p>
+          <bibl>Codd. Ca 26 Cc 17 Ch 23 Ml 24.</bibl>
         </div>
         <div>
           <head>Chambry 60.4</head>
@@ -1677,7 +1676,7 @@
           <pb ed="perry" n="P35"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις πρὸς σάτυρον φιλίαν ποιησάμενος συνεσθίων ἦν αὐτῷ. Χειμῶνος δὲ καὶ ψύχους γενομένου, ὁ ἄνθρωπος τὰς χεῖρας αὐτοῦ προσφέρων τῷ στόματι ἀπέπνει. Τοῦ δὲ σατύρου ἐπερωτήσαντος δι’ ἣν αἰτίαν τοῦτο πράττει, ἔφη· « Τὰς χεῖράς μου θερμαίνω ἐκ τοῦ κρύους. » Μετὰ μικρὸν δὲ ἐδέσματος θερμοῦ προσενεχθέντος, ὁ ἄνθρωπος προσφέρων τῷ στόματι ἐφύσα αὐτό. Πυνθανομένου δὲ πάλιν τοῦ σατύρου δι’ ἣν αἰτίαν τοῦτο πράττει, ἔφη· « Τὸ ἔδεσμα καταψύχω. » Ὑπολαϐὼν δὲ ὁ σάτυρος· « Ἀλλ’ ἔγωγε, ἔφη, ἀπὸ τοῦ νῦν ἀποτάσσομαί σου τῆς φιλίας, ὅτι ἐκ τοῦ αὐτοῦ στόματος τὸ θερμὸν καὶ τὸ ψυχρὸν ἐξάγεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ φεύγειν ἡμᾶς τὰς φιλίας ὧν ἀμφίϐολός ἐστιν ἡ διάθεσις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 130 Ld 10 Lf 130 Mc 17 Md 25 Me 28 Mg 17 Mh 18 Mi 60 Mk 18 Mm 25 Mn 10.</p>
+          <bibl>Codd. La 130 Ld 10 Lf 130 Mc 17 Md 25 Me 28 Mg 17 Mh 18 Mi 60 Mk 18 Mm 25 Mn 10.</bibl>
         </div>
         <div>
           <head>Chambry 60.5</head>
@@ -1685,7 +1684,7 @@
           <pb ed="perry" n="P35"/>
           <p><milestone unit="recitprose"/>Χειμὼν ἄνθρωπόν τινα ἐν ὄρει κατέλαϐεν. Ὁ δὲ καπνὸν ἐν τῇ ἄκρᾳ τοῦ ὄρους ἐκ πέτρας τινὸς ἀνιόντα ἰδὼν ἔνθα σάτυρος, οὓς λέγουσι παίκτας, κατῴκει, ἀνῆλθεν· αὐτὸς δὲ τὸν ξένον οἰκτείρας ἔσω εἰσήγαγεν. Ὁ δὲ πολλὰ ῥιγῶν τῇ πνοῇ τοῦ στόματος τὰς χεῖρας ἐθέρμαινε. Κἀκεῖνος αὐτῷ θερμὰ μὲν φαγεῖν δέδωκε καὶ θερμὰ πιεῖν καὶ πυρὶ κατέθαλπεν. Ὡς δὲ ἵδρωσε, τῇ πνοῇ πάλιν τὰς χεῖρας κατέψυχεν. Ὁ δὲ σάτυρος τοῦτον ἐξῆγεν « κακοῦ, λέγων, ξένου χρείαν οὐκ ἔχω, ὃς ποτὲ μὲν θερμόν, ποτὲ δὲ ψυχρὸν ἐκ τοῦ στόματος ἀσθμαίνει. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] διγνώμους ἄνδρας τοὺς ποτὲ μὲν ἐπαινοῦντας, ποτὲ δὲ ψέγοντας ὁ μῦθος διαϐάλλει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 145 Bb 89.</p>
+          <bibl>Codd. Ba 145 Bb 89.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-61">
@@ -1707,7 +1706,7 @@
           <l><milestone unit="recitvers"/>τιμῶντά σε γὰρ οὐδὲν ὠφέλησάς με,</l>
           <l><milestone unit="recitvers"/>τυπτήσαντα δὲ πολλοῖς καλοῖς ἠμείψω. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐκ ὡφεληθήσῃ τιμῶν πονηρὸν ἄνδρα, αὐτὸν δὲ τύπτων πλεῖον ὠφεληθήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 21 Cb 15 Cc 12 Cd 15 Ce 15 Cf 16 Ch 15 Mc 20 Ml 23.</p>
+          <bibl>Codd. Ca 21 Cb 15 Cc 12 Cd 15 Ce 15 Cf 16 Ch 15 Mc 20 Ml 23.</bibl>
         </div>
         <div>
           <head>Chambry 61.2</head>
@@ -1715,7 +1714,7 @@
           <pb ed="perry" n="P285"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις ξύλινον ἔχων θεὸν καθικέτευε τοῦ ἀγαθοποιῆσαι αὐτόν. Ὡς οὖν ταῦτα ἔπραττε, καὶ οὐδὲν ἧττον ἐν πενίᾳ διῆγε, θυμωθείς, ἄρας αὐτὸν τῶν σκελῶν, ἔρριψεν εἰς τὸ ἔδαφος. Προσκρουσάσης οὖν τῆς κεφαλῆς καὶ αὐτίκα κλασθείσης, χρυσὸς ἔρρευσεν ὅτι πλεῖστος, ὄνπερ δὴ συνάγων ὁ ἄνθρωπος ἐϐόα· « Στρεϐλὸς ὑπάρχεις, ὥς γε οἶμαι, καὶ ἀγνώμων· τιμῶντά σε γὰρ ἥκιστά με ὠφέλησας, τυπτήσαντα δέ σε πολλοῖς καλοῖς ἀμείϐῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐκ ὠφελήσῃ τιμῶν πονηρὸν ἄνθρωπον, τύπτων δὲ αὐτὸν μᾶλλον ὠφέλήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 132 Lf 132.</p>
+          <bibl>Codd. La 132 Lf 132.</bibl>
         </div>
         <div>
           <head>Chambry 61.3</head>
@@ -1723,7 +1722,7 @@
           <pb ed="perry" n="P285"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις ξύλινον θεὸν ἔχων πένης ὢν καθικέτευε τοῦ ἀγαθοποιῆσαι. Ὡς οὖν ταῦτ’ ἔπραττε καὶ μᾶλλον ἐν πενίᾳ διῆγε, θυμωθεὶς, ἐκ τοῦ σκέλους ἄρας αὐτὸν τῷ τοίχῳ προσέκρουσε. Τῆς δὲ κεφαλῆς αὐτοῦ παραχρῆμα κλασθείσης, ἔρρευσε χρυσὸς ἐξ αὐτῆς, ὃν συναγαγὼν ὁ ἄνθρωπος ἐϐόα· « Στρεϐλὸς τυγχάνεις, ὡς οἶμαι, καὶ ἀγνώμων· τιμῶντά σε γὰρ οὐδὲν ὠφέλησάς με· τυπτήσαντα δὲ πολλοῖς καλοῖς ἠμείψω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδὲν ὠφελήσεις σαυτὸν πονηρὸν ἄνδρα τιμῶν, αὐτὸν δὲ τύπτων πλέον ὠφεληθήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Lc 55 Lg 55 Ma 150 Md 20 Mh 13 Mi 55 Mm 20.</p>
+          <bibl>Codd. Lc 55 Lg 55 Ma 150 Md 20 Mh 13 Mi 55 Mm 20.</bibl>
           <p><milestone unit="traduction"/>Un homme avait un dieu de bois, et, comme il était pauvre, il le suppliait de lui faire du bien. Comme il en usait ainsi et que sa misère ne faisait qu’augmenter, il se fâcha, et prenant le dieu par la jambe, il le cogna contre la muraille. La tête du dieu s’étant soudain cassée, il en coula de l’or. L’homme le ramassa et s’écria : « Tu as l’esprit à rebours, à ce que je vois, et tu es un ingrat ; car, quand je t’honorais, tu ne m’as point aidé, et maintenant que je viens de te frapper, tu me réponds en me comblant de bienfaits. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’on ne gagne rien à honorer un méchant homme, et qu’on en tire davantage en le frappant.</p>
         </div>
@@ -1733,7 +1732,7 @@
           <pb ed="perry" n="P285"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπος ξύλινον θεὸν ἔχων καθικέτευεν ἀγαθοποιῆσαι αὐτόν. Ὡς οὖν αὐτὸν ἐν τούτῳ ἐθεράπευε καὶ πλέον ἐν πενίᾳ διῆγε, ἐθυμώθη, καὶ ἄρας αὐτὸν ἐκ τῶν σκελῶν ἔρριψεν αὐτὸν ἐν τῷ ἐδάφει καὶ προσέκρουε τὴν αὐτοῦ κεφαλὴν τοῖς λίθοις. Θλασθείσης δὲ αὐτῆς, παραύτικα ἔρρευσεν ἐξ αὐτῆς πολὺς χρύσος, ὅνπερ συνάγων ὁ ἄνθρωπος ἐϐόα· « Στρεϐλὸς ὑπάρχεις, ὡς οἶμαι, καὶ κακογνώμων· τιμῶντά σε γὰρ οὐδὲν ὠφέλησάς με· τυπτήσαντα δὲ καὶ συνθλάσαντα πολλοῖς καλοῖς ἀμείϐῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐκ ὠφεληθήσῃ τιμῶν πονηρόν ἄνθρωπον, ἀτιμάζων δὲ αὐτὸν καὶ τύπτων μᾶλλον ὠφεληθήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 21.</p>
+          <bibl>Cod. Mk 21.</bibl>
         </div>
         <div>
           <head>Chambry 61.5</head>
@@ -1741,7 +1740,7 @@
           <pb ed="perry" n="P285"/>
           <p><milestone unit="recitprose"/>Ξύλινόν τις εἶχε θεόν. Τούτῳ καθ’ ἑκάστην ἔθυε καὶ ηὔχετο ἀγαθοποιῆσαι αὐτόν. Ὡς δὲ χρόνῳ πολλῷ τοῦτο ποιῶν μᾶλλον ἐπένετο, θυμωθεὶς καὶ τοῦ σκέλους ἄρας χαμαὶ ἀπέκρουσεν. Χρυσὸς δέ, τῆς κεφαλῆς κλασθείσης, ἔρρευσεν, ὃν συναγαγὼν ὁ ἄνθρωπος εἶπεν· « Στρεϐλός τις &lt;εἶ&gt; καὶ ἀγνώμων, ὅς με θύοντα καὶ προσκυνοῦντά σε οὐδὲν ὠφέλεις, ὑϐρίσαντα δέ σε ἀγαθοῖς πολλοῖς ἠμείψω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐδὲν πλέον ὠφελήσῃ πονηρὸν ἄνδρα τιμῶν, ἀτιμάζων δὲ μᾶλλον ὠφεληθήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 97.</p>
+          <bibl>Cod. Ba 97.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-62">
@@ -1750,7 +1749,7 @@
         <pb ed="perry" n="P71"/>
         <p><milestone unit="recitprose"/>Δειλὸς φιλάργυρος λέοντα χρυσοῦν εὑρὼν ἔλεγεν· « Οὐκ οἶδα τίς γενήσομαι ἐν τοῖς παροῦσιν· ἐγὼ ἐκϐέϐλημαι τῶν φρενῶν καὶ τί πράττειν οὐκ ἔχω· μερίζει με φιλοχρηματία καὶ τῆς φύσεως ἡ δειλία. Ποία γὰρ τύχη ἢ ποῖος δαίμων εἰργάσατο χρυσοῦν λέοντα ; Ἡ μὲν γὰρ ἐμὴ ψυχὴ πρὸς τὰ παρόντα ἑαυτῇ πολεμεῖ· ἀγαπᾷ μὲν τὸν χρυσόν, δέδοικε δὲ τοῦ χρυσοῦ τὴν ἐργασίαν· ἅπτεσθαι μὲν ἐλαύνει ὁ πόθος, ἀπέχεσθαι δὲ ὁ τρόπος. Ὢ τύχης διδούσης καὶ μὴ λαμϐάνεσθαι συγχωρούσης· ὢ θησαυρὸς ἡδονὴν οὐκ ἔχων· ὢ χάρις δαίμονος ἄχαρις γενομένη. Τί οὖν ; ποίῳ τρόπῳ χρήσωμαι ; ἐπὶ ποίαν ἔλθω μηχανήν ; ἄπειμι τοὺς οἰκέτας δεῦρο κομίσων λαϐεῖν ὀφείλοντας τῇ πολυπληθεῖ συμμαχίᾳ, κἀγὼ πόρρω ἔσομαι θεατής. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος ἁρμόζει πρός τινα πλούσιον μὴ τολμῶντα προσψαῦσαι καὶ χρήσασθαι τῷ πλούτῳ.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pb 71 Ma 50.</p>
+        <bibl>Codd. Pb 71 Ma 50.</bibl>
         <p><milestone unit="traduction"/>Un avare, qui était peureux, ayant trouvé un lion d’or, disait : « Je ne sais que devenir en cette aventure. L’effroi m’ôte l’esprit, et je ne sais que faire : je suis partagé entre mon amour des richesses et ma couardise naturelle. Car quel est le hasard ou le dieu qui a fait un lion d’or ? Ce qui m’arrive là jette la discorde dans mon âme : elle aime l’or, mais elle craint l’œuvre qu’on a tirée de l’or ; le désir me pousse à la saisir, mon caractère à m’abstenir. Ô fortune qui offre et qui ne permet pas de prendre ! Ô trésor qui ne donne pas de plaisir ! Ô faveur d’un dieu qui devient une défaveur ! Quoi donc ! Comment en userai-je ? À quel expédient recourir ? Je m’en vais et j’amènerai ici mes serviteurs pour prendre le lion avec cette troupe d’alliés, et moi, de loin, je les regarderai faire. »</p>
         <p><milestone unit="epimythiumprose"/>Cette fable s’applique à un riche qui n’ose ni toucher à ses trésors, ni les mettre en usage.</p>
       </div>
@@ -1767,7 +1766,7 @@
           <l><milestone unit="recitvers"/>ἐμειδίασε καὶ πρὸς αὐτὴν ἐλάλει·</l>
           <l><milestone unit="recitvers"/>« Εἴθε τοὺς νεκροὺς ἤσθιες καὶ μὴ ζῶντας. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος οὗτος ἐλέγχει τοὺς πλεονέκτας καὶ ἐν ὑποκρίσει βιοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 25 Cc 16 Ch 19 Ma 154 Mb 14 Md 24 Mh 17 Mi 59 Mm 24.</p>
+          <bibl>Codd. Ca 25 Cc 16 Ch 19 Ma 154 Mb 14 Md 24 Mh 17 Mi 59 Mm 24.</bibl>
         </div>
         <div>
           <head>Chambry 63.2</head>
@@ -1775,7 +1774,7 @@
           <pb ed="perry" n="P288"/>
           <p><milestone unit="recitprose"/>Ἄρκος μεγάλως ἐκαυχᾶτο ὡς φιλάνθρωπος ὤν, ἐπεὶ νεκρὸν σῶμα οὐκ ἐσθίει· πρὸς ὃν ἡ ἀλώπηξ εἶπεν· « Εἴθε νεκροὺς εἷλκες, ἀλλὰ μὴ τοὺ ζῶντας. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ μῦθος πλεονέκτας τοὺς ἐν ὑποκρίσει καὶ κενοδοξίᾳ βιοῦντας ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 13 Bb 8 Bc 11.</p>
+          <bibl>Codd. Ba 13 Bb 8 Bc 11.</bibl>
           <p><milestone unit="traduction"/>Un ours se vantait hautement d’aimer les hommes, par la raison qu’il ne mangeait pas de cadavre. Le renard lui répondit : « Plût aux dieux que tu déchirasses les morts, et non les vivants ! »</p>
           <p><milestone unit="traduction"/>Cette fable démasque les convoiteux qui vivent dans l’hypocrisie et la vaine gloire.</p>
         </div>
@@ -1784,7 +1783,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P288"/>
           <p><milestone unit="recitprose"/>Ἄρκος ἐπὶ φιλανθρωπίᾳ ἐκόμπαζε, προϐαλλομένη τὸ μὴ νεκρὸν σῶμα ἐσθίειν· πρὸς ἣν ἀλώπηξ εἶπε· « Εἴθε νεκροὺς τοὺς ἀνθρώπους εἷλκες, καὶ μὴ ζῶντας. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 3.</p>
+          <bibl>Cod. Bd 3.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-64">
@@ -1793,7 +1792,7 @@
         <pb ed="perry" n="P38"/>
         <p><milestone unit="recitprose"/>Ἀρότης λύσας τὸ ζεῦγος ἐπὶ ποτὸν ἀπῆγε· λύκος δὲ λιμώττων καὶ τροφὴν ζητῶν, ὡς περιέτυχε τῷ ἀρότρῳ, τὸ μὲν πρῶτον τὰς τῶν ταύρων ζεύγλας περιέλειχε, λαθὼν δὲ κατὰ μικρόν, ἐπειδὴ καθῆκε τὸν αὐχένα, ἀνασπᾶν μὴ δυνάμενος, ἐπὶ τὴν ἄρουραν τὸ ἄροτρον ἔσυρεν. Ὁ δὲ ἀρότης ἐπανελθὼν καὶ θεασάμενος αὐτὸν ἔλεγεν· « Εἴθε γὰρ, ὦ κακὴ κεφαλή, καταλιπὼν τὰς ἁρπαγὰς καὶ τὸ ἀδικεῖν ἐπὶ τὸ γεωπονεῖν τραπείης. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ πονηροὶ τῶν ἀνθρώπων, κἂν χρηστότητα ἐπαγγέλλωνται, διὰ τὸν τρόπον οὐ πιστεύονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 39 Pb 38 Pd 24 Pe 6.</p>
+        <bibl>Codd. Pa 39 Pb 38 Pd 24 Pe 6.</bibl>
         <p><milestone unit="traduction"/>Un laboureur ayant dételé son attelage, le menait à l’abreuvoir. Or un loup affamé, qui cherchait pâture, ayant rencontré la charrue, se mit tout d’abord à lécher les côtés intérieurs du joug, puis peu à peu, sans s’en apercevoir, il descendit son cou dedans, et, ne pouvant l’en dégager, il traîna la charrue dans le sillon. Le laboureur revenant l’aperçut et dit : « Ah ! tête scélérate ! si seulement tu renonçais aux rapines et au brigandage pour te mettre au travail de la terre ! »</p>
         <p><milestone unit="traduction"/>Ainsi les méchants ont beau faire profession de vertu : leur caractère empêche de les croire.</p>
       </div>
@@ -1803,7 +1802,7 @@
         <pb ed="perry" n="P40"/>
         <p><milestone unit="recitprose"/>Ἀστρολόγος ἐξιὼν ἑκάστοτε ἑσπέρας ἔθος εἶχε τοὺς ἀστέρας ἐπισκοπῆσαι. Καὶ δή ποτε περιιὼν εἰς τὸ προάστειον καὶ τὸν νοῦν ὅλον ἔχων πρὸς τὸν οὐρανὸν ἔλαθε καταπεσὼν εἰς φρέαρ. Ὀδυρομένου δὲ αὐτοῦ καὶ βοῶντος, παριών τις, ὡς ἤκουσε τῶν στενάγμων, προσελθὼν καὶ μαθὼν τὰ συμϐεϐηκότα, ἔφη πρὸς αὐτόν· « Ὦ οὗτος, σὺ τὰ ἐν οὐρανῷ βλέπειν πειρώμενος τὰ ἐπὶ τῆς γῆς οὐχ ὁρᾷς ; »</p>
         <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις ἐπ’ ἐκείνων τῶν ἀνθρώπων οἳ παραδόξως ἀλαζονεύονται, μηδὲ τὰ κοινὰ τοῖς ἀνθρώποις ἐπιτελεῖν δυνάμενοι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 41 Pb 40 Pf 20 Ph 21 — Ca 19 Me 20 Mf 20 Mj 16.</p>
+        <bibl>Codd. Pa 41 Pb 40 Pf 20 Ph 21 — Ca 19 Me 20 Mf 20 Mj 16.</bibl>
         <p><milestone unit="traduction"/>Un astronome avait l’habitude de sortir tous les soirs pour examiner les astres. Or un jour qu’il errait dans la banlieue, absorbé dans la contemplation du ciel, il tomba par mégarde dans un puits. Comme il se lamentait et criait, un passant entendit ses gémissements, s’approcha, et apprenant ce qui était arrivé, lui dit : « Hé ! l’ami, tu veux voir ce qu’il y a dans le ciel, et tu ne vois pas ce qui est sur la terre ! »</p>
         <p><milestone unit="traduction"/>On pourrait appliquer cette fable aux hommes qui se vantent de faire des merveilles, et qui sont incapables de se conduire dans les circonstances ordinaires de la vie.</p>
       </div>
@@ -1815,7 +1814,7 @@
           <pb ed="perry" n="P44"/>
           <p><milestone unit="recitprose"/>Βάτραχοι λυπούμενοι ἐπὶ τῇ ἑαυτῶν ἀναρχίᾳ πρέσϐεις ἔπεμψαν πρὸς τὸν Δία, δεόμενοι βασιλέα αὐτοῖς παρασχεῖν. Ὁ δὲ συνιδὼν τὴν εὐήθειαν αὐτῶν ξύλον εἰς τὴν λίμνην καθῆκε. Καὶ οἱ βάτραχοι, τὸ μὲν πρῶτον καταπλαγέντες τὸν ψόφον, εἰς τὰ βάθη τῆς λίμνης ἐνέδυσαν. Ὕστερον δὲ, ὡς ἀκίνητον ἦν τὸ ξύλον, ἀναδύντες εἰς τοσοῦτον καταφρονήσεως ἦλθον ὡς ἐπιϐαίνοντες αὐτῷ ἐπικαθέζεσθαι. Ἀναξιοπαθοῦντες δὲ τοιοῦτον ἔχειν βασιλέα, ἧκον ἐκ δευτέρου πρὸς τὸν Δία καὶ τοῦτον παρεκάλουν ἀλλάξαι αὐτοῖς τὸν ἄρχοντα· τὸν γὰρ πρῶτον λίαν εἶναι νωχελῆ. Καὶ ὁ Ζεὺς ἀγανακτήσας καθ’ αὐτῶν ὕδρον αὐτοῖς ἔπεμψεν, ὑφ’ οὗ συλλαμϐανόμενοι κατησθίοντο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἄμεινόν ἐστι νωθεῖς καὶ μὴ πονηροὺς ἔχειν ἄρχοντας ἢ ταρακτικοὺς καὶ κακούργους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 44 Pb 44 Pc 16 Pe 18 Pf 22 Pg 22 Ph 23 Ma 30 Me 31 Mf 29.</p>
+          <bibl>Codd. Pa 44 Pb 44 Pc 16 Pe 18 Pf 22 Pg 22 Ph 23 Ma 30 Me 31 Mf 29.</bibl>
           <p><milestone unit="traduction"/>Les grenouilles, fâchées de l’anarchie où elles vivaient, envoyèrent des députés à Zeus, pour le prier de leur donner un roi. Zeus, voyant leur simplicité, lança un morceau de bois dans le marais. Tout d’abord les grenouilles effrayées par le bruit se plongèrent dans les profondeurs du marais ; puis, comme le bois ne bougeait pas, elles remontèrent et en vinrent à un tel mépris pour le roi qu’elles sautaient sur son dos et s’y accroupissaient. Mortifiées d’avoir un tel roi, elles se tendirent une seconde fois près de Zeus, et lui demandèrent de leur changer le monarque ; car le premier était trop nonchalant. Zeus impatienté leur envoya une hydre qui les prit et les dévora.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il vaut mieux être commandé par des hommes nonchalants, mais sans méchanceté, que par des brouillons et des méchants.</p>
         </div>
@@ -1823,7 +1822,7 @@
           <head>Chambry 66.2</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P44"/>
-          <p><milestone unit="manuscrits"/>Codd. Ca 37 Cb 26 Cc 28 Cd 26 Ce 25 Cf 29 Ch 33 Mc 29 Md 33 Mi 68 Mk 30 Ml 30 Mm 36.</p>
+          <bibl>Codd. Ca 37 Cb 26 Cc 28 Cd 26 Ce 25 Cf 29 Ch 33 Mc 29 Md 33 Mi 68 Mk 30 Ml 30 Mm 36.</bibl>
         </div>
         <div>
           <head>Chambry 66.3</head>
@@ -1831,7 +1830,7 @@
           <pb ed="perry" n="P44"/>
           <p><milestone unit="recitprose"/>Πολέμῳ ἐμφυλίῳ βάτραχοι πολεμοῦντες ἀλλήλοις ᾐτήσαντο τὸν Δία βασιλέα δοθῆναι αὐτοῖς τοῦ δι’ ἐκείνου τὰ αὐτῶν διοικεῖσθαι. Καὶ ξύλου δοκὸν μέσον τῆς λίμνης ῥίψας διετάραξε τὸ ὕδωρ, πάντας δὲ βατράχους σιγὴ κατέσχεν ἐκπλαγέντας. Χρόνῳ δέ τινι τοῦ ξύλου ἀκινήτως ὄντος κατεφρόνησαν ὥστε καὶ ἐπιϐάντες ἐπάνωθεν πολεμεῖν ἀλλήλοις. Καὶ πάλιν ἐδέοντο τοῦ Διὸς τύραννον ἢ στρατηγὸν λαϐεῖν. Ὁ δὲ βδελυχθεὶς αὐτοὺς ὕδρον ἔδωκε διαφθείροντα τοὺς βατράχους.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ φεύγοντες δουλεύειν εἰρηνικοῖς δεσπόταις καὶ ἄκοντες εἰς πονηροὺς ἐνέπεσον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 126.</p>
+          <bibl>Cod. Ba 126.</bibl>
         </div>
         <div>
           <head>Chambry 66.4</head>
@@ -1850,7 +1849,7 @@
           <l><milestone unit="recitvers"/>ἵνα αὐτοῖς ἕτερον ἄνακτα δώσῃ.</l>
           <l><milestone unit="recitvers"/>Ὁ δὲ ἐμμανὴς γενόμενος αὐτίκα</l>
           <l><milestone unit="recitvers"/>ἐπιδέδωκε τὴν ὕδραν τοῖς βατράχοις.</l>
-          <p><milestone unit="manuscrits"/>Cod. Pd 27.</p>
+          <bibl>Cod. Pd 27.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-67">
@@ -1861,7 +1860,7 @@
           <pb ed="perry" n="P69"/>
           <p><milestone unit="recitprose"/>Δύο βάτραχοι ἀλλήλοις ἐγειτνίων. Ἐνέμοντο δὲ ὁ μὲν βαθείαν καὶ τῆς ὁδοῦ πόρρω λίμνην, ὁ δὲ ἐν ὁδῷ μικρὸν ὕδωρ ἔχων. Καὶ δὴ τοῦ ἐν τῇ λίμνῃ παραινοῦντος θατέρῳ μεταϐῆναι πρὸς αὐτόν, ἵνα καὶ ἀμείνονος καὶ ἀσφαλεστέρας διαίτης μεταλάϐῃ, ἐκεῖνος οὐκ ἐπείθετο λέγων δυσαποσπάστως ἔχειν τῆς τοῦ τόπου συνηθείας, ἕως οὗ συνέϐη ἅμαξαν τῇδε παριοῦσαν θλᾶσαι αὐτόν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ τοῖς φαύλοις ἐπιτηδέυμασιν ἐνδιατρίϐοντες φθάνουσιν ἀπολλύμενοι πρὶν ἢ ἐπὶ τὰ καλλίονα τρέπεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 68 Pb 69 Pc 35 Pf 33 Pg 45 Ph 35 Ma 49 Me 47 Mf 42 — La 88 Lb 40 Le 40 Lf 88 Md 141 Mg 55 Mi 115 Mj 46 Ml 51 Mm 60.</p>
+          <bibl>Codd. Pa 68 Pb 69 Pc 35 Pf 33 Pg 45 Ph 35 Ma 49 Me 47 Mf 42 — La 88 Lb 40 Le 40 Lf 88 Md 141 Mg 55 Mi 115 Mj 46 Ml 51 Mm 60.</bibl>
           <p><milestone unit="traduction"/>Deux grenouilles voisinaient. Elles habitaient, l’une un étang profond, éloigné de la route, l’autre une petite mare sur la route. Celle de l’étang conseillait à l’autre de venir habiter près d’elle : elle y jouirait d’une vie meilleure et plus sûre. Mais celle-ci ne se laissa point persuader ; il lui serait pénible, disait-elle, de s’arracher à un séjour où elle avait ses habitudes ; si bien qu’un jour un chariot qui passait par là l’écrasa.</p>
           <p><milestone unit="traduction"/>Il en est ainsi des hommes : ceux qui pratiquent de vils métiers meurent avant de se tourner vers des emplois plus honorables.</p>
         </div>
@@ -1871,7 +1870,7 @@
           <pb ed="perry" n="P69"/>
           <p><milestone unit="recitprose"/>Δύο βάτραχοι ἀλλήλοις ἐγειτνίων καὶ ἐνέμοντο ὁ μὲν εἰς βαθείᾳ λίμνῃ καὶ τῆς ὁδοῦ πόρρω, ὁ δὲ ἕτερος μικρὸν ἔχων ὕδωρ καὶ πλησίον ὁδοῦ. Ὁ μὲν οὖν ἐν τῇ βαθείᾳ λίμνῃ οἰκῶν βάτραχος παρῄνει τὸν ἕτερον μεταϐῆναι πρὸς αὐτόν, ἵνα μετ’ αὐτοῦ διάγῃ καὶ ἀσφαλεστέρας διαίτης μεταλαμϐάνῃ. Ὁ δὲ οὐκ ἐπείθετο λέγων δυσαποσπάστως ἔχειν τῆς τοῦ τόπου συνηθείας ἕως [ἄν] &lt;συνέϐη&gt; ἅμαξαν παριοῦσαν συνθλᾶσαι αὐτόν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ οἱ ἐν τοῖς φαύλοις ἐπιτηδεύμασιν ἐνδιατρίϐοντες φθάνουσιν ἀπολλύμενοι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 36.</p>
+          <bibl>Cod. Pe 36.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-68">
@@ -1882,7 +1881,7 @@
           <pb ed="perry" n="P43"/>
           <p><milestone unit="recitprose"/>Βάτραχοι δύο, ξηρανθείσης αὐτῶν τῆς λίμνης, περιῄεσαν ζητοῦντες ποῦ καταμεῖναι. Ὡς δὲ ἐγένοντο κατά τι φρέαρ, ὁ ἕτερος συνεϐούλευεν ἀμελητὶ ἅλλεσθαι. Ὁ δὲ ἕτερος ἔλεγεν· « Ἐὰν οὖν καὶ τὸ ἐνθάδε ὕδωρ ξηρανθῇ, πῶς δυνησόμεθα ἀναϐῆναι ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος ἡμᾶς διδάσκει μὴ ἀπερισκέπτως προσέρχεσθαι τοῖς πράγμασιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 43 Pb 43 Pc 15 Pd 26 Pe 17 Pf 21 Pg 21 Ph 22 Ma 29 Me 30 Mf 28.</p>
+          <bibl>Codd. Pa 43 Pb 43 Pc 15 Pd 26 Pe 17 Pf 21 Pg 21 Ph 22 Ma 29 Me 30 Mf 28.</bibl>
         </div>
         <div>
           <head>Chambry 68.2</head>
@@ -1890,7 +1889,7 @@
           <pb ed="perry" n="P43"/>
           <p><milestone unit="recitprose"/>Βάτραχοι δύο ἐνέμοντο ἐν λίμνῃ. Ἐν ἡμέραις δὲ τοῦ θέρους ἐξηράνθη ἡ λίμνη καὶ καταλείψαντες ἐκείνην, ἄλλην ἐπεζήτουν. Παραχρῆμα οὖν ἐνέτυχον φρέατι βαθεῖ. Εἶπε δὲ ὁ ἕτερος τῷ ἑτέρῳ· « Συγκατέλθωμεν ἐνταῦθα, ὦ φίλε. » Ὑπολαϐὼν δὲ ὁ ἕτερος ἀντεῖπεν· « Ἐὰν οὖν καὶ τὸ ἐνθάδε ὕδωρ ξηρανθῇ, πῶς δυνησόμεθα ἀνελθεῖν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ ἀπερισκέπτως προσέρχεσθαι τοῖς πράγμασι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 38 Cb 27 Cd 27 Ce 26 Cf 30 Ch 34 Mc 30 Mk 31.</p>
+          <bibl>Codd. Ca 38 Cb 27 Cd 27 Ce 26 Cf 30 Ch 34 Mc 30 Mk 31.</bibl>
         </div>
         <div>
           <head>Chambry 68.3</head>
@@ -1898,7 +1897,7 @@
           <pb ed="perry" n="P43"/>
           <p><milestone unit="recitprose"/>Βάτραχοι δύο ἐν λίμνῃ ἐνέμοντο. Θέρους δὲ ξηρανθείσης τῆς λίμνης, ἐκείνην καταλιπόντες ἐπεζήτουν ἑτέραν. Καὶ δὴ βαθεῖ περιέτυχον φρέατι, ὅπερ ἰδὼν ἅτερος θατέρῳ φησί· « Συγκατέλθωμεν, ὦ οὗτος, εἰς τόδε τὸ φρέαρ. » Ὁ δὲ ὑπολαϐὼν εἶπεν· « Ἂν οὖν καὶ τὸ ἐνθάδε ὕδωρ ξηρανθῇ, πῶς ἀναϐησόμεθα ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ ἀπερισκέπτως προσιέναι τοῖς πράγμασιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 19 Lb 23 Lc 10 Le 23 Lf 19 Lg 10 Mg 27 Mj 26 Ml 29.</p>
+          <bibl>Codd. La 19 Lb 23 Lc 10 Le 23 Lf 19 Lg 10 Mg 27 Mj 26 Ml 29.</bibl>
           <p><milestone unit="traduction"/>Deux grenouilles habitaient un étang ; mais l’été l’ayant desséché, elles le quittèrent pour en chercher un autre. Elles rencontrèrent alors un puits profond. En le voyant, l’une dit à l’autre : « Amie, descendons ensemble dans ce puits. — Mais, répondit l’autre, si l’eau de ce puits vient à se dessécher aussi, comment remonterons-nous ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas s’engager à la légère dans les affaires.</p>
         </div>
@@ -1908,7 +1907,7 @@
           <pb ed="perry" n="P43"/>
           <p><milestone unit="recitprose"/>Βάτραχοι δύο, ξηρανθείσης τῆς λίμνης ἐν ᾗ κατῴκουν, περιῄεσαν ζητοῦντες ποῦ καταμεῖναι. Καὶ ἐλθόντες εἰς φρέαρ βαθὺ καὶ κύψαντες κάτω καὶ ἰδόντες τὸ ὕδωρ, ὁ μὲν εἷς συνεϐούλευεν ἵνα πηδήσωσι παρευθὺς κάτω. Ὁ δὲ ἕτερος εἶπεν· « Εἰ δὲ καὶ τοῦτο ξηρανθῇ, πῶς δυνησόμεθα ἀναϐῆναι ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ἄνευ συμϐουλῆς μὴ ποιεῖν τι.</p>
-          <p><milestone unit="manuscrits"/>Cod. T 3.</p>
+          <bibl>Cod. T 3.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-69">
@@ -1919,7 +1918,7 @@
           <pb ed="perry" n="P289"/>
           <p><milestone unit="recitprose"/>Ὄντος ποτὲ βατράχου ἐν τῇ λίμνῃ καὶ τοῖς ζῴοις πᾶσιν ἀναϐοήσαντος· « Ἐγὼ ἰατρός εἰμι φαρμάκων ἐπιστήμων, » ἀλώπηξ ἀκούσασα ἔφη· « Πῶς σὺ ἄλλους σώσεις, σαυτὸν χωλὸν ὄντα μὴ θεραπεύων ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ παιδείας ἀμύητος ὑπάρχων, πῶς ἄλλους παιδεῦσαι δυνήσεται ;</p>
-          <p><milestone unit="manuscrits"/>Cod. Ca 154.</p>
+          <bibl>Cod. Ca 154.</bibl>
           <p><milestone unit="traduction"/>Un jour une grenouille dans un marais criait à tous les animaux : « Je suis médecin et je connais les remèdes. » Un renard l’ayant entendue s’écria : « Comment sauveras-tu les autres, toi qui boites et ne te guéris pas toi-même ! »</p>
           <p><milestone unit="traduction"/>Cette fable montre que, si l’on n’a pas été initié à la science, on ne saurait instruire les autres.</p>
         </div>
@@ -1933,7 +1932,7 @@
           <l><milestone unit="recitvers"/>« Καὶ πῶς δέ, φησὶν ἀλώπηξ, ἄλλους σῴζεις,</l>
           <l><milestone unit="recitvers"/>σαυτὸν δὲ χωλὸν ὄντα οὐ θεραπεύεις ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ παιδείας ἀμύητος ὑπάρχων, πῶς ἄλλους ἀνθρώπους παιδεύσει ;</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 103 Cb 83 Cf 97 Cg 28 Mb 21 Mc 82.</p>
+          <bibl>Codd. Ch 103 Cb 83 Cf 97 Cg 28 Mb 21 Mc 82.</bibl>
         </div>
         <div>
           <head>Chambry 69.3</head>
@@ -1942,7 +1941,7 @@
           <p/>
           <p><milestone unit="recitprose"/>Ὁ τῷ πηλῷ συζῶν βάτραχος εἰς γῆν ἐξελθὼν ἔλεγε πᾶσι τοῖς ζῴοις· « Ἰατρός εἰμι φαρμάκων  ἐπιστήμων, οἷος οὐδὲ ὁ τῶν θεῶν ἰατρὸς Παιών. – Καὶ πῶς, &lt;εἶπεν&gt; ἀλώπηξ, ἄλλους ἰάσῃ, ὃς ἑαυτὸν χλωρὸν ὄντα οὐκ ἰατρεύεις ; »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] ὁ παιδείας ἀμύητος ὑπάρχων πῶς ἑτέρους παιδεύσει καὶ διορθώσεται ;</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 113.</p>
+          <bibl>Cod. Ba 113.</bibl>
         </div>
         <div>
           <head>Chambry 69.4</head>
@@ -1950,7 +1949,7 @@
           <pb ed="perry" n="P289"/>
           <p><milestone unit="recitprose"/>Ὁ τῷ πηλῷ κρυπτόμενος σκώληξ εἰς γῆν ἐξελθὼν ἔλεγε πᾶσι τοῖς ζῴοις· « Ἰατρός εἰμι φαρμάκων ἐπιστήμων, οἷός ἐστιν ὁ τῶν θεῶν ἰατρός Παιών. – Καὶ πῶς, εἶπεν ἀλώπηξ, ἄλλους ἰώμενος σαυτὸν χωλὸν ὄντα οὐκ ἰάσω ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, ἐὰν μὴ πρόχειρος ᾖ ἡ πεῖρα, πᾶς λόγος ἀργὸς ὑπάρχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 139 Lc 43 Lg 43 Md 92 Mg 133 Mh 83 Mi 8 Mm 110.</p>
+          <bibl>Codd. La 139 Lc 43 Lg 43 Md 92 Mg 133 Mh 83 Mi 8 Mm 110.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-70">
@@ -1961,7 +1960,7 @@
           <pb ed="perry" n="P45"/>
           <p><milestone unit="recitprose"/>Βόες ἅμαξαν εἷλκον. Τοῦ δὲ ἄξονος τρίζοντος, ἐπιστραφέντες ἔφασαν οὕτως πρὸς αὐτόν· « Ὦ οὗτος, ἡμῶν τὸ ὅλον βάρος φερόντων, σὺ κέκραγας ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἔνιοι, μοχθούντων ἑτέρων, αὐτοὶ προσποιοῦνται κάμνειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 45 Pb 45 Pc 17 Pe 19 Pg 23 Ma 31 Mb 17 — Ca 39 Cb 28 Cd 28 Ce 29 Cf 33 Ch 35 Mc 31 Mj 28 Mk 32.</p>
+          <bibl>Codd. Pa 45 Pb 45 Pc 17 Pe 19 Pg 23 Ma 31 Mb 17 — Ca 39 Cb 28 Cd 28 Ce 29 Cf 33 Ch 35 Mc 31 Mj 28 Mk 32.</bibl>
           <p><milestone unit="traduction"/>Des bœufs traînaient un chariot. Comme l’essieu grinçait, ils se retournèrent et lui dirent : « Hé ! l’ami, c’est nous qui portons toute la charge, et c’est toi qui cries ! »</p>
           <p><milestone unit="traduction"/>Ainsi l’on voit des gens qui affectent d’être fatigués, quand ce sont d’autres qui ont la peine.</p>
         </div>
@@ -1972,14 +1971,14 @@
           <p/>
           <p><milestone unit="recitprose"/>Ἐν πόλει μεγίστην ταῦροι ἅμαξαν εἷλκον· ἡ δὲ ἔτριζεν ἰσχυρῶς. Θυμωθεὶς οὖν ὁ βοηλάτης εἶπεν αὐτῇ· « Ὦ κακὸν κτῆμα, τί κράζεις, βίᾳ τῶν ἑλκόντων σε βοῶν σιωπώντων ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τινὲς ἐπ’ ἀλλοτρίοις πόνοις καὶ πλούτῳ καυχώμενοι μέγα φρονοῦσιν ὡς αὐτοὶ χειμασθέντες ἐν αὐτοῖς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 32 Bb 21.</p>
+          <bibl>Codd. Ba 32 Bb 21.</bibl>
         </div>
         <div>
           <head>Chambry 70.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P45"/>
           <p><milestone unit="recitprose"/>Ταῦροι δύο ἅμαξαν ἕλκοντες ἐπὶ πόλιν τινὰ φόρτον ἔφερον. Τῆς οὖν ἁμάξης τρυζούσης ἀεὶ φερομένης, θυμωθεὶς ὁ τὰς βοῦς ἐλαύνων ἔφη· « Ὦ κακὸν κτῆμα, τί κράζεις, τῶν βίᾳ σε ἑλκόντων βοῶν σιωπώντων ; »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 14.</p>
+          <bibl>Cod. Bd 14.</bibl>
         </div>
         <div>
           <head>Chambry 70.4</head>
@@ -1992,7 +1991,7 @@
           <l><milestone unit="recitvers"/>ἵνα τί οὕτω σὺ κατακράζεις, βίᾳ</l>
           <l><milestone unit="recitvers"/>τῶν καθελκόντων σε βοῶν σιωπώντων ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι τινὲς ἐπ’ ἀλλοτρίοις πόνοις καυχώμενοι δοκοῦσι μέγα φρονεῖν ἐπ’ αὐτοῖς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Mb 203 Pd 28.</p>
+          <bibl>Codd. Mb 203 Pd 28.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-71">
@@ -2003,7 +2002,7 @@
           <pb ed="perry" n="P372"/>
           <p><milestone unit="recitprose"/>Ἐνέμοντο μετ’ ἀλλήλων τρεῖς ἀεὶ βόες. Λέων δὲ τούτους φαγεῖν θέλων διὰ τὴν αὐτῶν ὁμόνοιαν οὐκ ἠδύνατο· ὑπούλοις δὲ λόγοις διαϐαλὼν ἐχώρισεν ἀπ’ ἀλλήλων, καὶ τότε ἕνα ἕκαστον αὐτῶν μεμονωμένους εὑρὼν κατεθοινήσατο.</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι], εἰ θέλεις μάλιστα ζῆν ἀκινδύνως, τοῖς μὲν ἐχθροῖς ἀπίστει, τοῖς δὲ φίλοις πίστευε καὶ συντήρει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 36 Bb 24 Mg 62.</p>
+          <bibl>Codd. Ba 36 Bb 24 Mg 62.</bibl>
           <p><milestone unit="traduction"/>Trois bœufs paissaient toujours ensemble. Un lion voulait les dévorer ; mais leur union l’en empêchait. Alors il les brouilla par des discours perfides et les sépara les uns des autres ; dès lors, les trouvant isolés, il les dévora l’un après l’autre.</p>
           <p><milestone unit="traduction"/>Si tu désires vraiment vivre en sûreté, défie-toi de tes ennemis, mais aie confiance en tes amis, et conserve-les.</p>
         </div>
@@ -2012,7 +2011,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P372"/>
           <p><milestone unit="recitprose"/>Ἐνέμοντο τρεῖς μετ’ ἀλλήλων βόες. Λέων δὲ τούτους φαγεῖν θέλων διὰ τὴν ὁμόνοιαν ἐδειλία· αἰμύλοις δὲ λόγοις τούτους διαχωρίσας μεμονωμένους τούτων ἕνα καθ’ ἕνα εὑρὼν ἀδεῶς ἤσθιεν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 28.</p>
+          <bibl>Cod. Bc 28.</bibl>
         </div>
         <div>
           <head>Chambry 71.3</head>
@@ -2026,7 +2025,7 @@
           <l><milestone unit="recitvers"/>καὶ τότ’ ἕκαστον εὑρὼν μεμονωμένον</l>
           <l><milestone unit="recitvers"/>κατεσπάραξεν οἷς τρόποις ἠϐουλήθη.</l>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] ὁ θέλων ζῆν ἀκινδύνως τοῖς μὲν ἐχθροῖς ἀπιστείτω, πιστευέτω δὲ τοῖς φίλοις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 20.</p>
+          <bibl>Cod. Mb 20.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-72">
@@ -2041,7 +2040,7 @@
         <l><milestone unit="recitvers"/>Αὐτὸς δ’ ἐπιστὰς εἶπε· « Τῶν τρόχων ἅπτου</l>
         <l><milestone unit="recitvers"/>καὶ τοὺς βόας κέντριζε, τοῖς θεοῖς δ’ εὔχου,</l>
         <l><milestone unit="recitvers"/>ὅταν τι ποιῇς καὐτὸς, ἢ μάτην εὔξῃ. »</l>
-        <p><milestone unit="manuscrits"/>Cod. Mb 19.</p>
+        <bibl>Cod. Mb 19.</bibl>
         <p><milestone unit="traduction"/>Un bouvier menait un chariot vers un village. Le chariot étant tombé dans un ravin profond, au lieu d’aider à l’en sortir, le bouvier restait là sans rien faire, invoquant parmi tous les dieux le seul Héraclès, qu’il honorait particulièrement. Héraclès lui apparut et lui dit : « Mets la main aux roues, aiguillonne tes bœufs et n’invoque les dieux qu’en faisant toi-même un effort ; autrement tu les invoqueras en vain. »</p>
       </div>
       <div type="poem" xml:id="chambry-73">
@@ -2052,7 +2051,7 @@
           <pb ed="perry" n="P46"/>
           <p><milestone unit="recitprose"/>Βορέας καὶ Ἥλιος περὶ δυνάμεως ἤριζον. Ἔδοξε δὲ αὐτοῖς ἐκείνῳ τὴν νίκην ἀπονεῖμαι ὃς ἂν αὐτῶν ἄνθρωπον ὁδοιπόρον ἀποδύσῃ. Καὶ ὁ Βορέας ἀρξάμενος σφοδρὸς ἦν· τοῦ δὲ ἀνθρώπου ἀντεχομένου τῆς ἐσθῆτος, μᾶλλον ἐπέκειτο. Ὁ δὲ ὑπὸ τοῦ ψύχους καταπονούμενος ἔτι μᾶλλον, καὶ περιττοτέραν ἐσθῆτα προσελάμϐανεν, ἕως ἀποκαμὼν &lt;ὁ Βορέας&gt; τῷ Ἡλίῳ αὐτὸν παρέδωκε. Κἀκεῖνος τὸ μὲν πρῶτον μετρίως προσέλαμψε· τοῦ δὲ ἀνθρώπου τὰ περισσὰ τῶν ἱματίων ἀποτιθεμένου, σφοδρότερον τὸ καῦμα ἐπέτεινεν, ἕως οὗ πρὸς τὴν ἀλέαν ἀντέχειν μὴ δυνάμενος, ἀποδυσάμενος, ποταμοῦ παραρρέοντος ἐπὶ λουτρὸν ἀπῄει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλάκις τὸ πείθειν τοῦ βιάζεσθαι ἀνυτικώτερόν ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 46 Pb 46 Pc 18 Pe 20 Pg 24.</p>
+          <bibl>Codd. Pa 46 Pb 46 Pc 18 Pe 20 Pg 24.</bibl>
           <p><milestone unit="traduction"/>Borée et le Soleil contestaient de leur force. Ils décidèrent d’attribuer la palme à celui d’entre eux qui dépouillerait un voyageur de ses vêtements. Borée commença ; il souffla avec violence. Comme l’homme serrait sur lui son vêtement, il l’assaillit avec plus de force. Mais l’homme incommodé encore davantage par le froid, prit un vêtement de plus, si bien que, rebuté, Borée le livra au Soleil. Celui-ci tout d’abord luisit modérément ; puis, l’homme ayant ôté son vêtement supplémentaire, le Soleil darda des rayons plus ardents, jusqu’à ce que l’homme, ne pouvant plus résister à la chaleur, ôta ses habits et s’en alla prendre un bain dans la rivière voisine.</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent la persuasion est plus efficace que la violence.</p>
         </div>
@@ -2062,14 +2061,14 @@
           <pb ed="perry" n="P46"/>
           <p><milestone unit="recitprose"/>Βορρᾶς χειμέριος ἔριν ἐποιήσατο πρὸς τὸν Ἥλιον, ποῖος ἐξ αὐτῶν ὁδοιποροῦντός τινος τὸ ἱμάτιον ἀποδύσει. Βορρᾶς δὲ πρῶτος βίᾳ τὸ ἱμάτιον φυσῶν ἤλπιζε συλήσειν. Ὁ δὲ ῥιγῶν καὶ κρατήσας ἀμφοτέραις χερσὶ τὸ ἱμάτιον, ἔϐαλε τὴν κεφαλὴν ἔν τινι πέτρας ὀπῇ, τὴν ψόαν ἔξω ἐάσας. Ὁ δὲ Ἥλιος τὸ μὲν πρῶτον χλιάνας αὐτὸν τοῦ ψύχους, ἔπειτα τὴν φλόγα προσαγαγὼν ἔπεισεν ἱδρώσαντα τὸ ἱμάτιον ἀποδύσασθαι· οὗτως οὖν ἡττήθη ὁ Βορρᾶς.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πραοτέρως ἐπιχειρῶν τινι πράγματι μᾶλλον ἀνύσεις πείθων ἢ βιαζόμενος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 17 Mg 28.</p>
+          <bibl>Codd. Ba 17 Mg 28.</bibl>
         </div>
         <div>
           <head>Chambry 73.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P46"/>
           <p><milestone unit="recitprose"/>Ἐν χειμῶνι Βορρᾶς πρὸς τὸν Ἥλιον ἰσχύος ἕνεκα ἔριν ἐποιεῖτο. Καὶ σῆμα ὂν τῆς ἰσχύος τινὸς ὁδοιποροῦντος τὴν τοῦ ἱματίου ἀφαίρεσιν ἐποιήσαντο. Βορρᾶς μὲν οὖν πρῶτος ἐναντίον τοῦ ἀνέμου μέγα φυσῶν ἐπειρᾶτο ἐκ τοῦ ἀνθρώπου βίᾳ τὸ ἱμάτιον ἀπορρίψας γυμνὸν ἐκεῖνον καταλιπεῖν. Ὁ δὲ ὑπὸ τοῦ κρύους πανταχόθεν περισυνάγων αὐτὸ καὶ ἰσχυρῶς περιστέλλων ἔκρυψεν, εἰσελθὼν ἔν τινι πέτρας ὀπῇ, τὴν ἑαυτοῦ κεφαλήν, τὴν τοῦ ἀνέμου φεύγων σφοδρότητα· τὸ &lt;δὲ&gt; λοιπὸν σῶμα ἔξω ἀφείς, ἐκκρύψαι αὐτὸ οὐκ ἠδύνατο. Οὕτω δὲ κείμενον ὁ Ἥλιος πρῶτον ὑπὸ τοῦ ψύχους νεκρωθέντα ἀπέθαλπε· ἔπειτα κατὰ μικρὸν τοῦτον περιθερμάνας ἱδρῶσαι πεποίηκε· οὗ γεγονότος, τὸ ἱμάτιον ἀπεκδυσάμενος νικήτην τὸν Ἥλιον ἔδειξεν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 5.</p>
+          <bibl>Cod. Bd 5.</bibl>
         </div>
         <div>
           <head>Chambry 73.4</head>
@@ -2086,7 +2085,7 @@
           <l><milestone unit="recitvers"/>πέπεικεν εὐθὺς ἐκδῦσαι τοὺς χιτῶνας.</l>
           <l><milestone unit="recitvers"/>Τότε ὁ Βορρᾶς αἰσχυνθεὶς ἀπεστράφη.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις τὸ πείθειν τοῦ βιάζεσθαι ἀνυτικώτερόν ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pd 29.</p>
+          <bibl>Cod. Pd 29.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-74">
@@ -2097,7 +2096,7 @@
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βουκόλος βόσκων ἀγέλην ταύρων ἀπώλεσε μόσχον. Περιελθὼν δὲ καὶ μὴ εὑρὼν ηὔξατο τῷ Διί, ἐάν τὸν κλέπτην εὕρῃ, ἔριφον αὐτῷ θῦσαι. Ἐλθὼν δὲ εἴς τινα δρυμῶνα καὶ θεασάμενος λέοντα κατεσθίοντα τὸν μόσχον, περίφοϐος γενόμενος, ἐπάρας τὰς χεῖρας εἰς τὸν οὐρανόν, εἶπε· « Ζεῦ δέσποτα, πάλαι μέν σοι ηὐξάμην ἔριφον θῦσαι, ἂν τὸν κλέπτην εὕρω, νῦν δὲ ταῦρόν σοι θύσω, ἐὰν τὰς τοῦ κλέπτου χεῖρας ἐκφύγω. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος λεχθείη ἂν ἐπ’ ἀνδρῶν δυστυχούντων, οἵτινες ἀπορούμενοι εὔχονται εὑρεῖν, εὑρόντες δὲ ζητοῦσιν ἀποφυγεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 49 Pb 49 Pc 20 Pe 23 Pg 27 Ma 34.</p>
+          <bibl>Codd. Pa 49 Pb 49 Pc 20 Pe 23 Pg 27 Ma 34.</bibl>
           <p><milestone unit="traduction"/>Un bouvier, qui paissait un troupeau de bœufs, perdit un veau. Il fit le tour du voisinage, sans le retrouver. Alors il promit à Zeus, s’il découvrait le voleur, de lui sacrifier un chevreau. Or, étant entré dans un bois, il vit un lion qui dévorait le veau ; épouvanté, il leva les mains au ciel en s’écriant : « Ô souverain Zeus, naguère j’ai fait vœu de t’immoler un chevreau, si je trouvais le voleur ; à présent je t’immolerai un taureau, si j’échappe aux griffes du voleur. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à ceux qui sont en butte à quelque disgrâce : dans leur embarras, ils souhaitent d’en trouver le remède, et, quand ils l’ont trouvé, ils cherchent à s’y soustraire.</p>
         </div>
@@ -2107,7 +2106,7 @@
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βουκόλος ἀγέλην ταύρων βόσκων ἀπώλεσε μόσχον. Περιελθὼν δὲ πᾶσαν τὴν ἔρημον διέτριϐεν ἐρευνῶν. Ὡς δὲ οὐδὲν εὑρεῖν ἠδυνήθη, ηὔξατο τῷ Διὶ οὕτως, ὅτι, « ἐὰν τὸν κλέπτην τὸν λαϐόντα τὸν μόσχον ὑποδείξῃς μοι, ἔριφόν σοι εἰς θυσίαν προσάξω. » Καὶ δὴ διερχομένου αὐτοῦ εἴς τινα δρυμόν, εὑρίσκει λέοντα κατεσθίοντα τοῦτον τὸν μόσχον. Ἔμφοϐος οὖν γενόμενος καὶ μεγάλως δειλιάσας, ἐπάρας τὰς χεῖρας αὐτοῦ εἰς τὸν οὐρανόν, εἶπεν· « Ὦ δέσποτα Ζεῦ, ἐπηγγειλάμην σοι ἔριφον δοῦναι, ἐὰν τὸν κλέπτην εὕρω, νυνὶ δὲ ταῦρόν σοι θύσω, ἐὰν τὰς χεῖρας τοῦ κλέπτου ἐκφύγω.</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος λεχθείη ἂν ἐπ’ ἀνδρῶν δυστυχούντων, οἵτινες ἀπορούμενοι εὔχονται εὑρεῖν, εὑρόντες δὲ ζητοῦσιν ἀποφυγεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 41 Cb 30 Cc 30 Cd 30 Ce 28 Cf 32 Mc 33 Md 35 Mh 31 Mi 70 Mk 34 Ml 32 Mm 38 Lf 135.</p>
+          <bibl>Codd. Ca 41 Cb 30 Cc 30 Cd 30 Ce 28 Cf 32 Mc 33 Md 35 Mh 31 Mi 70 Mk 34 Ml 32 Mm 38 Lf 135.</bibl>
         </div>
         <div>
           <head>Chambry 74.3</head>
@@ -2115,7 +2114,7 @@
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βουκόλος ἀγέλην ταύρων βόσκων ἀπώλεσε μόσχον. Περιελθὼν δὲ πᾶσαν τὴν ἔρημον διέτριϐεν ἐρευνῶν. Ὡς δὲ οὐδὲν εὑρεῖν ἠδυνήθη, ηὔξατο τῷ Διί, ἂν τὸν λαϐόντα μόσχον κλέπτην ὑποδείξῃ, ἔριφον εἰς θυσίαν προσάξειν. Καὶ δὴ ἐρχόμενος εἴς τινα δρυμῶνα εὑρίσκει λέοντα κατεσθίοντα τὸν μόσχον. Ἔμφοϐος οὖν γενόμενος καὶ μέγα δειλιάσας, ἐπάρας τὰς χεῖρας αὐτοῦ εἰς τὸν οὐρανόν, εἶπεν· « Ὦ δέσποτα Ζεῦ, ἐπηγγειλάμην σοι ἔριφον δώσειν, ἒν τὸν κλέπτην εὕρω· νῦν &lt;δὲ&gt; ταῦρον σοι θύσειν ὑπισχνοῦμαι, ἐὰν τούτου τὰς χεῖρας ἐκφύγω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας δυστυχεῖς οἵτινες ἀποροῦντες μὲν εὔχονται εὑρεῖν, εὑρόντες δὲ ζητοῦσιν ἀποφυγεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. La 135.</p>
+          <bibl>Cod. La 135.</bibl>
         </div>
         <div>
           <head>Chambry 74.4</head>
@@ -2123,7 +2122,7 @@
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βοηλάτης ταῦρον ἀπώλεσεν· ηὔξατο δὲ τῷ θεῷ, εἰ τὸν κλέπτην εὕροι, ταῦρον ἐπιθύσειν. Εὗρε δὲ ἐξαίφνης τοῦτον ὑπὸ λέοντος ἐσθιόμενον· εἶπεν δὲ τῷ θεῷ ὅτι « καὶ ἕτερον βοῦν σοι ἐπιθύσω, εἰ τὸν κλέπτην ἐκφύγω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἀϐούλως οὐ δεῖ εὐχὴν τῷ θεῷ συντάσσεσθαι διὰ τὴν πρὸς ὥραν συμϐαίνουσαν λύπην.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 16 Bb 11.</p>
+          <bibl>Codd. Ba 16 Bb 11.</bibl>
         </div>
         <div>
           <head>Chambry 74.5</head>
@@ -2131,14 +2130,14 @@
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βουθρέμμων τις ἐν ὄρει ταῦρον ἀπώλεσεν. Ταῦρον οὖν ἐπιθύσειν ηὔχετο τῷ θεῷ, εἰ τῷ κλέπτῃ ἐντύχοι. Ἐξαίφνης οὖν εὗρε τοῦτον ὑπὸ λέοντος ἐσθιόμενον. Στενάξας οὖν ἔφη· « Βοῦν σοι καὶ ταῦρον, θεέ, προσενέγκω, εἰ τὰς χεῖρας τοῦ κλέπτου βοηθήσεις μοι ἐκφυγεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἀϐούλως οὐδὲ εὐχὴν ποιεῖσθαι χρή· ἄδηλον γὰρ τὸ συμϐησόμενον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 14.</p>
+          <bibl>Cod. Bc 14.</bibl>
         </div>
         <div>
           <head>Chambry 74.6</head>
           <head type="sub">Aliter — Βουκόλος καὶ λέων.</head>
           <pb ed="perry" n="P49"/>
           <p><milestone unit="recitprose"/>Βουκόλος ταῦρον ἀπολέσας ηὔξατο τῷ Ἑρμῇ, εἰ τὸν κλέψαντα εὕροι, ἕτερον ταῦρον αὐτῷ θύσειν. Αἴφνης δὲ ἰδὼν λέοντα τοῦτον ἐσθίοντα εἶπεν· « Καὶ ἕτερόν σοι, ὦ Ἑρμῆ, βοῦν θύσω, εἰ τὸν κλέπτην ἐκφυγεῖν δυνηθείην. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 4.</p>
+          <bibl>Cod. Bd 4.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-75">
@@ -2149,7 +2148,7 @@
           <pb ed="perry" n="P48"/>
           <p><milestone unit="recitprose"/>Βωταλὶς ἀπό τινος θυρίδος κρεμαμένη νυκτὸς ᾖδε. Νυκτερὶς δὲ ἐξήκουσε αὐτῆς τὴν φωνὴν καὶ προσελθοῦσα ἐπυνθάνετο ἀπ’ αὐτῆς τὴν αἰτίαν δι’ ἣν ἡμέρας μὲν ἡσυχάζει, νύκτωρ δὲ ᾄδει. Τῆς δὲ λεγούσης ὡς οὐ μάτην τοῦτο πράττει· ἡμέρας γάρ ποτε ᾄδουσα συνελήφθη, διὸ ἀπ’ ἐκείνου ἐσωφρονίσθη, ἡ νυκτερὶς εἶπεν· « Ἀλλ’ οὐ νῦν σε δεῖ φυλάττεσθαι, ὅτε οὐδὲν ὄφελός ἐστι, τότε δὲ πρὶν ἢ συλληφθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἐπὶ τοῖς ἀτυχήμασι μετάνοια ἀνωφελὴς καθέστηκεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 48 Pb 48 Pe 22 Pf 23 Pg 26 Ma 33 Me 32 Mf 30.</p>
+          <bibl>Codd. Pa 48 Pb 48 Pe 22 Pf 23 Pg 26 Ma 33 Me 32 Mf 30.</bibl>
           <p><milestone unit="traduction"/>Un serin, qui était dans une cage accrochée à une fenêtre, chantait pendant la nuit. Une chauve-souris entendit de loin sa voix, et, s’approchant de lui, lui demanda pour quelle raison il se taisait le jour et chantait la nuit. « Ce n’est pas sans motif, dit-il, que j’en use ainsi ; car c’est de jour que je chantais, lorsque j’ai été pris ; aussi depuis ce temps, je suis devenu prudent. » La chauve-souris reprit : « Mais ce n’est pas à présent qu’il faut te mettre sur tes gardes, alors que c’est inutile : c’est avant d’être pris que tu devais le faire. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que, quand le malheur est venu, le regret ne sert à rien.</p>
         </div>
@@ -2159,7 +2158,7 @@
           <pb ed="perry" n="P48"/>
           <p><milestone unit="recitprose"/>Βουταλὶς ἀπό τινος θυρίδος ἐκρέματο. Νυκτερὶς δὲ προσελθοῦσα ἐπυνθάνετο τὴν αἰτίαν δι’ ἣν ἡμέρας μὲν ἡσυχάζει, νύκτωρ δὲ ᾄδει. Τῆς δὲ μὴ μάτην τοῦτο ποιεῖν λεγούσης· ἡμέρας γάρ ποτε ᾄδουσα συνελήφθη, καὶ διὰ τοῦτο ἀπ’ ἐκείνου ἐσωφρονίσθη, ἡ νυκτερὶς εἶπεν· « Ἀλλ’ οὐ νῦν σε φυλάττεσθαι δεῖ, ὅτε μηδὲν ὄφελος, ἀλλὰ πρὶν ἢ συλληφθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἐπὶ τοῖς ἀτυχήμασιν ἀνόνητος ἡ μετάνοια.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 81 Lb 24 Le 24 Lf 81 Md 134 Mg 29 Mi 108 Mj 27 Mm 39.</p>
+          <bibl>Codd. La 81 Lb 24 Le 24 Lf 81 Md 134 Mg 29 Mi 108 Mj 27 Mm 39.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-76">
@@ -2170,7 +2169,7 @@
           <pb ed="perry" n="P50"/>
           <p><milestone unit="recitprose"/>Γαλῆ ἐρασθεῖσα νεανίσκου εὐπρέπους ηὔξατο τῇ Ἀφροδίτῃ ὅπως αὐτὴν μεταμορφώσῃ εἰς γυναῖκα. Καὶ ἡ θεὸς ἐλεήσασα αὐτῆς τὸ πάθος μετετύπωσεν αὐτὴν εἰς κόρην εὐειδῆ, καὶ οὕτως ὁ νεανίσκος θεασάμενος αὐτὴν καὶ ἐρασθεὶς οἴκαδε ὡς ἑαυτὸν ἀπήγαγε. Καθημένων δὲ αὐτῶν ἐν τῷ θαλάμῳ, ἡ Ἀφροδίτη γνῶναι βουλομένη εἰ μεταϐαλοῦσα τὸ σῶμα ἡ γαλῆ καὶ τὸν τρόπον ἤλλαξε, μῦν εἰς τὸ μέσον καθῆκεν. Ἡ δὲ ἐπιλαθομένη τῶν παρόντων ἐξαναστᾶσα ἀπὸ τῆς κοίτης τὸν μῦν ἐδίωκε καταφαγεῖν θέλουσα. Καὶ ἡ θεὸς ἀγανακτήσασα κατ’ αὐτῆς πάλιν αὐτὴν εἰς τὴν ἀρχαίαν φύσιν ἀποκατέστησεν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ φύσει πονηροί, κἂν φύσιν ἀλλάξωσι, τὸν γοῦν τρόπον οὐ μεταϐάλλονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 50 Pb 50 Pc 21 Pe 24 Pg 28 Ma 35 Mb 22.</p>
+          <bibl>Codd. Pa 50 Pb 50 Pc 21 Pe 24 Pg 28 Ma 35 Mb 22.</bibl>
           <p><milestone unit="traduction"/>Une chatte, s’étant éprise d’un beau jeune homme, pria Aphrodite de la métamorphoser en femme. La déesse prenant en pitié sa passion, la changea en une gracieuse jeune fille ; et alors le jeune homme l’ayant vue s’en amouracha et l’emmena dans sa maison. Comme ils reposaient dans la chambre nuptiale, Aphrodite, voulant savoir si, en changeant de corps, la chatte avait aussi changé de caractère, lâcha une souris au milieu de la chambre. La chatte, oubliant sa condition présente, se leva du lit et poursuivit la souris pour la croquer. Alors la déesse indignée contre elle la remit dans son premier état.</p>
           <p><milestone unit="traduction"/>Pareillement les hommes naturellement méchants ont beau changer d’état, ils ne changent point de caractère.</p>
         </div>
@@ -2180,7 +2179,7 @@
           <pb ed="perry" n="P50"/>
           <p><milestone unit="recitprose"/>Γαλῆ ἐρασθεῖσα νεανίσκου τινὸς εὐπρεποῦς ηὔξατο τῇ Ἀφροδίτῃ ὅπως αὐτὴν μεταμορφώσῃ εἰς γυναῖκα. Καὶ δὴ ἐλεήσασα αὐτὴν ἡ θεὸς μετεποιήσατο αὐτὴν εἰς κόρην εὐειδῆ. Ἐρασθεὶς οὖν ὁ νεανίσκος τοῦ κάλλους αὐτῆς ἀπήγαγεν αὐτὴν εἰς τὸν οἶκον αὐτοῦ. Καθεζομένων δὲ αὐτῶν ἐν τῷ θαλάμῳ, ἡ Ἀφροδίτη γνῶναι βουλομένη εἰ μεταϐαλοῦσα τὸ σῶμα καὶ τὸν τρόπον ἤλλαξε, μῦν εἰς τὸ μέσον καθῆκεν. Ἡ δὲ ἐπιλαθομένη τῶν παρόντων, ἀναστᾶσα ἀπὸ τῆς κοίτης, τὸν μῦν κατεδίωκε, καταφαγεῖν ἐθέλουσα. Ἀγανακτήσασα δὲ ἡ θεὸς πάλιν αὐτὴν εἰς τὴν ἰδίαν φύσιν ἀποκατέστησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων οἱ φύσει πονηροί, κἂν τὴν φύσιν ἀλλάξωσι, τὸν γοῦν τρόπον οὐκ ἀλλάσσουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 48 Cb 31 Cd 31 Ce 30 Cf 34 Ch 38 Mc 34 Md 36 Mh 32 Mi 71 Mk 35 Ml 40 Mm 41 Mn 12 Ld 12.</p>
+          <bibl>Codd. Ca 48 Cb 31 Cd 31 Ce 30 Cf 34 Ch 38 Mc 34 Md 36 Mh 32 Mi 71 Mk 35 Ml 40 Mm 41 Mn 12 Ld 12.</bibl>
         </div>
         <div>
           <head>Chambry 76.3</head>
@@ -2188,7 +2187,7 @@
           <pb ed="perry" n="P50"/>
           <p><milestone unit="recitprose"/>Γαλῆ ἠράσθη ποτὲ ἀνδρὸς εὐπρεποῦς καὶ τὴν Ἀθηνᾶν ἐδυσώπει ταύτην μεταμεῖψαι εἰς γυναῖκα καὶ ἐρασθῆναι αὐτῆς καὶ τὸν ἄνδρα ἐκεῖνον· ὃ δὴ καὶ ἔπραξεν ἡ θεά. Ἔτι δὲ τοῦ γάμου ὄντος, μῦς διέδραμεν ἐν τῷ μέσῳ. Ἡ δὲ τὰ νυμφικὰ ῥίψασα καὶ τῇ φύσει ἀκολουθήσασα τὸν μῦν κατεδίωκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, κἂν πρὸς βραχύ τις ἐν ὑποκρίσει μορφῶται καὶ κρύπτηται, ἡ φύσις τοῦτον διὰ τῶν ἐργων ἐξελέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 19 Mg 36.</p>
+          <bibl>Codd. Ba 19 Mg 36.</bibl>
         </div>
         <div>
           <head>Chambry 76.4</head>
@@ -2196,7 +2195,7 @@
           <pb ed="perry" n="P50"/>
           <p><milestone unit="recitprose"/>Γαλῆ ἠράσθη ποτὲ ἀνδρὸς εὐπρεποῦς καὶ τὴν Ἀθηνᾶν ἐδυσώπει ταύτην μεταμεῖψαι εἰς γυναῖκα καὶ τὸν ἐρώμενον καὶ ἄκοντα ταύτης ἐπιθυμῆσαι. Καὶ ἐγένετο οὕτως, τῆς θεᾶς ἰλασθείσης, ὡς ὁ μῦθος ληρεῖ. Τοῦ δὲ γάμου ἔτι ἐμμένοντος, μῦν ἡ νύμφη ἐμϐλέψασα τῆς ὀπῆς διακύψαντα, τῶν νυμφικῶν στολῶν ἐπελάθετο καὶ τῶν οἰκείων ἐθῶν ἐπεδράττετο, καὶ γαλῆ ἦν ἡ γαλῆ, τὸν μῦν μὲν κατατρέχουσα, τῶν δὲ ὑμεναίων ἐπιλελησμένη.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, κἂν πρὸς βραχύ τις ἐν ὑποχρίσει μορφῶται καὶ ἀμείϐῃ τὴν φύσιν, τοῦτον τὰ ἔργα ἐλέγχουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 16.</p>
+          <bibl>Cod. Bc 16.</bibl>
         </div>
         <div>
           <head>Chambry 76.5</head>
@@ -2215,7 +2214,7 @@
           <l><milestone unit="recitvers"/>τὸν μῦν διώκει ὑποκάτω κραϐϐάτου.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι, κἂν βραχύ τις ἐν ὑποχρίσει μορφῶται, ἡ φύσις αὐτοῦ δι’ ἔρωτος ἐλέγχεται.</p>
           <p/>
-          <p><milestone unit="manuscrits"/>Cod. Pd 30.</p>
+          <bibl>Cod. Pd 30.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-77">
@@ -2226,7 +2225,7 @@
           <pb ed="perry" n="P59"/>
           <p><milestone unit="recitprose"/>Γαλῆ εἰσελθοῦσα εἰς χαλκέως ἐργαστήριον τὴν ἐκεῖ κειμένην ῥίνην περιέλειχε. Συνέϐη δὲ, ἐκτριϐομένης τῆς γλώσσης, πολὺ αἷμα φέρεσθαι. Ἡ δὲ ἐτέρπετο ὑπονοοῦσά τι τοῦ σιδήρου ἀφαιρεῖσθαι, μεχρὶ παντελῶς ἀπέϐαλε τὴν γλῶσσαν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος εἴρηται πρὸς τοὺς ἐν φιλονεικίαις ἑαυτοὺς καταϐλάπτοντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 49 Pb 59 Pe 27 Pg 36 Ma 41 Mb 32.</p>
+          <bibl>Codd. Ca 49 Pb 59 Pe 27 Pg 36 Ma 41 Mb 32.</bibl>
           <p><milestone unit="traduction"/>Une belette, s’étant glissée dans l’atelier d’un forgeron, se mit à lécher la lime qui s’y trouvait. Or il arriva que, sa langue s’usant, il en coula beaucoup de sang ; et elle s’en réjouissait, s’imaginant qu’elle enlevait quelque chose au fer, tant qu’enfin elle perdit la langue.</p>
           <p><milestone unit="traduction"/>Cette fable vise les gens qui, en querellant les autres, se font tort à eux-mêmes.</p>
         </div>
@@ -2236,7 +2235,7 @@
           <pb ed="perry" n="P59"/>
           <p><milestone unit="recitprose"/>Γαλῆ εἰσελθοῦσα εἰς χαλκέως ἐργαστήριον καὶ εὑροῦσα τὴν ῥίνην εἰς τὸ μέσον κειμένην, ταύτην κατεμασᾶτο καὶ ἀνέλειχε. Ἐκτριϐομένης δὲ τῆς γλώσσης αὐτῇ, ὥστε καὶ αἷμα φέρεσθαι, ἐτέρπετο, ὑπονοοῦσά τι τοῦ σιδήρου ἀφαιρεῖσθαι, καὶ ἐπέμενε λοιπόν, μέχρι παντελῶς ἀπέϐαλε τὴν γλῶσσαν.</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς ἐν φιλονεικίαις αὑτοὺς μᾶλλον ἢ τοὺς πέλας καταναλίσκοντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 24 Ph 24.</p>
+          <bibl>Codd. Pf 24 Ph 24.</bibl>
         </div>
         <div>
           <head>Chambry 77.3</head>
@@ -2244,7 +2243,7 @@
           <pb ed="perry" n="P59"/>
           <p><milestone unit="recitprose"/>Γαλῆ εἰς ἐργαστήριον εἰσελθοῦσα χαλκέως τὴν ἐκεῖ κειμένην περιέλειχε ῥίνην. Ξυομένης δὲ τῆς γλώσσης, αἷμα πολὺ ἐφέρετο. Ἡ δὲ ἥδετο, νομίζουσά τι τοῦ σιδήρου ἀφαιρεῖν, ἄχρις οὗ παντελῶς πᾶσαν τὴν γλῶσσαν ἀνήλωσεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς ἐν φιλονεικίαις ἑαυτοὺς βλάπτοντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 85 Lb 34 Lc 37 Le 34 Lf 85 Lg 37 Md 138 Me 41 Mf 36 Mg 43 Mi 112 Mj 40 Ml 42 Mm 52.</p>
+          <bibl>Codd. La 85 Lb 34 Lc 37 Le 34 Lf 85 Lg 37 Md 138 Me 41 Mf 36 Mg 43 Mi 112 Mj 40 Ml 42 Mm 52.</bibl>
         </div>
         <div>
           <head>Chambry 77.4</head>
@@ -2252,7 +2251,7 @@
           <pb ed="perry" n="P59"/>
           <p><milestone unit="recitprose"/>Χαλκέως τινὸς οἶκον αἴλουρος εἰσελθοῦσα καὶ τὰ ἐκείνου πάντα ἐργαλεῖα ἐρευνήσασα, ἐνέτυχε καὶ τῇ αὐτοῦ ῥίνῃ. Ἀναλείξασα δὲ ταύτην τῇ γλώσσῃ ἡδέως ἔλειχε. Ἐξερχομένου δὲ ἐκ τῆς γλώττης αὐτῆς αἷματος, ἡδύνετο αὐτὴ καὶ οὐκ ᾐσθάνετο, ἕως οὗ ἐφθάρη ἡ γλῶσσα αὐτῆς.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ θνῄσκοντες οἱ φιλόνεικοι οὐκ αἰσθάνονται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mh 96.</p>
+          <bibl>Cod. Mh 96.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-78">
@@ -2263,7 +2262,7 @@
           <pb ed="perry" n="P60"/>
           <p><milestone unit="recitprose"/>Γέρων ποτὲ ξύλα κόψας καὶ ταῦτα φέρων πολλὴν ὁδὸν ἐϐάδιζε. Διὰ δὲ τὸν κόπον τῆς ὁδοῦ ἀποθέμενος τὸ φορτίον τὸν Θάνατον ἐπεκαλεῖτο. Τοῦ δὲ Θανάτου φανέντος καὶ πυθομένου δι’ ἣν αἰτίαν αὐτὸν παρακαλεῖται, ὁ γέρων ἔφη· « Ἴνα τὸ φορτίον ἄρῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶς ἄνθρωπος φιλόζωος, [ἐν τῷ βίῳ] κἂν δυστυχῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 60 Pd 32 Pe 28 Pg 37 Ma 42 Mb 33.</p>
+          <bibl>Codd. Pb 60 Pd 32 Pe 28 Pg 37 Ma 42 Mb 33.</bibl>
           <p><milestone unit="traduction"/>Un jour un vieillard, ayant coupé du bois, le chargea sur son dos. Il avait un long trajet à faire. Fatigué par la marche, il déposa son fardeau et il appela la Mort. La Mort parut et lui demanda pour quel motif il l’appelait. Le vieillard répondit : « C’est pour que tu me soulèves mon fardeau… »</p>
           <p><milestone unit="traduction"/>Cette fable montre que tous les hommes sont attachés à l’existence, même s’ils ont une vie misérable.</p>
         </div>
@@ -2273,7 +2272,7 @@
           <pb ed="perry" n="P60"/>
           <p><milestone unit="recitprose"/>Γέρων ποτὲ ξύλα κόψας καὶ ταῦτα φέρων πολλὴν ὁδὸν ἐϐάδιζε, καὶ διὰ τὸν πολὺν κόπον ἀποθέμενος ἐν τόπῳ τινὶ τὸν φόρτον, τὸν Θάνατον ἐπεκαλεῖτο. Τοῦ δὲ Θανάτου παριόντος καὶ πυνθανομένου τὴν αἰτίαν δι’ ἣν αὐτὸν ἐκάλει, δειλιάσας ὁ γέρων ἔφη· « Ἴνα μου τὸν φόρτον ἄρῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶς ἄνθρωπος φιλοζωεῖ, εἰ καὶ δυστυχεῖ καὶ πτωχός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Cod. T 2.</p>
+          <bibl>Cod. T 2.</bibl>
         </div>
         <div>
           <head>Chambry 78.3</head>
@@ -2281,7 +2280,7 @@
           <pb ed="perry" n="P60"/>
           <p><milestone unit="recitprose"/>Γέρων ποτὲ εἰς ὄρος ἀναϐάς, ξύλα κόψας, ταῦτα ἔφερε πολλὴν ὁδὸν βαδίζων. Κοπιάσας δὲ καὶ τὸ φορτίον ἀποθέμενος, οἰμώξας τὸν Θάνατον ἐπεκαλεῖτο. Τοῦ δὲ παραυτίκα ἐπισταθέντος αὐτῷ καὶ πυνθανομένου δι’ ἣν αἰτίαν ἐπεκαλέσατο αὐτόν, ἔφη ὁ γέρων· « Ἵνα τὸ φορτίον ἄρῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶς ἄνθρωπος φιλοζωεῖ, κἂν λίαν δυστυχῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 25 Ph 25.</p>
+          <bibl>Codd. Pf 25 Ph 25.</bibl>
         </div>
         <div>
           <head>Chambry 78.4</head>
@@ -2289,7 +2288,7 @@
           <pb ed="perry" n="P60"/>
           <p><milestone unit="recitprose"/>Γέρων ποτὲ ξύλα κόψας καὶ ταῦτα ἐπὶ τῶν ὤμων ἄρας πολλὴν ἐϐάδισεν ὁδόν. Κεκοπιακὼς δὲ καὶ ἀποθέμενος τὸν φόρτον τὸν Θάνατον ἐπεκαλεῖτο. Τοῦ δὲ Θανάτου φανέντος καὶ πυνθανομένου δι’ ἣν αἰτίαν αὐτὸν ἐπεκαλεῖτο, ὁ γέρων ἔφη· « Ἵνα τὸν φόρτον μοι ἄρῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶς ἄνθρωπος φιλοζωεῖ, εἰ καὶ δυστυχεῖ λίαν, κἂν καὶ μυρίους κινδύνους ὑποστῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 50 Cb 32 Cd 32 Ce 31 Cf 35 Ch 39 Md 37 Mi 72 Mm 42.</p>
+          <bibl>Codd. Ca 50 Cb 32 Cd 32 Ce 31 Cf 35 Ch 39 Md 37 Mi 72 Mm 42.</bibl>
         </div>
         <div>
           <head>Chambry 78.5</head>
@@ -2297,7 +2296,7 @@
           <pb ed="perry" n="P60"/>
           <p><milestone unit="recitprose"/>Γέρων ποτὲ ξυλὰ τεμὼν ἐξ ὄρους κἀπὶ τῶν ὤμων ἀράμενος, ἐπειδὴ πολλὴν ὁδὸν ἐπηχθισμένος ἐϐάδισεν, ἀπειρηκὼς ἀπέθετό τε τὰ ξύλα καὶ τὸν Θάνατον ἐλθεῖν ἐπεκαλεῖτο. Τοῦ δὲ Θανάτου εὐθὺς ἐπιστάντος καὶ τὴν αἰτίαν πυνθανομένου δι’ ἣν αὐτὸν καλοίη, ὁ γέρων ἔφη· « Ἵνα τὸν φόρτον τοῦτον ἄρας ἐπιθῇς μοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶς ἄνθρωπος φιλόζωος ὤν, κἂν μυρίοις κινδύνοις περιπεσὼν δοκῇ θανάτου ἐπιθυμεῖν, ὅμως τὸ ζῆν πολὺ πρὸ τοῦ θανάτου αἱρεῖται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 20 Lb 25 Lc 11 Le 25 Lf 20 Lg 11 Mg 32 Mj 30 Ml 34.</p>
+          <bibl>Codd. La 20 Lb 25 Lc 11 Le 25 Lf 20 Lg 11 Mg 32 Mj 30 Ml 34.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-79">
@@ -2308,7 +2307,7 @@
           <pb ed="perry" n="P296"/>
           <p><milestone unit="recitprose"/>Γεωργὸς ἀετὸν εὑρὼν ἠγρευμένον, τὸ κάλλος αὐτοῦ θαυμάσας, ἀπέλυσεν αὐτὸν ἐλεύθερον. Ὁ δὲ οὐκ ἄμοιρος αὐτῷ χάριτος κατεφάνη, ἀλλ’ ὑπὸ τεῖχος σαθρὸν καθήμενον ἰδών, προσπετάσας τοῖς ποσὶν ἧρε τὸ ἐπὶ τῆς κεφαλῆς αὐτοῦ φακιόλιον. Ὁ δὲ ἐξαναστὰς ἐδίωκε· τοῦτο δὲ ὁ ἀετὸς ἔρριψε. Καὶ ἀναλαϐόμενος αὐτὸ καὶ ὑποστρέψας εὗρε τὸ τεῖχος συμπεπτωκὸς ἔνθα ἐκάθητο, θαυμάσας τὴν ἀμοιϐήν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς ἀγαθόν τι πεπονθότας ἔκ τινος ἀντευεργετεῖν χρή· [ὃ γὰρ ἀγαθὸν ποιήσεις, ἀντιδοθήσεταί σοι].</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 23 Mg 39.</p>
+          <bibl>Codd. Ba 23 Mg 39.</bibl>
           <p><milestone unit="traduction"/>Un laboureur, ayant trouvé un aigle pris au filet, fut si frappé de sa beauté qu’il le délivra et lui donna la liberté. L’aigle ne se montra pas ingrat envers son bienfaiteur ; mais le voyant assis au pied d’un mur qui menaçait ruine, il vola vers lui et enleva dans ses griffes le bandeau qui lui ceignait la tète. L’homme se leva et se mit à sa poursuite. L’aigle laissa tomber le bandeau. Le laboureur le ramassa, et revenant sur ses pas, il trouva le mur écroulé à l’endroit où il s’était assis, et fut bien étonné d’être ainsi payé de retour.</p>
           <p><milestone unit="traduction"/>Il faut rendre les services qu’on a reçus ; [car le bien que vous ferez vous sera rendu].</p>
         </div>
@@ -2318,14 +2317,14 @@
           <pb ed="perry" n="P296"/>
           <p><milestone unit="recitprose"/>Γεωργῷ τινι ἀετὸς ἐθηρεύθη καὶ γνωσθεὶς ἀπελύθη. Ὁ δὲ τοῦ καλοῦ μὴ ἐπιλαθόμενος τὸν γεωργόν ποτε ὑπὲρ τοίχου ὁρῶν καθήμενον εὐολίσθου, τὸ ἐπὶ τῆς κεφαλῆς ἐκείνου ἀφείλετο σημικίνθιον, τῆς καθέδρας τοῦτον ἐξεγεῖραι βουλόμενος, ὡς καὶ κατώρθωσε. Μετὰ γὰρ τὸ καταδιῶξαι τοῦτον, ὁ εὐεργέτης ἀπέρριψε τὸ ἀναληφθέν, πληρεστάτην ἀντιδοὺς τὴν ἀντίχαριν· οὐ μακρῶς γὰρ ἔμελλε συμπατεῖσθαι τῇ τοῦ τοίχου καταϐολῇ ὁ ἀνήρ· μικρὸν γὰρ ἐκείνου ὑποχωρήσαντος, ἐπιχθόνιον ἐγεγόνει τὸ τῆς ἀνύψωμα καθέδρας.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς ἀγαθόν τι πεπονθότας ὁμοίως ἀντιποιεῖσθαι χρή.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 18.</p>
+          <bibl>Cod. Bc 18.</bibl>
         </div>
         <div>
           <head>Chambry 79.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P296"/>
           <p><milestone unit="recitprose"/>Γεωργὸς ἀετὸν εὑρὼν ἠγρευμένον, τὸ κάλλος αὐτοῦ θαυμάσας, ἀπέλυσεν. Ὁ δὲ τοῦτον ἀμειϐόμενος τῆς ἐλευθερίας, ἐπεὶ τοῦτον εἶδεν παρὰ σαθρὸν τοιχίον καθήμενον, κατελθὼν ἦρεν τὸ ἐπὶ τῆς κεφαλῆς αὐτοῦ φάρος. Ὁ δὲ ἀναστὰς ἐδίωκε τὸν ἀετὸν ἐπὶ πολὺ τόπου διάστημα. Ὁ δὲ ἀετὸς ὕπερ ἔλαϐεν αὖθις ἔρριψεν· ὅπερ λαϐὼν ὁ γεωργὸς καὶ ὑποστρέψας, ἐπεὶ τὸ τεῖχος εὗρε συμπεπτωκὸς ἐν ᾧπερ ἐκάθητο, τὸν ἀετὸν [θαυμάσας] τῆς ἀμοιϐῆς ἀπεθαύμασε.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 7.</p>
+          <bibl>Cod. Bd 7.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-80">
@@ -2336,7 +2335,7 @@
           <pb ed="perry" n="P52"/>
           <p><milestone unit="recitprose"/>Γεωργὸς ὑπὸ χειμῶνος ἐναποληφθεὶς ἐν τῇ ἐπαύλει, ἐπειδὴ οὐκ ἠδύνατο προελθεῖν καὶ ἑαυτῷ τροφὴν πορίσαι, τὸ μὲν πρῶτον τὰ πρόϐατα κατέφαγεν. Ἐπειδὴ δὲ ἔτι ὁ χειμὼν ἐπέμενε, καὶ τὰς αἶγας κατεθοινήσατο. Ἐκ τρίτου δέ, ὡς οὐδεμία ἄνεσις ἐγίνετο, καὶ ἐπὶ τοὺς ἀροτῆρας βοῦς ἐχώρησεν. Οἱ δὲ κύνες θεασάμενοι τὰ πραττόμενα ἔφασαν πρὸς ἀλλήλους· « Ἀπιτέον ἡμῖν ἐνθένδε· ὁ δεσπότης γάρ, εἰ οὐδὲ τῶν συνεργαζομένων βοῶν ἀπέσχετο, ἡμῶν πῶς φείσεται ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι δεῖ τούτους μάλιστα φυλάττεσθαι οἳ οὐδὲ τῆς κατὰ τῶν οἰκείων ἀδικίας ἀπέχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 52 Pb 52 Pc 23 Pe 26 Pg 30 Ma 38 Mb 24.</p>
+          <bibl>Codd. Pa 52 Pb 52 Pc 23 Pe 26 Pg 30 Ma 38 Mb 24.</bibl>
           <p><milestone unit="traduction"/>Un laboureur se trouva confiné par le mauvais temps dans sa métairie. Ne pouvant sortir pour se procurer de la nourriture, il mangea d’abord ses moutons ; puis, comme le mauvais temps persistait, il mangea aussi ses chèvres ; enfin, comme il n’y avait pas de relâche, il en vint à ses bœufs de labour. Alors les chiens, voyant ce qui se passait, se dirent entre eux : « Il faut nous en aller d’ici, car si le maître a osé toucher aux bœufs qui travaillent avec lui, comment nous épargnera-t-il ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut se garder particulièrement de ceux qui ne craignent pas de faire du mal même à leurs proches.</p>
         </div>
@@ -2346,7 +2345,7 @@
           <pb ed="perry" n="P52"/>
           <p><milestone unit="recitprose"/>Γεωργός τις, χειμῶνος ὄντος ἐναποληφθεὶς ἐν τῷ προαστείῳ αὐτοῦ, ἀπορῶν τροφῆς, ἐπεὶ οὐκ ἐδύνατο προελθεῖν καὶ ἑαυτῷ τροφὴν πορίσαι, τὰ πρόϐατα αὐτοῦ κατέφαγεν. Ἐπεὶ δὲ ὁ χειμὼν ἔτι ἐπέμενε, καὶ τὰς αἶγας κατεθοινήσατο. Ἐκ τρίτου δέ, ὡς οὐδεμία ἄνεσις ἐγένετο, καὶ ἐπὶ τοὺς ἀροτῆρας βόας ἐχώρησεν. Οἱ δὲ κύνες θεασάμενοι τὰ γινόμενα ἔφασαν πρὸς ἀλλήλους· « Παρέλθωμεν ἐντεῦθεν· ὡς ὁρῶμεν γὰρ ὅτι ὁ κύριος ἡμῶν τοὺς ἐργαζομένους βόας οὐκ ἠλέησεν, ἡμῶν πῶς φείσεται ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τούτους μάλιστα ἐκφεύγειν καὶ φυλάττεσθαι χρὴ οἵτινες οὐδὲ τῆς κατὰ τῶν οἰκείων ἀδικίας ἀπέχονται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ca 43.</p>
+          <bibl>Cod. Ca 43.</bibl>
         </div>
         <div>
           <head>Chambry 80.3</head>
@@ -2354,7 +2353,7 @@
           <pb ed="perry" n="P52"/>
           <p><milestone unit="recitprose"/>Γεωργὸς ὑπὸ χειμῶνος ἐναποληφθεὶς ἐν τῷ προαστείῳ αὐτοῦ, ἀπορῶν τροφῆς, πρῶτον μὲν τὰ πρόϐατα αὐτοῦ κατέφαγεν, ἔπειτα τὰς αἶγας. Ὡς δὲ ὁ χειμὼν ἐπεκράτει, ἐπὶ τοὺς ἀροτῆρας βόας ἐχώρησεν. Ἰδόντες δὲ ταῦτα οἱ κύνες ἔφησαν πρὸς ἀλλήλους· « Πορευθῶμεν οὖν ἡμεῖς ἔνθεν· ὡς ὁρῶμεν γὰρ ὅτι ὁ κύριος ἡμῶν τῶν ἐργαζομένων βοῶν οὐκ ἐφείσατο, ἡμῶν [δὲ] πῶς φείσεται ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τούτους μάλιστα ἐκφεύγειν καὶ φυλάττεσθαι χρὴ οἵτινες οὐδὲ τῶν οἰκείων ἀπέχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cb 34 Ce 33 Cf 37 Ch 41 Mh 34.</p>
+          <bibl>Codd. Cb 34 Ce 33 Cf 37 Ch 41 Mh 34.</bibl>
         </div>
         <div>
           <head>Chambry 80.4</head>
@@ -2362,7 +2361,7 @@
           <pb ed="perry" n="P52"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις ὑπὸ χειμῶνος ἐν τῷ αὐτοῦ προαστείῳ ἀποληφθεὶς καὶ τροφῆς ἀπορῶν πρῶτα μὲν τὰ πρόϐατα κατέφαγεν, εἶτα τὰς αἶγας. Τοῦ δὲ χειμῶνος ἐπικρατοῦντος, καὶ τοὺς ἐργάτας βοῦς σφάξας ἐθοινήσατο. Οἱ δὲ κύνες ταῦτα ἰδόντες διελέχθησαν πρὸς ἀλλήλους· « Φεύγωμεν ἀλλ’ ἡμεῖς γε ἐντεῦθεν· εἰ γὰρ τῶν ἐργατῶν βοῶν ὁ δεσπότης ἡμῶν οὐκ ἐφείσατο, πῶς ἡμῶν φείσεται ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τούτους μάλιστα ἐκφεύγειν καὶ φυλάττεσθαι χρὴ οἵτινες οὐδὲ τῶν οἰκείων ἀπέχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 23 Lb 18 Ld 13 Le 18 Lf 23 Mc 35 Md 39 Me 25 Mf 25 Mi 74 Mj 21 Mk 36 Ml 15 Mm 44 Mn 13.</p>
+          <bibl>Codd. La 23 Lb 18 Ld 13 Le 18 Lf 23 Mc 35 Md 39 Me 25 Mf 25 Mi 74 Mj 21 Mk 36 Ml 15 Mm 44 Mn 13.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-81">
@@ -2373,7 +2372,7 @@
           <pb ed="perry" n="P51"/>
           <p><milestone unit="recitprose"/>Γεωργοῦ παῖδα ὄφις ἑρπύσας ἀπέκτεινεν. Ὁ δὲ ἐπὶ τούτῳ δεινοπαθήσας πέλεκυν ἀνέλαϐε καὶ παραγενόμενος εἰς τὸν φωλεὸν αὐτοῦ εἱστήκει παρατηρούμενος, ὅπως, ἂν ἐξίῃ, εὐθέως αὐτὸν πατάξῃ. Παρακύψαντος δὲ τοῦ ὄφεως, κατενεγκὼν τὸν πέλεκυν, τοῦ μὲν διήμαρτε, τὴν δὲ παρακειμένην πέτραν διέκοψεν. Εὐλαϐηθεὶς δὲ ὕστερον παρεκάλει αὐτὸν ὅπως αὐτῷ διαλλαγῇ. Ὁ δὲ εἶπεν· « Ἀλλ’ οὔτε ἐγὼ δύναμαί σοι εὐνοῆσαι, ὁρῶν τὴν κεχαραγμένην πέτραν, οὔτε σὺ ἐμοὶ, ἀποβλέπων εἰς τὸν τοῦ παιδὸς τάφον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι αἱ μεγάλαι ἔχθραι οὐ ῥᾳδίως τὰς καταλλαγὰς ἔχουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 51 Pb 51 Pc 22 Pe 25 Pg 29 Ma 37 Mb 23 Ca 42.</p>
+          <bibl>Codd. Pa 51 Pb 51 Pc 22 Pe 25 Pg 29 Ma 37 Mb 23 Ca 42.</bibl>
           <p><milestone unit="traduction"/>Un serpent, s’étant approché en rampant de l’enfant d’un laboureur, l’avait tué. Le laboureur en ressentit une terrible douleur ; aussi, prenant une hache, il alla se mettre aux aguets près du trou du serpent, prêt à le frapper, aussitôt qu’il sortirait. Le serpent ayant passé la tête dehors, le laboureur abattit sa hache, mais le manqua et fendit en deux le roc voisin. Dans la suite, craignant la vengeance du serpent, il l’engagea à se réconcilier avec lui ; mais le serpent répondit : « Nous ne pouvons plus nourrir de bons sentiments, ni moi pour toi, quand je vois l’entaille du rocher, ni toi pour moi, quand tu regardes le tombeau de ton enfant. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les grandes haines ne se prêtent guère à des réconciliations.</p>
         </div>
@@ -2383,7 +2382,7 @@
           <pb ed="perry" n="P51"/>
           <p><milestone unit="recitprose"/>Ὄφις γεωργοῦ παῖδα δακὼν ἐν τῷ ποδὶ παραχρῆμα νεκρὸν ἔδειξεν. Ὁ δὲ πατὴρ τῇ λύπῃ συσχεθεὶς καὶ πέλεκυν ἁρπάσας ἐπειρᾶτο φονεῦσαι τὸν ὄφιν. Καὶ δὴ καταλαϐὼν αὐτὸν θηρεύοντα στερρῶς καταφέρει τὸν πέλεκυν κατὰ τοῦ ὄφεως. Ἀστοχήσας δὲ τοῦ θανατῶσαι αὐτὸν, τὴν οὐρὰν ἀπέτεμεν μόνην· ὁ δὲ ὄφις ἐν τῷ φωλεῷ εἰσέδυ. Φοϐηθεὶς οὖν ὁ γεωργὸς μήπως ἀμύνηται αὐτὸν καὶ φονεύσῃ, λαϐὼν ἄλευρον καὶ μέλι, ἐξεκάλει τὸν ὄφιν πρὸς εἰρήνην. Ὁ δὲ ἔνδον ὢν τοῦ φωλεοῦ ἔφησε τῷ ἀνθρώπῳ· « Ἀπὸ τοῦ νῦν μηκέτι κάμνῃς· φιλία γὰρ ἐν ἡμῖν οὐκέτι προσγενήσεται, διότι ἐγὼ μὲν τὴν οὐρὰν βλέπων λυποῦμαι, σὺ δὲ τὸν τοῦ υἱοῦ τύμϐον ὁρῶν οὐκέτι εἰρηνεύσεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐκ ἐπιλανθάνεταί τις τῶν κακῶν ἀμοίϐην, ἂν τὸ μνημόσυνον βλέπῃ περὶ οὗ ἐλυπήθη.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 92 Cf 98.</p>
+          <bibl>Codd. Ce 92 Cf 98.</bibl>
         </div>
         <div>
           <head>Chambry 81.3</head>
@@ -2413,7 +2412,7 @@
           <l><milestone unit="recitvers"/>καὶ σὺ δὲ πάλιν τὸν τύμϐον τοῦ υἱοῦ σου</l>
           <l><milestone unit="recitvers"/>βλέπων καθ’ ὥραν, οὐκέτι εἰρηνεύσεις. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδεὶς μίσους ἢ ἀμοιϐῆς κακῶν ἐπιλανθάνεται, μέχρις ἂν τὸ μνημόσυνον βλέπῃ περὶ οὗ ἐλυπήθη.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 104 Cg 29 Ca 155 Cb 84 Cd 98.</p>
+          <bibl>Codd. Ch 104 Cg 29 Ca 155 Cb 84 Cd 98.</bibl>
         </div>
         <div>
           <head>Chambry 81.4</head>
@@ -2421,7 +2420,7 @@
           <pb ed="perry" n="P51"/>
           <p><milestone unit="recitprose"/>Ὄφις ἐν γεωργοῦ προθύροις φωλεύων ἀνεῖλεν αὐτοῦ τὸ νήπιον παιδίον. Πένθος δὲ τοῖς γονεῦσιν ἐγένετο μέγα. Ὁ δὲ πατήρ, ὑπὸ τῆς λύπης πέλεκυν λαϐών, ἔμελλε τὸν ὄφιν ἐξελθόντα φονεύσειν. Ὡς δὲ ἔκυψε μικρόν, σπεύσας ὁ γεωργὸς τοῦ πατάξαι αὐτόν, ἠστόχησε, μόνον κρούσας τὴν τῆς τρώγλης ὀπήν. Ἀπελθόντος δὲ τοῦ ὄφεως, ὁ γεωργὸς νομίσας τὸν ὄφιν μηκέτι μνησικακεῖν, λαϐὼν ἄρτον καὶ ἅλας, ἔθηκεν ἐν τῇ τρώγλῃ. Ὁ δὲ ὄφις λεπτὸν συρίξας εἶπεν· « Οὐκ ἔσται ἡμῖν ἀπάρτι πίστις ἢ φιλία, ἕως ἂν ἐγὼ τὴν πέτραν ὁρῶ, σὺ δὲ τὸν τύμϐον τοῦ σοῦ τέκνου. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδεὶς μίσους ἢ ἀμύνης ἐπιλανθάνεται ἐφ’ ὅσον βλέπει μνημόσυνον δι’ οὗ ἐλυπήθη.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 145 Lc 57 Lg 57 Md 93 Mh 84 Mi 9 Mm 111.</p>
+          <bibl>Codd. La 145 Lc 57 Lg 57 Md 93 Mh 84 Mi 9 Mm 111.</bibl>
         </div>
         <div>
           <head>Chambry 81.5</head>
@@ -2429,7 +2428,7 @@
           <pb ed="perry" n="P51"/>
           <p><milestone unit="recitprose"/>Ὄφις ἐν γεωργοῦ προθύροις φωλεύων ἀνεῖλεν αὐτοῦ παῖδα νήπιον τύψας. Πένθος δὲ μέγα τοῖς γονεῦσιν ἐγένετο. Ὁ πατὴρ δὲ πληγεὶς ὑπὸ τῆς λύπης πέλεκυν λαϐὼν ἔμελλε τὸν ὄφιν τῆς τρώγλης ἐξιόντα πατάξειν. Ὡς δὲ ἐξέκυψε μικρόν, σπεύσας ὁ γεωργὸς τοῦ πλῆξαι ἠστόχησε, τὴν πέτραν δὲ μόνον τῆς ὀπῆς κρούσας καὶ διαχαράξας ἀπῆλθε. Λογιζόμενος &lt;οὖν&gt; ὡς ἑρπετὸν μῆνιν οὐ φυλάσσει, λαϐὼν δὲ ἄρτον καὶ ἅλας πρὸς εἰρήνην ἐκάλει τὸν ὄφιν. Ὁ ὄφις δὲ λεπτὸν συρίσας εἶπεν· « Οὐκ ἔστιν ἡμῖν ἀπάρτι πίστις ἢ φιλία, ἕως ἂν ἐγὼ ταύτην τὴν πέτραν ὁρῶ, σὺ δὲ τὸν τοῦ παιδὸς τάφον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐδεὶς μίσους ἢ ἀμύνης ποτὲ ἐπιλανθάνεται, ἐφ’ ὅσον βλέπει μνημόσυνον δι’ ὧν ἐλυπήθη.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 118 Bb 70.</p>
+          <bibl>Codd. Ba 118 Bb 70.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-82">
@@ -2440,7 +2439,7 @@
           <pb ed="perry" n="P176"/>
           <p><milestone unit="recitprose"/>Γεωργός τις χειμῶνος ὥρᾳ ὄφιν εὑρὼν ὑπὸ κρύους πεπηγότα, τοῦτον ἐλεήσας καὶ λαϐὼν ὑπὸ κόλπον ἔθετο. Θερμανθεὶς δὲ ἐκεῖνος καὶ ἀναλαϐὼν τὴν ἰδίαν φύσιν ἔπληξε τὸν εὐεργέτην καὶ ἀνεῖλε· θνῄσκων δὲ ἔλεγε· « Δίκαια πάσχω, τὸν πονηρὸν οἰκτείρας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἀμετάθετοί εἰσιν αἱ πονηρίαι, κἂν τὰ μέγιστα φιλανθρωπεύωνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 62 Pe 30 Ma 43.</p>
+          <bibl>Codd. Pb 62 Pe 30 Ma 43.</bibl>
           <p><milestone unit="traduction"/>Un laboureur trouva dans la saison d’hiver un serpent raidi par le froid. Il en eut pitié, le ramassa et le mit dans son sein. Réchauffé, le serpent reprit son naturel, frappa et tua son bienfaiteur, qui, se sentant mourir, s’écria : « Je l’ai bien mérité, ayant eu pitié d’un méchant. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que la perversité ne change pas, quelque bonté qu’on lui témoigne.</p>
         </div>
@@ -2450,7 +2449,7 @@
           <pb ed="perry" n="P176"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόρος χειμῶνος ὁδεύων ὥρᾳ, ὡς ἐθεάσατο ἔχιν ὑπὸ κρύους διαφθειρόμενον, τοῦτον ἐλεήσας ἀνείλατο καὶ βαλὼν εἰς τὸν ἑαυτοῦ κόλπον θερμαίνειν ἐπειρᾶτο. Ὁ δὲ μέχρι μὲν ὑπὸ τοῦ ψύχους συνείχετο, ἠρέμει· ἐπειδὴ δὲ ἐθερμάνθη καὶ ἀνεζωώθη, τὴν αὐτοῦ γαστέρα ἔδακε. Καὶ ὃς ἀποθνῄσκειν μέλλων ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γὰρ τοῦτον ἀπολλύμενον ἔσῳζον, ὃν ἔδει καὶ ἐρρωμένον ἀναιρεῖν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πονηρία εὐεργετουμένη πρὸς τῷ ἀμοιϐὰς μὴ ἀποδιδόναι καὶ κατὰ τῶν εὐεργετῶν ἀναπτεροῦται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 174 Pb 171 Pc 102 Pg 112 Ma 122 Ca 130.</p>
+          <bibl>Codd. Pa 174 Pb 171 Pc 102 Pg 112 Ma 122 Ca 130.</bibl>
         </div>
         <div>
           <head>Chambry 82.3</head>
@@ -2458,7 +2457,7 @@
           <pb ed="perry" n="P176"/>
           <p><milestone unit="recitprose"/>Ἔχιδναν ἐκ τοῦ ψύχους ἐκπνέουσαν εἶδε γεωργὸς καὶ λαϐὼν ἔϐαλεν ἐν τῷ κόλπῳ καὶ ἔθαλψεν. Ἡ δὲ ἀπλωθεῖσα, τοῦ γεωργοῦ τῇ χειρὶ ταύτην ὁμαλίσαι βουληθέντος, δακοῦσα τοῦτον ἀπέκτεινεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἀνδρὶ πονηρῷ μήτε καλῶς πράττοντι μήτε φαύλως χάριν παρασχοῦ· ἡ γὰρ πονηρὰ φύσις ἀντὶ ἀγαθῶν πονηρὰ ἀνταποδίδωσι· χρηστὸν γὰρ ἦθος οὐ τίκτει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 42 Bb 28.</p>
+          <bibl>Codd. Ba 42 Bb 28.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-83">
@@ -2469,7 +2468,7 @@
           <pb ed="perry" n="P42"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ γεωργὸς μέλλων τελευτᾶν καὶ βουλόμενος τοὺς αὑτοῦ παῖδας ἐμπείρους εἶναι τῆς γεωργίας, μετακαλεσάμενος αὐτούς, ἔφη· « Τεκνία, ἐν μιᾷ μου τῶν ἀμπέλων θησαυρὸς ἀπόκειται. » Οἱ δὲ μετὰ τὴν αὐτοῦ τελευτὴν ὕνας τε καὶ δικέλλας λαϐόντες πᾶσαν αὑτῶν τὴν γεωργίαν ὤρυξαν. Καὶ τὸν μὲν θησαυρὸν οὐχ εὗρον, ἡ δὲ ἄμπελος πολλαπλασίαν τὴν φορὰν αὐτοῖς ἀπεδίδου.</p>
           <p><milestone unit="epimythiumprose"/>Τοῦτο μὲν ἔγνωσαν ὅτι ὁ κάματος θησαυρός ἐστι τοῖς ἀνθρώποις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 10 Pb 42 Pd 25 Pe 7 Pi 5 Mb 11.</p>
+          <bibl>Codd. Pa 10 Pb 42 Pd 25 Pe 7 Pi 5 Mb 11.</bibl>
         </div>
         <div>
           <head>Chambry 83.2</head>
@@ -2477,7 +2476,7 @@
           <pb ed="perry" n="P42"/>
           <p><milestone unit="recitprose"/>Ἀνὴρ τῇ τέχνῃ γεωργὸς ὑπάρχων, μέλλων καταλῦσαι τὸν βίον καὶ βουλόμενος τοὺς παῖδας αὐτοῦ ἐμπείρους ποιῆσαι τῆς γεωργικῆς, προσκαλεσάμενος ἔφη πρὸς αὐτούς· « Τεκνία, ἐγὼ τοῦ βίου ὑπεξέρχομαι· πλὴν ἅπερ μοι ὑπάρχει ἐν τῷ ἀμπελῶνι εὑρήσετε πάντα. » Οἱ δὲ νομίσαντες θησαυρόν τινα ἐνταῦθα ἔχειν, μετά τὴν ἀποϐίωσιν τοῦ πατρὸς αὐτῶν λαϐόντες δικέλλας ὕννας τε κατέσκαψαν πᾶσαν τὴν γῆν ἐκ πόθου. Καὶ τὸν μὲν θησαυρὸν οὐχ εὗρον· ἡ δὲ ἄμπελος καλῶς κατασκαφθεῖσα καὶ ὠφεληθεῖσα πολυπλασίονα τὸν καρπὸν ἀπέδωκε καὶ πλοῦτον ἀνήνεγκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ κάματος θησαυρός ἐστι τοῖς ἀνθρώποις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 33 Cb 18 Cc 24 Cd 18 Ce 22 Cf 25 Ch 25 Ma 155 Mc 23 Md 29 Mh 27 Mi 64 Mk 24 Mm 29.</p>
+          <bibl>Codd. Ca 33 Cb 18 Cc 24 Cd 18 Ce 22 Cf 25 Ch 25 Ma 155 Mc 23 Md 29 Mh 27 Mi 64 Mk 24 Mm 29.</bibl>
         </div>
         <div>
           <head>Chambry 83.3</head>
@@ -2485,7 +2484,7 @@
           <pb ed="perry" n="P42"/>
           <p><milestone unit="recitprose"/>Γεωργός τις μέλλων καταλύειν τὸν βίον καὶ βουλόμενος τοὺς ἑαυτοῦ παῖδας πεῖραν λαϐεῖν τῆς γεωργίας, προσκαλεσάμενος αὐτοὺς ἔφη· « Παῖδες ἐμοὶ, ἐγὼ μὲν ἤδη τοῦ βίου ὑπέξειμι, ὑμεῖς δ’ ἅπερ ἐν τῇ ἀμπέλῳ μοι κέκρυπται ζητήσαντες, εὑρήσετε πάντα. » Οἱ μὲν οὖν οἰηθέντες θησαυρὸν ἐκεῖ που κατορωρύχθαι, πᾶσαν τὴν τῆς ἀμπέλου γῆν μετὰ τὴν ἀποϐίωσιν τοῦ πατρὸς κατέσκαψαν. Καὶ θησαυρῷ μὲν οὐ περιέτυχον, ἡ δὲ ἄμπελος καλῶς σκαφεῖσα πολλαπλασίονα τὸν καρπὸν ἀνέδωκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ κάματος θησαυρός ἐστι τοῖς ἀνθρώποις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 22 Lb 27 Le 27 Lf 22 Lh 12 Me 34 Mf 31 Mg 34 Mj 32.</p>
+          <bibl>Codd. La 22 Lb 27 Le 27 Lf 22 Lh 12 Me 34 Mf 31 Mg 34 Mj 32.</bibl>
           <p><milestone unit="traduction"/>Un laboureur, sur le point de terminer sa vie, voulut que ses enfants acquissent de l’expérience en agriculture. Il les fit venir et leur dit : « Mes enfants, je vais quitter ce monde ; mais vous, cherchez ce que j’ai caché dans ma vigne, et vous trouverez tout. » Les enfants, s’imaginant qu’il y avait enfoui un trésor en quelque coin, bêchèrent profondément tout le sol de la vigne après la mort du père. De trésor, ils n’en trouvèrent point ; mais la vigne bien remuée donna son fruit au centuple.</p>
           <p><milestone unit="traduction"/>Cette fable montre que le travail est pour les hommes un trésor.</p>
         </div>
@@ -2498,7 +2497,7 @@
           <pb ed="perry" n="P61"/>
           <p><milestone unit="recitprose"/>Γεωργός τις χρυσίον εὑρὼν ἐν γῇ σκάπτων ἔστεφεν αὐτὴν καθ’ ἡμέραν ὡς εὐεργετηθεὶς παρ’ αὐτῆς. Τούτῳ δὲ ἐπιστᾶσά φησιν ἡ Τύχη· « Ὦ οὗτος, τί τῇ Γῇ τὰ ἐμὰ δῶρα περιτιθεῖς, ἃ ἐγώ σοι δέδωκα πλουτῆσαι βουλομένη σε ; Ἂν γὰρ ὁ καιρὸς μεταλλάξῃ [τὴν φύσιν] καὶ εἰς ἄλλας χεῖρας τὸ χρυσίον ἐξαλλάσσῃ, πάλιν τὴν Τύχην μέμψῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Διδάσκει ἡμᾶς ὁ λόγος ὅτι χρὴ ἐπιγινώσκειν τὸν εὐεργέτην καὶ τούτῳ χάριτας ἀποδιδόναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 59 Pb 61 Pe 29 Pg 38 Ma 36 Ca 51.</p>
+          <bibl>Codd. Pa 59 Pb 61 Pe 29 Pg 38 Ma 36 Ca 51.</bibl>
         </div>
         <div>
           <head>Chambry 84.2</head>
@@ -2506,7 +2505,7 @@
           <pb ed="perry" n="P61"/>
           <p><milestone unit="recitprose"/>Γεωργός τις σκάπτων ἐν γῇ εὗρε χρυσὸν καὶ ἐστεφάνου τὴν Γῆν καθ’ ἡμέραν καὶ κατεκόσμει ὡς ὑπ’ αὐτῆς εὐεργετηθείς. Ἐπιστᾶσα δὲ αὐτῷ ἡ Τύχη ἔφη· « Ὦ οὗτος, τί παρέχεις τῇ Γῇ τὰ ἐμὰ δῶρα, ἅπερ ἐγὼ δέδωκα βουλομένη σε πλουτίσαι ; Ἂν γὰρ ὁ καιρὸς μεταλλάξῃ [τὴν φύσιν] καὶ εἰς ἑτέρας προφάσεις ἐξαναλώσῃς τὸν βίον, πάλιν τὴν Τύχην μέμψῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος ἔμφασιν ἔχει ὅτι χρὴ προγινώσκειν τὸν εὐεργέτην καὶ τούτῳ ἀπονέμειν τὴν χάριν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 26 Ph 26 Me 42 Mf 37.</p>
+          <bibl>Codd. Pf 26 Ph 26 Me 42 Mf 37.</bibl>
         </div>
         <div>
           <head>Chambry 84.3</head>
@@ -2514,7 +2513,7 @@
           <pb ed="perry" n="P61"/>
           <p><milestone unit="recitprose"/>Γεωργός τις σκάπτων χρυσίῳ περιέτυχε. Καθ’ ἑκάστην οὖν τὴν Γῆν, ὡς ὑπ’ αὐτῆς εὐεργετηθείς, ἔστεφε. Τῷ δὲ ἡ Τύχη ἐπιστᾶσά φησιν· « Ὦ οὗτος, τί τῇ Γῇ τὰ ἐμὰ δῶρα προσανατίθης, ἅπερ ἐγώ σοι δέδωκα, πλουτίσαι σε βουλομένη ; Εἰ γὰρ ὁ καιρὸς μεταϐάλοι καὶ πρὸς ἑτέρας χεῖρας τοῦτό σοι τὸ χρυσίον ἔλθοι, οἶδ’ ὅτι τηνικαῦτα ἐμὲ τὴν Τύχην μέμψῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι χρὴ τὸν εὐεργέτην ἐπιγινώσκειν καὶ τούτῳ χάριτας ἀποδιδόναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 86 Lb 35 Le 35 Lf 86 Lh 15 Md 139 Mg 44 Mi 113 Mj 41 Ml 45 Mm 53.</p>
+          <bibl>Codd. La 86 Lb 35 Le 35 Lf 86 Lh 15 Md 139 Mg 44 Mi 113 Mj 41 Ml 45 Mm 53.</bibl>
           <p><milestone unit="traduction"/>Un laboureur, en bêchant, tomba sur un magot d’or. Aussi chaque jour il couronnait la Terre, persuadé que c’était à elle qu’il devait cette faveur. Mais la Fortune lui apparut et lui dit : « Pourquoi, mon ami, imputes-tu à la Terre les dons que je t’ai faits, dans le dessein de t’enrichir ? Si en effet les temps viennent à changer et que cet or passe en d’autres mains, je suis sûre qu’alors c’est à moi, la Fortune, que tu t’en prendras. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut reconnaître qui vous fait du bien et le payer de retour.</p>
         </div>
@@ -2527,7 +2526,7 @@
           <pb ed="perry" n="P299"/>
           <p><milestone unit="recitprose"/>Φυτὸν ἦν εἰς γεωργοῦ χώραν, καρπὸν μὴ φέρον, ἀλλὰ μόνον στρουθῶν καὶ τεττίγων κελαδούντων ἦν καταφυγή. Ὁ δὲ γεωργὸς ὡς ἄκαρπον ἐκτεμεῖν ἤμελλεν. Καὶ δὴ τὸν πέλεκυν λαϐὼν ἐπέφερε τὴν πλήγην. Οἱ δὲ τέττιγες καὶ οἱ στρουθοὶ ἱκέτευον τὴν καταφυγὴν αὐτῶν μὴ ἐκκόψαι, ἀλλ’ ἐᾶσαι, ὥστε ᾄδειν ἐν αὐτῷ καὶ σὲ τὸν γεωργὸν τέρπειν. Ὁ δὲ μηδὲν αὐτῶν φροντίσας, καὶ δευτέραν πληγὴν καὶ τρίτην ἐπέφερε. Ὡς δὲ ἐκοίλανε τὸ δένδρον, σμῆνος μελισσῶν καὶ μέλι εὗρε. Γευσάμενος δὲ τὸν πέλεκυν ἔρριψε καὶ τὸ φυτὸν ἐτίμα ὡς ἱερὸν καὶ ἐπεμελεῖτο.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ τοσοῦτον οἱ ἄνθρωποι φύσει τὸ δίκαιον ἀγαπῶσι καὶ τιμῶσιν ὅσον τὸ κερδαλέον ἐπιδιώκουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 140 Bb 85.</p>
+          <bibl>Codd. Ba 140 Bb 85.</bibl>
           <p><milestone unit="traduction"/>Il y avait dans le champ d’un laboureur un arbre qui ne portait pas de fruit, et qui servait uniquement de refuge aux moineaux et aux cigales bruissantes. Le laboureur, vu sa stérilité, s’en allait le couper, et déjà, la hache en main, il assénait son coup. Les cigales et les moineaux le supplièrent de ne pas abattre leur asile, mais de le leur laisser pour qu’ils pussent y chanter et charmer le laboureur lui-même. Lui, sans s’inquiéter d’eux, asséna un second, puis un troisième coup. Mais ayant fait un creux dans l’arbre, il trouva un essaim d’abeilles et du miel. Il y goûta, et jeta sa hache, et dès lors il honora l’arbre, comme s’il était sacré, et il en prit grand soin.</p>
           <p><milestone unit="traduction"/>Ceci prouve que par nature les hommes ont moins d’amour et de respect pour la justice que d’acharnement au gain.</p>
         </div>
@@ -2556,7 +2555,7 @@
           <l><milestone unit="recitvers"/>οὗ γευσάμενος τὸν πέλεκυν προσρίπτει</l>
           <l><milestone unit="recitvers"/>καὶ τοῦ δένδρου εὐθέως ἐπεμελεῖτο</l>
           <l><milestone unit="recitvers"/>πλεῖον τῶν δένδρων ὧν εἰχε τῶν ἐγκάρπων.</l>
-          <p><milestone unit="manuscrits"/>Cod. Mb 215.</p>
+          <bibl>Cod. Mb 215.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-86">
@@ -2567,7 +2566,7 @@
           <pb ed="perry" n="P53"/>
           <p><milestone unit="recitprose"/>Γεωργοῦ παῖδες ἐστασίαζον. Ὁ δὲ, ὡς πολλὰ παραινῶν οὐκ ἠδύνατο πεῖσαι αὐτοὺς λόγοις μεταϐάλλεσθαι, ἔγνω δεῖν διὰ πράγματος τοῦτο πρᾶξαι, καὶ παρῄνεσεν αὐτοῖς ῥάϐδων δέσμην κομίσαι. Τῶν δὲ τὸ προσταχθὲν ποιησάντων, τὸ μὲν πρῶτον δοὺς αὐτοῖς ἀθρόας τὰς ῥάϐδους ἐκέλευσε κατεάσσειν. Ἐπειδὴ δὲ κατὰ πᾶν βιαζόμενοι οὐκ ἠδύναντο, ἐκ δευτέρου λύσας τὴν δέσμην, ἀνὰ μίαν αὐτοῖς ῥάϐδον ἐδίδου. Τῶν δὲ ῥᾳδίως κατακλώντων, ἔφη· « Ἀτὰρ οὖν καὶ ὑμεῖς, ὦ παῖδες, ἐὰν μὲν ὁμοφρονῆτε, ἀχείρωτοι τοῖς ἐχθροῖς ἔσεσθε· ἐὰν δὲ στασιάζητε, εὐάλωτοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοσοῦτον ἰσχυροτέρα ἐστὶν ἡ ὁμόνοια ὅσον εὐκαταγώνιστος ἡ στάσις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 53 Pb 53 Pc 24 Pe 27 Pg 31 Mb 25.</p>
+          <bibl>Codd. Pa 53 Pb 53 Pc 24 Pe 27 Pg 31 Mb 25.</bibl>
           <p><milestone unit="traduction"/>Les enfants d’un laboureur vivaient en désaccord. Il avait beau les exhorter : ses paroles étaient impuissantes à les faire changer de sentiments ; aussi résolut-il de leur donner une leçon en action, Il leur dit de lui apporter un fagot de baguettes. Quand ils eurent exécuté son ordre, tout d’abord il leur donna les baguettes en faisceau et leur dit de les casser. Mais en dépit de tous leurs efforts, ils n’y réussirent point. Alors il délia le faisceau et leur donna les baguettes une à une ; ils les cassèrent facilement. « Eh bien ! dit le père, vous aussi, mes enfants, si vous restez unis, vous serez invincibles à vos ennemis ; mais si vous êtes divisés, vous serez faciles à vaincre. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’autant la concorde est supérieure en force, autant la discorde est facile à vaincre.</p>
         </div>
@@ -2577,7 +2576,7 @@
           <pb ed="perry" n="P53"/>
           <p><milestone unit="recitprose"/>Γεωργοῦ παῖδες ἐστασίαζον. Ὁ δὲ πατὴρ αὐτῶν παραινῶν αὐτοῖς οὐκ ἠδύνατο αὐτοὺς διαλλάττεσθαι ἐν λόγοις. Ἔγνω οὖν διὰ πραγμάτων αὐτοὺς πεῖσαι. Καὶ δὴ καθημένων αὐτῶν, προσέταξε ῥάϐδους αὐτῷ κομίσαι. Ἐνεχθεισῶν δὲ τῶν ῥάϐδων, λαϐὼν ταύτας, ἐποίησεν αὐτὰς δέσμην μίαν, καὶ ἐκέλευσεν τοὺς παῖδας ἕνα ἕκαστον λαϐεῖν τὴν δέσμην καὶ συνθλάσαι. Οἱ δὲ δοκιμάσαντες οὐκ ἠδυνήθησαν. Ὕστερον δὲ λύσας αὐτὰς ἔδωκεν ἀνὰ μίαν κλάσαι. Οἱ δὲ διὰ τάχους τοῦτο ἐποίησαν. Τότε λέγει αὐτοῖς ὁ πατὴρ αὐτῶν· « Οὕτω καὶ ὑμεῖς, ὦ τεκνία μου, ἐάν μοι ἔσεσθε ὁμοφρονοῦντες, ἀκαταγώνιστοι καὶ ἀχείρωτοι ἔσεσθε τοῖς ἐχθροῖς· ἐὰν δὲ μένητε στασιάζοντες καὶ φιλονεικοῦντες, εὐχερῶς ἔσεσθε εὐάλωτοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοσοῦτον ἰσχυροτέρα ἐστὶν ἡ ὁμόνοια ὅσον εὐκαταφρόνητος ἡ διάστασις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 52 Cb 35 Ce 34 Cf 38 Ch 42 Ma 161 Mc 36 Md 40 Mh 35 Mi 75 Mk 37 Ml 43 Mm 45 Mn 14 Ld 14.</p>
+          <bibl>Codd. Ca 52 Cb 35 Ce 34 Cf 38 Ch 42 Ma 161 Mc 36 Md 40 Mh 35 Mi 75 Mk 37 Ml 43 Mm 45 Mn 14 Ld 14.</bibl>
         </div>
         <div>
           <head>Chambry 86.3</head>
@@ -2585,14 +2584,14 @@
           <pb ed="perry" n="P53"/>
           <p><milestone unit="recitprose"/>Ἐν τοῖς παλαιοῖς πατὴρ παίδων ὑπεργηράσας παραινῶν αὐτοῖς τὰ εἰκότα ἐκέλευσε καὶ δέσμην ῥάϐδων ἐνεγκεῖν. Ἔφη δὲ τοῖς υἱοῖς· « Πειραθῆτε, τέκνα, συνδεδεμένας τὰς ῥάϐδους κατεάξαι. » Οἱ δὲ οὐκ ἠδυνήθησαν. Μίαν δὲ ἑκάστην ἀποσπασθεῖσαν εὐχερῶς κατέκλασαν. Ἔφη δέ· « Ὦ παῖδες ἐμοί, καὶ αὐτοί, εἰ μὲν ἀλλήλοις ὁμοφρονῆτε, οὐδεὶς ὑμᾶς βλάψει, εἰ δὲ τῇ γνώμῃ ἀλλήλων χωρισθῆτε, ἀπολεῖσθε πάντες ὡς ἡ μία ῥάϐδος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἡ ὁμόνοια ὅπλον μέγα καὶ ἀκίνδυνόν ἐστι καὶ κτῆμα πρὸς ἀνάπαυσιν βίου.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 38 Mg 64.</p>
+          <bibl>Codd. Ba 38 Mg 64.</bibl>
         </div>
         <div>
           <head>Chambry 86.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P53"/>
           <p><milestone unit="recitprose"/>Πατὴρ ἀποθνῄσκων τοὺς οἰκείους παῖδας πρὸς ὁμοφροσύνην παρεκάλει· τρεῖς δὲ ῥάϐδους δεδεμένας κατεάξαι ταῖς χερσὶ τούτοις ἐδίδου. Οἱ δὲ λαϐόντες οὐκ ἠδυνήθησαν. Εἶτα μίαν μόνην ἑκάστῳ δοὺς κατεάξαι, τὴν ἑαυτοῦ ῥᾳδίως ἕκαστος κατέκλασεν. Πρὸς οὓς ὁ πατὴρ ἔφη· « Οὕτω καὶ ὑμεῖς, ὦ παῖδες, ἐὰν ὁμοῦ ἦτε ἐν ἅπασι, οὐδεὶς ὑμᾶς βλάψαι δυνήσεται, εἰ δὲ διχονοεῖτε, ἕκαστον ἰδίως πᾶς τις εὐχερῶς καταλάψαι δυνήσεται. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 18.</p>
+          <bibl>Cod. Bd 18.</bibl>
         </div>
         <div>
           <head>Chambry 86.5</head>
@@ -2600,7 +2599,7 @@
           <pb ed="perry" n="P53"/>
           <p><milestone unit="recitprose"/>Υἱούς τις ἔχων πολλοὺς καὶ μὴ ὁμονοοῦντας, τούτους ἐν μιᾷ καλέσας ὁ πατὴρ καὶ ῥάϐδον αὐτοῖς ἐπιδώσας ἔφη· « Θέλω κατεάξαι ταύτην τὴν ῥάϐδον, » καὶ κατέαξαν αὐτήν. Ὁ δὲ πάλιν ἐπέδωκε αὐτοῖς ῥάϐδους πολλὰς κατεάξαι καὶ οὐκ ἠδυνήθησαν κατεάξαι αὐτάς. Ὁ δὲ ἔφη πρὸς αὐτούς· « Βλέπετε ὡς οὐκ ηὐπορήσατε κατεάξαι τὰς ῥάϐδους· οὕτως καὶ ὑμεῖς, ἐὰν ὁμονοοῦντές ἐστε, οὐδεὶς ὑμᾶς βλάψει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καλὸν ἔργον ὁμόνοια καὶ τοῖς πᾶσιν εὐάρμοστον.</p>
-          <p><milestone unit="manuscrits"/>Codex Barberinus 47 n° 153.</p>
+          <bibl>Codex Barberinus 47 n° 153.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-87">
@@ -2611,7 +2610,7 @@
           <pb ed="perry" n="P57"/>
           <p><milestone unit="recitprose"/>Γυνὴ πρεσϐῦτις τοὺς ὀφθαλμοὺς νοσοῦσα ἰατρὸν ἐπὶ μισθῷ παρεκάλεσεν. Ὁ δὲ εἰσιών, ὁπότε αὐτὴν ἔχριε, διετέλει ἐκείνης συμμυούσης καθ’ ἕκαστον τῶν σκευῶν ὑφαιρούμενος. Ἐπειδὴ δὲ πάντα ἐκφορήσας κἀκείνην ἐθεράπευσεν, ἀπῄτει τὸν ὡμολογημένον μισθόν· καὶ μὴ βουλομένης αὐτῆς ἀποδοῦναι, ἤγαγεν αὐτὴν ἐπὶ τοὺς ἄρχοντας. Ἡ δὲ ἔλεγε τὸν μὲν μισθὸν ὑπεσχῆσθαι, ἐὰν θεραπεύσῃ αὐτῆς τὰς ὁράσεις, νῦν δὲ χεῖρον διατεθῆναι ἐκ τῆς ἰάσεως αὐτοῦ ἢ πρότερον· « τότε μὲν γὰρ ἔϐλεπον πάντα, ἔφη, τὰ ἐπὶ τῆς οἰκίας σκεύη, νῦν δ’ οὐδὲν ἰδεῖν δύναμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ πονηροὶ τῶν ἀνθρώπων διὰ πλεονεξίαν λανθάνουσι καθ’ ἐαυτῶν τὸν ἔλεγχον ἐπισπώμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 57 Pb 57 Pg 34 Ph 29 Mb 29.</p>
+          <bibl>Codd. Pa 57 Pb 57 Pg 34 Ph 29 Mb 29.</bibl>
           <p><milestone unit="traduction"/>Une vieille femme, qui avait les yeux malades, fit appeler, moyennant salaire, un médecin. Il vint chez elle, et à chaque onction qu’il lui faisait, il ne manquait pas, tandis qu’elle avait les yeux fermés, de lui dérober ses meubles pièce à pièce. Quand il eut tout emporté, la cure aussi étant terminée, il réclama le salaire convenu. La vieille se refusant à payer, il la traduisit devant les magistrats. Elle déclara qu’elle avait bien promis le salaire, s’il lui guérissait la vue ; mais que son état, après la cure du médecin, était pire qu’auparavant. « Car, dit-elle, je voyais alors tous les meubles qui étaient dans ma maison ; à présent au contraire je ne puis plus rien voir. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que les malhonnêtes gens ne songent pas que leur cupidité fournit contre eux la pièce à conviction.</p>
         </div>
@@ -2621,7 +2620,7 @@
           <pb ed="perry" n="P57"/>
           <p><milestone unit="recitprose"/>Γυνὴ πρεσϐῦτις τοὺς ὀφθαλμοὺς νοσοῦσα, ἰατρόν τινα ἐπὶ μισθῷ ἰατρεῦσαι αὐτὴν παρεκάλει, στοιχήσασα αὐτῷ ἐνώπιον μαρτύρων ὅτι, ἐὰν θεραπεύσῃ αὐτῆς τοὺς ὀφθαλμούς, πολὺν λήψεται παρ’ αὐτῆς τὸν μισθόν· ἐὰν δὲ μὴ θεραπεύσῃ, ἐπιμείνῃ δὲ ἡ ἀρρωστία, μηδὲν αὐτῷ παρασχήσει. Καὶ οὕτω γενομένου, ὅσον ὁ ἰατρὸς ἐπετίθει τοῖς ὀφθαλμοῖς αὐτῆς τήν ἰατρείαν, κατ’ ὀλίγον ὀλίγον τὰ προσόντα αὐτῇ ἔκλεπτε. Μετ’ οὐ πολὺ δὲ θεραπεύσας αὐτήν, ἐξῄτει τὸν στοιχηθέντα μισθόν. Ἀναϐλέψασα τοίνυν ἡ γραῦς οὐδὲν τῶν προσόντων αὐτῇ ἐθεάσατο ἐν τῇ οἰκίᾳ αὐτῆς. Ὡς οὖν ἐπέμενεν ὁ ἰατρὸς ἐκϐιάζων αὐτήν, ἐκείνη δὲ ἀνεϐάλλετο, ἀπήγαγεν αὐτὴν πρὸς τοὺς ἄρχοντας. Στᾶσα οὖν ἐνώπιον αὐτῶν ἔφη· « Ὁ ἄνθρωπος οὗτος, καθῶς λέγει, ἀλήθειαν λέγει· ἐπηγγειλάμην γὰρ δοῦναι αὐτῷ τὸν μισθόν, ἐὰν καλῶς ἀναϐλέψω· εἰ δὲ ἐπιμείνω τῇ ἀρρωστίᾳ, ἵνα μηδὲν παρέξω αὐτῷ. Νῦν οὖν φάσκει ὅτι ἐθεραπεύθην· ἐγὼ δὲ τοὐναντίον λέγω παθεῖν με· ὅταν γὰρ τοὺς ὀφθαλμοὺς ἐνόσουν, τότε καὶ σκεύη διάφορα καὶ χρήματα ἔϐλεπον ἐν τῇ οἰκίᾳ μου· νυνὶ δὲ ὅτε αὐτὸς φάσκει βλέπειν με, οὐδὲν δύναμαι ἄρτι θεάσασθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ οἱ πονηροὶ τῶν ἀνθρώπων διὰ πλεονεξίαν λανθάνουσι καθ’ ἐαυτῶν τὸν ἔλεγχον ἐπισπώμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 46 Cb 33 Cd 33 Ce 32 Cf 36 Ch 40 Ma 160 Md 38 Mh 33 Mi 73 Mm 43.</p>
+          <bibl>Codd. Ca 46 Cb 33 Cd 33 Ce 32 Cf 36 Ch 40 Ma 160 Md 38 Mh 33 Mi 73 Mm 43.</bibl>
         </div>
         <div>
           <head>Chambry 87.3</head>
@@ -2629,7 +2628,7 @@
           <pb ed="perry" n="P57"/>
           <p><milestone unit="recitprose"/>Γυνὴ πρέσϐις τοὺς ὀφθαλμοὺς νοσοῦσα ἰατρὸν ἐπὶ μισθῷ παρεκάλεσε θεραπεῦσαι αὐτήν, ἐνώπιον μαρτύρων εἰποῦσα ὅτι « ἐὰν θεραπευθῶ τοὺς ὀφθαλμούς μου, πολὺν λήψῃ παρ’ ἐμοῦ τὸν μισθόν· ἐὰν δὲ μὴ θεραπευθῶ, ἀλλ’ ἐπιμείνω τῇ ἀρρωστίᾳ, οὐδὲν ἀποδώσω σοι. » Οὕτως οὖν ὁ ἰατρὸς τοὺς ὀφθαλμοὺς αὐτῆς θεραπεύων κατ’ ὀλίγον ὀλίγον τὰ προσόντα αὐτῇ ἔκλεπτε. Μετ’ οὐ πολὺ δὲ θεραπεύσας αὐτὴν ἐξῄτει τὸν συμφωνηθέντα μισθόν. Ἀναϐλέψασα τοίνυν ἡ γραῦς οὐδὲν τῶν προσόντων αὐτῇ ἐν τῇ οἰκίᾳ ἐθεάσατο. Ὡς οὖν ὁ ἰατρὸς ἐκείνην ἠνώχλει, ἡ δὲ ἀνεϐάλλετο, ἀπήγαγεν αὐτὴν εἰς τοὺς δικαστάς. Σταθεῖσα δὲ ἡ γραῦς ἐνώπιον πάντων εἶπεν· « Ἀληθῶς λέγει οὗτος ὁ ἄνθρωπος· ἐπηγγειλάμην γὰρ αὐτῷ δοῦναι μισθόν, ἐὰν καλῶς βλέψω· εἰ δὲ ἐπιμείνω τῇ ἀρρωστίᾳ, μηδὲν αὐτῷ ἀποδώσειν. Νῦν δὲ αὐτὸς μετὰ &lt;ταῦτά&gt; φησι θεραπευθῆναί με· ἐγὼ δέ φημι τὸ ἐναντίον παθεῖν. Ὅτε γὰρ ἐνόσουν τοὺς ὀφθαλμούς, τότε καὶ σκεύη διάφορα καὶ χρήματα ὑπῆρχον ἐν τῇ οἰκίᾳ μου, καὶ ταῦτα ἑώρων· νῦν δὲ οὐ δύναμαι ταῦτα βλέπειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτως οἱ πονηροὶ τῶν ἀνθρώπων λανθάνουσι διὰ πλεονεξίαν καθ’ ἐαυτῶν τὸν ἔλεγχον ἐπισπώμενοι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 39.</p>
+          <bibl>Cod. Mk 39.</bibl>
         </div>
         <div>
           <head>Chambry 87.4</head>
@@ -2637,7 +2636,7 @@
           <pb ed="perry" n="P57"/>
           <p><milestone unit="recitprose"/>Γυνὴ γραῦς ἀλγοῦσα τοὺς ὀφθαλμοὺς εἰσκαλεῖταί τινα τῶν ἰατρῶν ἐπὶ μισθῷ, συμφωνήσασα ὡς, εἰ μὲν θεραπεύσειεν αὐτήν, τὸν ὁμολογηθέντα μισθὸν αὐτῷ δώσειν, εἰ δὲ μή, μηδὲν δώσειν. Ἐνεχείρησε μὲν οὖν ὁ ἰατρὸς τῇ θεραπείᾳ· καθ’ ἡμέραν δὲ φοιτῶν ὡς τὴν πρεσϐῦτιν καὶ τοὺς ὀφθαλμοὺς αὐτῇ χρίων, ἐκείνης μηδαμῶς ἀναϐλέπειν ἐχούσης τὴν ὥραν ἐκείνην ὑπὸ τοῦ χρίσματος, αὐτὸς ἕν τι τῶν τῆς οἰκίας σκευῶν ὑφαιρούμενος ὁσημέραι ἀπῄει. Ἡ μὲν οὖν γραῦς τὴν ἑαυτῆς περιουσίαν ἑώρα καθ’ ἑκάστην ἐλαττουμένην ἐπὶ τοσοῦτον ὡς καὶ τέλος παντάπασιν αὐτῇ θεραπευθείσῃ μηδὲν ὑπολειφθῆναι. Τοῦ δ’ ἰατροῦ τοὺς συμφωνηθέντας μισθοὺς αὐτὴν ἀποιτοῦντος, ὡς καθαρῶς βλέπουσαν ἤδη, καὶ τοὺς μάρτυρας παραγαγόντος· « Μᾶλλον μὲν οὖν, εἶπεν ἐκείνη, τὰ νῦν οὐδ’ ὁτιοῦν βλέπω· ἡνίκα μὲν γὰρ τοὺς ὀφθαλμοὺς ἐνόσουν, πολλὰ τῶν ἐμῶν κατὰ τὴν ἐμαυτῆς ἔϐλεπον οἰκίαν· νῦν δ’ ὅτε με σὺ βλέπειν φῇς, οὐδ’ ὁτιοῦν ἐκείνων ὁρῶ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πονηροὶ τῶν ἀνθρώπων ἐξ ὧν πράττουσι λανθάνουσι καθ’ ἑαυτῶν τὸν ἔλεγχον ἐπισπώμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 21 Lb 26 Le 26 Lf 21 Me 33 Mg 33 Mj 31 Ml 35.</p>
+          <bibl>Codd. La 21 Lb 26 Le 26 Lf 21 Me 33 Mg 33 Mj 31 Ml 35.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-88">
@@ -2646,7 +2645,7 @@
         <pb ed="perry" n="P246"/>
         <p><milestone unit="recitprose"/>Γυνή τις ἄνδρα μέθυσον εἶχε· τοῦ δὲ πάθους αὐτὸν ἀπαλλάξαι θέλουσα τοιόνδε τι σοφίζεται. Κεκαρωμένον γὰρ αὐτὸν ὑπὸ τῆς μέθης παρατηρήσασα καὶ νεκροῦ δίκην ἀναισθητοῦντα ἐπ’ ὤμων ἄρασα ἐπὶ τὸ πολυάνδριον ἀπενεγκοῦσα κατέθετο καὶ ἀπῆλθεν. Ἡνίκα δ’ αὐτον ἤδη ἀνανήφειν ἐστοχάσατο, προσελθοῦσα τὴν θύραν ἔκοπτε τοῦ πολυανδρίου. Ἐκείνου δὲ φήσαντος· « Τίς ὁ τὴν θύραν κόπτων ; » ἡ γυνὴ ἀπεκρίνατο· « Ὁ τοῖς νεκροῖς τὰ σιτία κομίζων ἐγὼ πάρειμι. » Κἀκεῖνος· « Μή μοι φαγεῖν, ἀλλὰ πιεῖν, ὦ βέλτιστε, μᾶλλον προσένεγκε· λυπεῖς γάρ με βρώσεως, ἀλλὰ μὴ πόσεως μνημονεύων. » Ἡ δὲ τὸ στῆθος πατάξασα· « Οἴμοι τῇ δυστήνῳ, φησίν· οὐδὲν γὰρ οὐδὲ σοφισαμένη ὤνησα· σὺ γάρ, ἄνερ, οὐ μόνον οὐκ ἐπαιδεύθης, ἀλλὰ καὶ χείρων σαυτοῦ γέγονας, εἰς ἕξιν σοι καταστάντος τοῦ πάθους. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ ταῖς κακαῖς πράξεσιν ἐγχρονίζειν. Ἔστι γὰρ ὅτε καὶ μὴ θέλοντι τῷ ἀνθρώπῳ τὸ ἔθος ἐπιτίθεται.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 74 Lb 30 Le 30 Lf 74 Lh 14 Md 128 Me 37 Mg 35 Mi 102 Mj 35 Ml 46 Mm 48.</p>
+        <bibl>Codd. La 74 Lb 30 Le 30 Lf 74 Lh 14 Md 128 Me 37 Mg 35 Mi 102 Mj 35 Ml 46 Mm 48.</bibl>
         <p><milestone unit="traduction"/>Une femme avait un ivrogne pour mari. Pour le défaire de son vice, elle imagina l’artifice que voici. Elle observa le moment où son mari engourdi par l’ivresse était insensible comme un mort, le chargea sur ses épaules, l’emporta au cimetière, le déposa et se retira. Quand elle jugea qu’il avait cuvé son vin, elle revint et frappa à la porte du cimetière : « Qui frappe à la porte ? » dit l’ivrogne. « C’est moi qui viens apporter à manger aux morts », répondit la femme. Et lui : « Ne m’apporte pas à manger, mon brave, apporte-moi plutôt à boire : tu me fais de la peine en me parlant de manger, non de boire. » La femme, se frappant la poitrine s’écria : « Hélas ! que je suis malheureuse ! ma ruse même n’a fait aucun effet sur toi, mon homme ; car non seulement tu n’es pas assagi, mais encore tu es devenu pire, et ton défaut est devenu une seconde nature. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas s’invétérer dans la mauvaise conduite ; car il vient un moment où, bon gré, mal gré, l’habitude s’impose à l’homme.</p>
       </div>
@@ -2658,7 +2657,7 @@
           <pb ed="perry" n="P55"/>
           <p><milestone unit="recitprose"/>Γυνὴ χήρα φίλεργος θεραπαινίδας ἔχουσα, ταύτας εἰώθει νυκτὸς ἐπὶ τὰ ἔργα ἐγείρειν πρὸς ἀλεκτροφωνίαν. Αἱ δὲ συνεχῶς καταπονούμεναι ἔγνωσαν δεῖν τὸν ἐπὶ τῆς οἰκίας ἀλέκτορα ἀποπνίξαι· ἐκεῖνον γὰρ ᾤοντο τῶν κακῶν αἴτιον εἶναι νύκτωρ ἐγείροντα τὴν δέσποιναν. Συνέϐη δὲ αὐταῖς πραξάσαις τοῦτο χαλεπωτέροις τοῖς δεινοῖς περιπεσεῖν· ἡ γὰρ δέσποινα ἀγνοοῦσα τὴν τῶν ἀλεκτρυόνων ὥραν νυχιέστερον ἐπὶ τὸ ἔργον ἤγειρεν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοῖς ἀνθρώποις τὰ ἴδια βουλεύματα κακῶν αἴτια γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 55 Pb 55 Pc 26 Pf 27 Pg 32 Ph 27 Ca 44 Ma 39 Mb 28.</p>
+          <bibl>Codd. Pa 55 Pb 55 Pc 26 Pf 27 Pg 32 Ph 27 Ca 44 Ma 39 Mb 28.</bibl>
           <p><milestone unit="traduction"/>Une veuve laborieuse avait de jeunes servantes qu’elle éveillait la nuit au chant du coq pour les mettre au travail. Celles-ci, continuellement exténuées de fatigue, décidèrent de tuer le coq de la maison ; car, à leurs yeux, c’était lui qui causait leur malheur en éveillant leur maîtresse avant le jour. Mais, quand elles eurent exécuté ce dessein, il se trouva qu’elles avaient aggravé leur malheur ; car la maîtresse, à qui le coq n’indiquait plus l’heure, les faisait lever de plus grand matin pour les faire travailler.</p>
           <p><milestone unit="traduction"/>Cette fable montre que pour beaucoup de gens ce sont leurs propres résolutions qui sont causes de leurs malheurs.</p>
         </div>
@@ -2668,7 +2667,7 @@
           <pb ed="perry" n="P55"/>
           <p><milestone unit="recitprose"/>Γυνὴ χήρα φίλεγρος θεραπαινίδας ἔχουσα, ταύτας εἰώθει νυκτὸς ἐγείρειν ἐπὶ τὰ ἔργα πρὸς τὰς τῶν ἀλεκτρυόνων ᾠδάς. Αἱ δὲ συνεχῶς τῷ πόνῳ ταλαιπωρούμεναι ἔγνωσαν δεῖν τὸν ἐπὶ τῆς οἰκίας ἀποκτεῖναι ἀλεκτρυόνα, ὡς ἐκείνου νύκτωρ ἐξανιστάντος τὴν δέσποιναν. Συνέϐη δ’ αὐταῖς τοῦτο διαπραξαμέναις χαλεπωτέροις περιπεσεῖν τοῖς δεινοῖς. Ἡ γὰρ δεσπότις, ἀγνοοῦσα τὴν τῶν ἀλεκτρυόνων ὥραν, ἔννυχώτερον ταύτας ἀνίσπη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοῖς ἀνθρώποις τὰ βουλεύματα κακῶν αἴτια γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 83 Lb 32 Lc 32 Le 32 Lf 83 Lg 32 Md 136 Me 39 Mf 34 Mg 41 Mi 110 Mj 37 Ml 44 Mm 50 Ce 37 Cf 41.</p>
+          <bibl>Codd. La 83 Lb 32 Lc 32 Le 32 Lf 83 Lg 32 Md 136 Me 39 Mf 34 Mg 41 Mi 110 Mj 37 Ml 44 Mm 50 Ce 37 Cf 41.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-90">
@@ -2679,7 +2678,7 @@
           <pb ed="perry" n="P58"/>
           <p><milestone unit="recitprose"/>Γυνὴ χήρα ὄρνιν ἔχουσα καθ’ ἑκάστην ἡμέραν ὠὸν τίκτουσαν ὑπέλαϐεν ὅτι, ἐὰν πλείονα αὐτῇ τροφὴν παραϐάλῃ, καὶ δὶς τῆς ἡμέρας τέξεται. Καὶ δὴ τοῦτο αὐτῆς ποιησάσης, συνέϐη τὴν ὄρνιν πίονα γενομένην μηκέτι μηδὲ ἅπαξ τεκεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τινὲς τῶν ἀνθρώπων διὰ πλεονεξίαν περιττοτέρων ἐπιθυμοῦντες καὶ τὰ παρόντα ἀπολλῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 58 Pb 58 Pc 28 Pd 31 Pg 35 Ma 40 Mb 30.</p>
+          <bibl>Codd. Pa 58 Pb 58 Pc 28 Pd 31 Pg 35 Ma 40 Mb 30.</bibl>
         </div>
         <div>
           <head>Chambry 90.2</head>
@@ -2687,7 +2686,7 @@
           <pb ed="perry" n="P58"/>
           <p><milestone unit="recitprose"/>Γυνὴ χήρα ὄρνιν εἶχε καθ’ ἑκάστην ἡμέραν ὠὸν τίκτουσαν. Ὑπέλαϐε δὲ ἡ γυνὴ ὅτι, ἐὰν πλείονας κριθὰς δώσει τῇ ὄρνιθι, τέξεται δὶς τῆς ἡμέρας. Ἡ δὲ τοῦτο ποιήσασα, καὶ λιπαρᾶς τῆς ὄρνιθος γενομένης, οὐδὲ τὸ ἅπαξ ἔτικτεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ τῶν ἀνθρώπων διὰ πλεονεξίαν περισσοτέρων ἐπιθυμοῦντες καὶ τὰ προσόντα ἀπώλεσαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 47 Cb 36 Ce 35 Cf 39 Ch 43 Mh 36.</p>
+          <bibl>Codd. Ca 47 Cb 36 Ce 35 Cf 39 Ch 43 Mh 36.</bibl>
         </div>
         <div>
           <head>Chambry 90.3</head>
@@ -2695,7 +2694,7 @@
           <pb ed="perry" n="P58"/>
           <p><milestone unit="recitprose"/>Γυνή τις χήρα ὄρνιν εἶχε καθ’ ἑκάστην ἡμέραν ὠὸν αὐτῇ τίκτουσαν. Νομίσασα δὲ ὡς, εἰ πλείους τῇ ὄρνιθι κριθὰς παραϐάλλοι, δὶς τέξεται τῆς ἡμέρας, τοῦτο πεποίηκεν. Ἡ δ’ ὄρνις πιμελὴς γενομένη οὐδ’ ἅπαξ τῆς ἡμέρας τεκεῖν ἠδύνατο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ διὰ πλεονεξίαν τῶν πλειόνων ἐπιθυμοῦντες καὶ τὰ παρόντα ἀποϐάλλουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 24 Lb 28 Lc 12 Ld 15 Le 28 Lf 24 Lg 12 Md 41 Me 35 Mf 32 Mi 76 Mj 33 Mk 38 Ml 37 Mm 46 Mn 15.</p>
+          <bibl>Codd. La 24 Lb 28 Lc 12 Ld 15 Le 28 Lf 24 Lg 12 Md 41 Me 35 Mf 32 Mi 76 Mj 33 Mk 38 Ml 37 Mm 46 Mn 15.</bibl>
           <p><milestone unit="traduction"/>Une femme veuve avait une poule qui lui pondait tous les jours un œuf. Elle s’imagina que si elle lui donnait plus d’orge, sa poule pondrait deux fois par jour, et elle augmenta en effet sa ration. Mais la poule devenue grasse ne fut même plus capable de pondre une fois le jour.</p>
           <p><milestone unit="traduction"/>Cette fable montre que, lorsqu’on cherche par cupidité à avoir plus que l’on n’a, on perd même ce qu’on possède.</p>
         </div>
@@ -2708,7 +2707,7 @@
           <pb ed="perry" n="P56"/>
           <p><milestone unit="recitprose"/>Γυνὴ μάγος ἐπῳδὰς καὶ θείων καταθέσεις μηνιμάτων ἐπαγγελλομένη διετέλει πολλὰ τελοῦσα καὶ ἐκ τούτων οὐ μικρὰ βιοποριστοῦσα. Ἐπὶ τούτοις ἐγγραφόμενοί τινες αὐτὴν ὡς καινοτομοῦσαν περὶ τὰ θεῖα, εἰς δίκην ἀπήγαγον καὶ κατηγορήσαντες κατεδίκασαν αὐτὴν ἐπὶ θανάτῳ. Θεασάμενος δέ τις αὐτὴν ἀπαγομένην ἐκ τῶν δικαστηρίων ἔφη· « Ὦ αὕτη, ἡ τὰς δαιμόνων ὀργὰς ἀποτρέπειν ἐπαγγελλομένη, πῶς οὐδὲ ἀνθρώπους πεῖσαι ἠδυνήθης ; »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς γυναῖκα πλάνον, ἥτις τὰ μείζονα κατεπαγγελλομένη τοῖς μετρίοις ἀδύνατος ἐλέγχεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 56 Pb 56 Pc 27 Pf 28 Pg 33 Ph 28 Me 40 Mf 35 Ca 45.</p>
+          <bibl>Codd. Pa 56 Pb 56 Pc 27 Pf 28 Pg 33 Ph 28 Me 40 Mf 35 Ca 45.</bibl>
           <p><milestone unit="traduction"/>Une magicienne faisait profession de fournir des charmes et des moyens d’apaiser la colère des dieux. Elle ne manquait jamais de pratique et gagnait ainsi largement sa vie. Mais on l’accusa à ce propos d’innover en matière de religion, on la traduisit en justice, et ses accusateurs la firent condamner à mort. En la voyant emmener du tribunal, un quidam lui dit : « Hé ! la femme, toi qui te faisais fort de détourner la colère des dieux, comment n’as-tu même pas pu persuader des hommes ? »</p>
           <p><milestone unit="traduction"/>Cette fable s’appliquerait bien à une gipsy qui promet des merveilles et se montre incapable des choses ordinaires.</p>
         </div>
@@ -2718,7 +2717,7 @@
           <pb ed="perry" n="P56"/>
           <p><milestone unit="recitprose"/>Γυνὴ μάγος καὶ θείων μηνιμάτων ἀποτροπιασμοὺς ἐπαγγελλομένη πολλὰ διετέλει ποιοῦσα καὶ κέρδος ἐντεῦθεν ἔχουσα. Γραψάμενοι δέ τινες αὐτὴν ἀσεϐείας εἷλον καὶ καταδικασθεῖσαν ἀπῆγον εἰς θάνατον. Ἰδὼν δέ τις ἀπαγομένην αὐτὴν, ἔφη· « Ἡ τὰς τῶν θεῶν ὀργὰς ἀποτρέπειν ἐπαγγελλομένη, πῶς οὐδὲ ἀνθρώπων βουλὴν μεταπεῖσαι ἠδυνήθης ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ μεγάλα ἐπαγγέλλονται, μηδὲ μικρὰ ποιῆσαι δυνάμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 84 Lb 33 Le 33 Lf 84 Md 137 Mg 42 Mi 111 Mj 38 Ml 41 Mm 51 Ce 36 Cf 40.</p>
+          <bibl>Codd. La 84 Lb 33 Le 33 Lf 84 Md 137 Mg 42 Mi 111 Mj 38 Ml 41 Mm 51 Ce 36 Cf 40.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-92">
@@ -2729,7 +2728,7 @@
           <pb ed="perry" n="P300"/>
           <p><milestone unit="recitprose"/>Δάμαλις βοῦν ὁρῶσα ἐργαζόμενον ἐταλάνιζεν αὐτὸν ἐπὶ τῷ κόπῳ. Ἐπειδὴ δὲ ἑορτὴ κατέλαϐε, τὸν βοῦν ἀπολύσαντες, τὴν δάμαλιν ἐκράτησαν τοῦ σφάξαι. Ἰδὼν δὲ ὁ βοῦς ἐμειδίασε καὶ πρὸς αὐτὴν εἶπεν· « Ὦ δάμαλις, διὰ τοῦτο ἤργεις διότι ἔμελλες ἀρτίως τυθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τὸν ἀργοῦντα κίνδυνος μένει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 61 Cb 42 Cd 38 Ce 44 Cf 48 Ch 49 Ma 163 Md 47 Mh 42 Mi 82 Mk 45 Ml 53 Mm 59.</p>
+          <bibl>Codd. Ca 61 Cb 42 Cd 38 Ce 44 Cf 48 Ch 49 Ma 163 Md 47 Mh 42 Mi 82 Mk 45 Ml 53 Mm 59.</bibl>
           <p><milestone unit="traduction"/>Une génisse, voyant un bœuf au travail, le plaignait de sa peine. Mais une solennité religieuse étant arrivée, on détela le bœuf et l’on s’empara de la génisse pour l’égorger. À cette vue le bœuf sourit et lui dit : « Ô génisse, voilà pourquoi tu n’avais rien à faire : on te destinait à être immolée bientôt. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que le danger guette l’oisif.</p>
         </div>
@@ -2739,7 +2738,7 @@
           <pb ed="perry" n="P300"/>
           <p><milestone unit="recitprose"/>Δάμαλις ἀγύμναστος βοῦν ἀροτριῶντα ἐταλάνιζε τοῦ κόπου, λέγουσα· « Ὢ πόσα κάμνεις καὶ ταλαιπωρεῖς. » Ὁ βοῦς δὲ ἐσίγα καὶ τὴν αὔλακα ἔτεμνεν. Ἐπεὶ δὲ οἱ ἀγρόται τοῖς θεοῖς ἤθελον θύειν, ὁ μὲν γέρων βοῦς ἀποζευχθεὶς εἰς νομὴν ἀπελύθη· ὁ δὲ μόσχος σχοινίῳ εἵλκετο ἐπὶ τὸ τυθῆναι. Ὁ δὲ βοῦς εἶπεν αὐτῷ· « Εἰς τοῦτο μὴ κάμνων ἐτηρήθης καί σου τὸν τράχηλον μάχαιρα, οὐ ζυγὸς τρίψει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τῷ ἐργαζομένῳ καὶ πονοῦντι ἔπαινος πρόσεστι, τῷ δὲ ἀργῷ κίνδυνος καὶ μάστιγες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 24 Bb 15 Mg 48.</p>
+          <bibl>Codd. Ba 24 Bb 15 Mg 48.</bibl>
         </div>
         <div>
           <head>Chambry 92.3</head>
@@ -2747,14 +2746,14 @@
           <pb ed="perry" n="P300"/>
           <p><milestone unit="recitprose"/>Δάμαλις ἔτι ἀγύμναστος βοῦν ἀροτριῶντα διὰ τὸν κόπον ὠνείδιζε λέγουσα· « Ὦ πόσα κάμνεις καὶ ταλαιπωρεῖς. » Ὁ δὲ τοῦ οἰκείου ἔργου ἐχόμενος ἐσιώπα. Ἑορτὴν δὲ τῶν γηπόνων τοῖς θεοῖς ἐκτελούντων ποτέ, ὁ ἀρότης μέν βοῦς τοῦ καμάτου ἀπολυθεὶς τοῖς χλοηφόροις ἐνετρύφα πεδίοις· ὁ δὲ μόσχος φραγελλωθεὶς τῷ βωμῷ τυθῆναι ἐσύρετο. Τότε οὖν ὁ βοῦς εἰρήκει αὐτῷ· « Οἶμαι ὅτι εἰς τοῦτο διετηοήθης ἀεργός, ἵνα ἐς ὕστερον ἀντὶ δουλείας ζυγοῦ τὴν μάχαιραν ὑπηρετήσῃς, τῇ χρονίᾳ ἀνέσει καλῶς ἐκτραφείς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τῷ ἐνεργοῦντι καὶ ἐργαζομένῳ ἔπαινοι, τῷ ἀεργῷ δὲ κίνδυνοι καὶ μάστιγες.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 19.</p>
+          <bibl>Cod. Bc 19.</bibl>
         </div>
         <div>
           <head>Chambry 92.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P300"/>
           <p><milestone unit="recitprose"/>Ἀγύμναστος δάμαλις ἀροτριῶντα βοῦν ἐταλάνιζε, λέγουσα· « Ὦ ταλαίπωρε, πότε τῶν ἀπεράντων κόπων καὶ τῆς ταλαιπωρίας ταύτης ἐλευθερωθήσῃ ; » Ὁ δὲ βοῦς ἐσίγα καὶ τὴν αὔλακα ἔτεμνε. Ἐπεὶ δὲ ὁ δεσπότης αὐτῶν θύειν τοῖς θεοῖς ἐϐεϐούλευτο, τὸν μὲν ἐργάτην βοῦν ἀπέλυσεν εἰς νομάς, τὴν δὲ δάμαλιν σχοινίοις δήσας πρὸς τὸν βωμὸν εἷλκεν ἄκουσαν. Ἐπιστραφεὶς δὲ ὁ βοῦς καὶ γελάσας εἶπεν· « Ὦ τάλαινα, ταῦτά σοι ἡ ἄνεσις προεξένησεν, κἀμοῦ μὲν ὁ ζυγός, σοῦ δὲ ἡ μάχαιρα τρίψει τὸν τράχηλον. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 8.</p>
+          <bibl>Cod. Bd 8.</bibl>
         </div>
         <div>
           <head>Chambry 92.5</head>
@@ -2774,7 +2773,7 @@
           <l><milestone unit="recitvers"/>ἀντὶ γὰρ ζυγοῦ τὸν τράχηλόν σου τρίψει</l>
           <l><milestone unit="recitvers"/>μάχαιρα, φημί, καὶ καταθύσει πάλιν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι τῷ ἐργαζομένῳ ἔπαινος ἔσται, τῷ δὲ ἀργοῦντι κίνδυνος καὶ μάστιξ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 39.</p>
+          <bibl>Cod. Mb 39.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-93">
@@ -2783,7 +2782,7 @@
         <pb ed="perry" n="P326"/>
         <p><milestone unit="recitprose"/>Λέοντός τις κυνηγὸς ἴχνη ἐπεζήτει· δρυτόμον δὲ ἐρωτήσας εἰ εἶδεν ἴχνη λέοντος καὶ ποῦ κοιτάζει, ἐφη· « Καὶ αὐτὸν τὸν λέοντά σοι ἤδη δείξω. » Ὁ δὲ ὠχριάσας ἐκ τοῦ φόϐου καὶ τοὺς ὀδόντας συγκρούων εἶπεν· « Ἴχνη μόνα ζητῶ, οὐχὶ αὐτὸν τὸν λέοντα. »</p>
         <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς θρασεῖς καὶ δειλοὺς ὁ μῦθος ἐλέγχει, τοὺς τολμηροὺς ἐν τοῖς λόγοις καὶ οὐκ ἐν τοῖς ἔργοις.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 79 Bb 49.</p>
+        <bibl>Codd. Ba 79 Bb 49.</bibl>
         <p><milestone unit="traduction"/>Un chasseur cherchait la piste d’un lion. Il demanda à un bûcheron s’il avait vu des pas de lion et où gîtait la bête. « Je vais, répondit le bûcheron, te montrer le lion lui-même. » Le chasseur devint blême de peur, et, claquant des dents, il dit : « C’est la piste seulement que je cherche, et non le lion lui-même. »</p>
         <p><milestone unit="traduction"/>Cette fable apprend à reconnaître les gens hardis et lâches, j’entends hardis en paroles et lâches en actions.</p>
       </div>
@@ -2795,7 +2794,7 @@
           <pb ed="perry" n="P85"/>
           <p><milestone unit="recitprose"/>Ἔν τινι ποίμνῃ προϐάτων δέλφαξ εἰσελθὼν ἐνέμετο. Καὶ δή ποτε τοῦ ποιμένος συλλαμϐάνοντος αὐτόν, ἐκεκράγει τε καὶ ἀντέτεινε. Τῶν δὲ προϐάτων αἰτιωμένων αὐτὸν ἐπὶ τῷ βοᾶν καὶ λεγόντων· « Ἡμᾶς μὲν συνεχῶς συλλαμϐάνει καὶ οὐ κράζομεν, » ἔφη πρὸς ταῦτα· « Ἀλλ’ οὐχ ὁμοία γε τῇ ὑμετέρᾳ ἡ ἐμὴ σύλληψις· ὑμᾶς γὰρ ἢ διὰ τὰ ἔρια ἀγρεύει ἢ διὰ τὸ γάλα, ἐμὲ δὲ διὰ τὰ κρέα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι εἰκότως ἐκεῖνοι ἀνοιμώζουσιν οἷς ὁ κίνδυνος οὐ περὶ χρημάτων ἐστίν, ἀλλα περὶ σωτηρίας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 82 Pb 86 Pc 44 Pe 50 Ma 65 Mb 50 Ca 72.</p>
+          <bibl>Codd. Pa 82 Pb 86 Pc 44 Pe 50 Ma 65 Mb 50 Ca 72.</bibl>
           <p><milestone unit="traduction"/>Un cochon s’étant mêlé à un troupeau de moutons paissait avec eux. Or un jour le berger s’empara de lui ; alors il se mit à crier et à regimber. Comme les moutons le blâmaient de crier et lui disaient : « Nous, il nous empoigne constamment, et nous ne crions pas », il répliqua : « Mais quand il nous empoigne, vous et moi, ce n’est pas dans la même vue ; car vous, c’est pour votre laine ou votre lait qu’il vous empoigne ; mais moi, c’est pour ma chair. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux-là ont raison de gémir qui sont en risque de perdre, non leur argent, mais leur vie.</p>
         </div>
@@ -2805,7 +2804,7 @@
           <pb ed="perry" n="P85"/>
           <p><milestone unit="recitprose"/>Ὄνῳ τις ἐπιθεὶς αἶγα καὶ πρόϐατον καὶ δέλφακα ἤλαυνεν εἰς ἄστυ. Τοῦ δὲ δέλφακος παρ’ ὅλην τὴν ὁδὸν κεκραγότος, ἀλώπηξ ἀκούσασα ἐπυνθάνετο αὐτοῦ τὴν αἰτίαν δι’ ἥν, τῶν λοιπῶν μεθ’ ἡσυχίας φερομένων, αὐτὸς μόνος βοᾷ. Ὁ δὲ ὑποτυχὼν εἶπεν· « Ἀλλ’ ἔγωγε οὐ μάτην ὀδύρομαι· εὖ γὰρ οἶδα ὅτι τοῦ μὲν προϐάτου ἔρια τε καὶ ἄρνας παρεχομένου ὁ δεσπότης ἀφέξεται· ὁμοίως δὲ καὶ τῆς αἰγὸς διὰ τοὺς τυροὺς καὶ τοὺς ἐρίφους· ἐμοὶ δὲ οὐκ ἔχων εἰς ἄλλο τι χρήσασθαι, πάντως θῦσαί με θέλει καὶ φαγεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οὐ μεμπτέοι εἰσὶν ὅσοι τὰς μελλούσας προορώμενοι συμφορὰς ἀποκλαίονται ἑαυτούς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 177 Pb 174 Pf 97 Mb 149 Me 124 Mf 104 Mj 114 Ca 131.</p>
+          <bibl>Codd. Pa 177 Pb 174 Pf 97 Mb 149 Me 124 Mf 104 Mj 114 Ca 131.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-95">
@@ -2816,7 +2815,7 @@
           <pb ed="perry" n="P62"/>
           <p><milestone unit="recitprose"/>Δελφῖνες καὶ φάλαιναι πρὸς ἀλλήλους ἐμάχοντο. Ἐπὶ πολὺ δὲ τῆς διαφορᾶς σφοδρυνομένης, κωϐιὸς ἀνέδυ (ἐστὶ δὲ οὗτος μικρὸς ἰχθύς) καὶ ἐπειρᾶτο αὐτοὺς διαλύειν. Εἷς δέ τις τῶν δελφίνων ὑποτυχὼν ἔφη τρὸς αὐτόν· « Ἀλλ’ ἡμῖν ἀνεκτότερόν ἐστι μαχομένους ὑπ’ ἀλλήλων διαφθαρῆναι ἢ σοῦ διαλλακτοῦ τυχεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων οὐδενὸς ἄξιοι ὄντες, ὅταν ταραχῆς λάϐωνται, δοκοῦσί τινες εἶναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 60 Pb 72 Pc 29 Pg 39 Ca 53.</p>
+          <bibl>Codd. Pa 60 Pb 72 Pc 29 Pg 39 Ca 53.</bibl>
           <p><milestone unit="traduction"/>Des dauphins et des baleines se livraient bataille. Comme la lutte se prolongeait et devenait acharnée, un goujon (c’est un petit poisson) s’éleva à la surface et essaya de les réconcilier. Mais un des dauphins prenant la parole lui dit : « Il est moins humiliant pour nous de combattre et de périr les uns par les autres que de t’avoir pour médiateur. »</p>
           <p><milestone unit="traduction"/>De même certains hommes qui n’ont aucune valeur, s’ils tombent sur un temps de troubles publics, s’imaginent qu’ils sont des personnages.</p>
         </div>
@@ -2826,7 +2825,7 @@
           <pb ed="perry" n="P62"/>
           <p><milestone unit="recitprose"/>Δελφῖνες καὶ φάλαιναι πρὸς ἀλλήλους ἐμάχοντο. Ἐπὶ πολὺ δὲ τῆς στάσεως αὐτῶν σφοδρυνομένης, καρὶς ἀναδῦσα ἐπειρᾶτο αὐτοὺς διαλύειν. Εἷς δέ τις τῶν δελφίνων ὑποτυχὼν ἔφη πρὸς αὐτήν· « Ἀλλ’ ἡμῖν αἱρετώτερόν ἐστιν ὑπ’ ἀλλήλων διαφθαρῆναι ἢ σοῦ διαλλακτοῦ τυχεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων οὐδενὸς ἄξιοι ὄντες, ἂν ταραχῆς λάϐωνται, δοκοῦσί τινες εἶναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 29 Ph 30 Mj 47.</p>
+          <bibl>Codd. Pf 29 Ph 30 Mj 47.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-96">
@@ -2835,7 +2834,7 @@
         <pb ed="perry" n="P63"/>
         <p><milestone unit="recitprose"/>Δημάδης ὁ ῥήτωρ δημηγορῶν ποτε ἐν Ἀθήναις, ἐκείνων μὴ πάνυ τι αὐτῷ προσεχόντων, ἐδεήθη αὐτῶν ὅπως ἐπιτρέψωσιν αὐτῷ Αἰσώπειον μῦθον εἰπεῖν. Τῶν δὲ συγχωρησάντων αὐτῷ, ἀρξάμενος ἔλεγε· « Δήμητρα καὶ χελιδὼν καὶ ἔγχελυς τὴν αὐτὴν ὁδὸν ἐϐάδιζον· γενομένων δὲ αὐτῶν κατά τινα ποταμόν, ἡ μὲν χελιδὼν ἔπτη, ἡ δὲ ἔγχελυς κατέδυ· » καὶ ταῦτα εἰπὼν ἐσιώπησεν. Ἐρομένων δὲ αὐτῶν· « Ἡ οὖν Δήμητρα τί ἔπαθεν ; » ἔφη· « Κεχόλωται ὑμῖν, οἵτινες τὰ τῆς πόλεως πράγματα ἐάσαντες Αἰσωπείων μύθων ἀντέχεσθε. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἀλόγιστοί εἰσιν ὅσοι τῶν μὲν ἀναγκαίων ὀλιγωροῦσι, τὰ δὲ πρὸς ἡδονὴν μᾶλλον αἱροῦνται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 61 Pb 63 Pc 30 Pg 40 Ma 44 Ca 54.</p>
+        <bibl>Codd. Pa 61 Pb 63 Pc 30 Pg 40 Ma 44 Ca 54.</bibl>
         <p><milestone unit="traduction"/>L’orateur Démade parlait un jour au peuple d’Athènes. Comme on ne prêtait pas beaucoup d’attention à son discours, il demanda qu’on lui permît de conter une fable d’Ésope. La demande accordée, il commença ainsi : « Déméter, l’hirondelle et l’anguille faisaient route ensemble ; elles arrivèrent au bord d’une rivière ; alors l’hirondelle s’éleva dans les airs, l’anguille plongea dans les eaux », et là-dessus il s’arrêta de parler. « Et Déméter, lui cria-t-on, que fit-elle ? — Elle se mit en colère contre vous, répondit-il, qui négligez les affaires de l’état, pour vous attacher à des fables d’Ésope. »</p>
         <p><milestone unit="traduction"/>Ainsi parmi les hommes ceux-là sont déraisonnables qui négligent les choses nécessaires et préfèrent celles qui leur font plaisir.</p>
       </div>
@@ -2844,7 +2843,7 @@
         <head type="sub">Διογένης καὶ φαλακρός — Diogène et le chauve.</head>
         <pb ed="perry" n="P248"/>
         <p><milestone unit="recitprose"/>Διογένης ὁ κυνικὸς φιλόσοφος λοιδορούμενος ὑπό τινος φαλακροῦ εἶπεν· « Ἐγὼ μὲν οὐ λοιδορῶ· μὴ γένοιτο· ἐπαινῶ δὲ τὰς τρίχας ὅτι κρανίου κακοῦ ἀπηλλάγησαν. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Pe 38.</p>
+        <bibl>Cod. Pe 38.</bibl>
         <p><milestone unit="traduction"/>Diogène, le philosophe cynique, insulté par un homme qui était chauve, répliqua : « Ce n’est pas moi qui aurai recours à l’insulte, Dieu m’en garde ! bien au contraire, je loue les cheveux qui ont quitté un méchant crâne. »</p>
       </div>
       <div type="poem" xml:id="chambry-98">
@@ -2853,7 +2852,7 @@
         <pb ed="perry" n="P247"/>
         <p><milestone unit="recitprose"/>Διογένης ὁ κύων ὁδοιπορῶν, ὡς ἐγένετο κατά τινα ποταμὸν πλημμυροῦντα, εἱστήκει πρὸς τῇ βαλϐίδι ἀμηχανῶν. Εἷς δέ τις τῶν διαϐιϐάζειν εἰθισμένων θεασάμενος αὐτὸν διαποροῦντα, προσελθὼν καὶ ἀράμενος αὐτόν, σὺν φιλοφροσύνῃ διεπέρασεν αὐτόν. Ὁ δὲ εἱστήκει τὴν αὑτοῦ πενίαν μεμφόμενος, δι’ ἣν ἀμείψασθαι τὸν εὐεργέτην οὐ δύναται. Ἔτι δὲ αὐτοῦ ταῦτα διανοουμένου, ἐκεῖνος θεασάμενος ἕτερον ὁδοιπόρον διελθεῖν μὴ δυνάμενον, προσδραμὼν καὶ αὐτὸν διεπέρασε. Καὶ ὁ Διογένης προσελθὼν αὐτῷ εἶπεν· « Ἀλλ’ ἔγωγε οὐκέτι σοι χάριν ἔχω ἐπὶ τῷ γεγονότι· ὁρῶ γὰρ ὅτι οὐ κρίσει, ἀλλὰ νόσῳ αὐτὸ ποιεῖς. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι &lt;οἱ&gt; μετὰ τῶν σπουδαίων καὶ τοὺς ἀνεπιτηδείους εὐεργετοῦντες οὐκ εὐεργεσίας δόξαν, ἀλογιστίας δὲ μᾶλλον ὀφλισκάνουσι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 63 Ca 56.</p>
+        <bibl>Codd. Pa 63 Ca 56.</bibl>
         <p><milestone unit="traduction"/>Diogène le Cynique étant en voyage, arriva sur le bord d’une rivière qui coulait à pleins bords, et s’arrêta sur la berge, embarrassé. Un homme qui avait l’habitude de faire passer l’eau, le voyant perplexe, s’approcha, le prit sur ses épaules, et le transporta complaisamment de l’autre côté. Et Diogène était là, se reprochant sa pauvreté, qui l’empêchait de payer de retour son bienfaiteur. Il y songeait encore, lorsque l’homme, apercevant un autre voyageur qui ne pouvait traverser, courut à lui et le passa. Alors Diogène, s’approchant du passeur, lui dit : « Je ne te sais plus gré de ton service ; car je vois que ce n’est point le discernement, mais une manie qui te fait faire ce que tu fais. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’à obliger les gens de rien aussi bien que les gens de mérite, on s’expose à passer non pour un homme serviable, mais pour un homme sans discernement.</p>
       </div>
@@ -2865,7 +2864,7 @@
           <pb ed="perry" n="P302"/>
           <p><milestone unit="recitprose"/>Αἱ δρύες κατεμέμφοντο τὸν Δία ὅτι « ἐπεὶ κοπτόμεθα, τί ἡμᾶς μετὰ τῶν λοιπῶν φυτῶν ἐποίησας ; » Ὁ δὲ Ζεὺς εἶπεν· « Ὑμεῖς αὐταὶ αἴτιοι τῆς κοπῆς· εἰ μὴ γὰρ ὑμεῖς τὰ στελίδια ἐγεννᾶτε, οὐκ ἂν πέλεκυς ὑμᾶς ἐξέκοπτεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι αἴτιοι κακῶν ἑαυτοῖς τινες ὄντες τὴν μέμψιν ἀφρόνως τῷ θεῷ ἐπιτιθέασιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 5.</p>
+          <bibl>Cod. Ba 5.</bibl>
         </div>
         <div>
           <head>Chambry 99.2</head>
@@ -2873,7 +2872,7 @@
           <pb ed="perry" n="P302"/>
           <p><milestone unit="recitprose"/>Αἱ δρύες κατεμέμφοντο τοῦ Διὸς λέγουσαι ὅτι « μάτην παρήχθημεν ἐν τῷ βίῳ· ὑπὲρ πάντα γὰρ τὰ φυτὰ βιαίως τὴν τομὴν ὑφιστάμεθα. » Καὶ ὁ Ζεύς· « Ὑμεῖς αὐταὶ αἴτιοι τῆς τοιαύτης ἑαυταῖς καθεστήκατε συμφορᾶς· εἰ μὴ γὰρ τοὺς στειλειοὺς ἐγεννᾶτε, καὶ πρὸς τεκτονικὴν καὶ γεωργικὴν χρήσιμοι ἦτε, οὐκ ἂν πέλεκυς ὑμᾶς ἐξέκοπτεν. »</p>
           <p><milestone unit="epimythiumprose"/>Αἴτιοί τινες ἑαυτοῖς τῶν κακῶν καταστάντες τὴν μέμψιν ἀφρόνως τιθέασι τῷ θεῷ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 5.</p>
+          <bibl>Cod. Bc 5.</bibl>
           <p><milestone unit="traduction"/>Les chênes se plaignaient à Zeus : « C’est en vain, disaient-ils, que nous sommes venus au jour ; car plus que tous les autres arbres nous sommes exposés aux coups brutaux de la hache. » Zeus leur répondit : « C’est vous-mêmes qui êtes les auteurs de votre malheur ; si vous ne produisiez pas les manches de cognée, et si vous ne serviez pas à la charpenterie et à l’agriculture, la hache ne vous abattrait pas. »</p>
           <p><milestone unit="traduction"/>Certains hommes, qui sont les auteurs de leurs maux, en rejettent sottement le blâme sur les dieux.</p>
         </div>
@@ -2882,7 +2881,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P302"/>
           <p><milestone unit="recitprose"/>Αἱ δρύες ἐμέμφοντο τῷ Διὶ λέγουσαι· « Τίνος χάριν ἡμᾶς ἐποίησας, ἐπεὶ παρὰ τῶν ἀνθρώπων ἐμέλλομεν κόπτεσθαι ; » Ὁ δὲ πρὸς αὐτὰς ἔφη ὅτι « τῆς τομῆς οὐκ ἐγώ, ἀλλ’ ὑμεῖς αἴτιοι· ἂν γὰρ ὑμεῖς τοὺς στελέχους οὐκ ἐϐλαστάνετε, οὐκ ἂν ὑμᾶς ἐξέκοπτε πέλεκυς. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 1.</p>
+          <bibl>Cod. Bd 1.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-100">
@@ -2893,7 +2892,7 @@
           <pb ed="perry" n="P303"/>
           <p><milestone unit="recitprose"/>Δρυοτόμοι δρῦν ἔσχιζον· οἱ δὲ ἐξ αὐτῆς σφῆνας ποιήσαντες ἔσχιζον αὐτὴν &lt;εὐκόλως&gt;. Ἡ δὲ ἔφη· « Οὐ τοσοῦτον τὸν κόψαντά με πέλεκυν μέμφομαι ὅσον τοὺς ἐξ ἐμοῦ φυέντας σφῆνας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δεινότερόν ἐστι λύπη, ὅταν τις ὑπὸ τῶν συγγενῶν πάθῃ τι ἢ παρὰ τῶν ἀλλοτρίων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 162.</p>
+          <bibl>Cod. Ma 162.</bibl>
         </div>
         <div>
           <head>Chambry 100.2</head>
@@ -2901,7 +2900,7 @@
           <pb ed="perry" n="P303"/>
           <p><milestone unit="recitprose"/>Δρῦς ὑπὸ δρυοτόμου ἐτέμνετο· μὴ εὐκόλως δὲ ταύτην ἰσχύοντος ἐκτεμεῖν, διὰ σφηνὸς αὐτὴν ἐκ τῶν ἑαυτῆς σχιδάκων διαιρεῖν ἐμηχανᾶτο. Ἡ δέ· « Οὐ τόσον κατὰ τῆς κοπτούσης &lt;ἀξίνης&gt;, ἔφη, βαρυθυμῶ ὅσον δὴ καθ’ ὑμῶν τῶν ἐξ ἐμοῦ γεννωμένων σφηνῶν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἀπαισιώτερον τὸ ὑπὸ τῶν οἰκείων πάσχειν τι δεινὸν ἢ ὑπὸ ἀλλοτρίων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 22.</p>
+          <bibl>Cod. Bc 22.</bibl>
         </div>
         <div>
           <head>Chambry 100.3</head>
@@ -2909,7 +2908,7 @@
           <pb ed="perry" n="P303"/>
           <p><milestone unit="recitprose"/>Δρυτόμοι ἔσχιζόν τινα πεύκην· σφῆνας δὲ ἐξ αὐτῆς πεποιηκότες εὐκόλως ἔσχιζον. Ἡ δὲ εἶπεν· « Οὐ τοσοῦτον τὸν κόψαντα πέλεκυν μέμφομαι ὅσον τοὺς ἐξ ἐμοῦ γεννηγέντας σφῆνας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ τοσοῦτόν ἐστι δεινόν, ὅτε τις ὑπὸ ἀλλοτρίων ἀνθρώπων πάθῃ τι τῶν ἀπαισίων ὅσον ὑπὸ τῶν οἰκείων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 28 Bb 17 Mg 51.</p>
+          <bibl>Codd. Ba 28 Bb 17 Mg 51.</bibl>
           <p><milestone unit="traduction"/>Des bûcherons fendaient un pin, et ils le fendaient facilement grâce aux coins qu’ils avaient faits de son bois. Et le pin disait : « Je n’en veux pas tant à la hache qui me coupe qu’aux coins qui sont nés de moi. »</p>
           <p><milestone unit="traduction"/>Il n’est pas si rude d’essuyer quelque traitement fâcheux de la part des étrangers que de la part de ses proches.</p>
         </div>
@@ -2918,7 +2917,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P303"/>
           <p><milestone unit="recitprose"/>Πεύκη δρυτόμον ἰδοῦσα σφῆνας ἐξ αὐτῆς πεποιημένον καὶ ταύτην σχίζοντα ῥᾳδίως ἔφη· « Οὐ τοσοῦτον τῷ πελέκει μέμφομαι ὅσον τοῖς ἐξ ἐμοῦ γενομένοις σφησί. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 11.</p>
+          <bibl>Cod. Bd 11.</bibl>
         </div>
         <div>
           <head>Chambry 100.5</head>
@@ -2932,7 +2931,7 @@
           <l><milestone unit="recitvers"/>τὴν κόπτουσάν με ταῖς χερσὶ τῶν ἀνθρώπων</l>
           <l><milestone unit="recitvers"/>ὡς τοὺς ἐξ ἐμοῦ γεγενημένους σφῆνας. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ τῶν ἀνθρώπων ἐν συμφοραῖς περιπίπτουσι παρὰ τῶν ξένων· ἐκ δὲ τῶν ἰδίων ἐάν τι συμϐῇ μικρὸν αὐτοῖς λυπηρόν, χεῖρον καὶ βαρύτερον αὐτοῖς καταφαίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 37 Ch 112 Ca 174 Cb 92 Cd 106 Mb 197.</p>
+          <bibl>Codd. Cg 37 Ch 112 Ca 174 Cb 92 Cd 106 Mb 197.</bibl>
         </div>
         <div>
           <head>Chambry 100.6</head>
@@ -2940,7 +2939,7 @@
           <pb ed="perry" n="P303"/>
           <p><milestone unit="recitprose"/>Πρίσται κατέσχιζον πεύκην καὶ σφῆνας ἐξ αὐτῆς ἐποίουν κατασχίζοντες αὐτήν. Ἡ δὲ ἐθρήνει λέγουσα· « Οὐ τοσοῦτον τὸν πρίονα μέμφομαι ὅσον τοὺς ἐξ ἐμοῦ σφῆνας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι λυπηρότεραι αἱ τῶν οἰκείων κακώσεις ὑπὲρ τῶν ξένων λίαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 99 Cf 106.</p>
+          <bibl>Codd. Ce 99 Cf 106.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-101">
@@ -2951,7 +2950,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Δρῦς καὶ κάλαμος ἤριζον περὶ ἰσχύος. Ἀνέμου δὲ σφοδροῦ γενομένου, ὁ μὲν κάλαμος σαλευόμενος καὶ συγκλινόμενος ταῖς τούτου πνοαῖς τὴν ἐκρίζωσιν ἐξέφυγεν, ἡ δὲ δρῦς ἀντιστᾶσα ἐκ ῥιζῶν ἔπεσεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ δεῖ τοῖς κρείττοσιν ἐρίζειν ἢ ἀνθίστασθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 70 Mb 38 Cd 39.</p>
+          <bibl>Codd. Pb 70 Mb 38 Cd 39.</bibl>
         </div>
         <div>
           <head>Chambry 101.2</head>
@@ -2959,7 +2958,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Δρῦς καὶ κάλαμος ἤρισαν περὶ ἰσχύος. Ἀνέμου δὲ σφοδροῦ γενομένου, ὁ μὲν κάλαμος σαλευόμενος ταῖς πνοαῖς ἐξέφυγεν· ἡ δρῦς δὲ ἀντιστᾶσα ἐκ ῥιζῶν ἀνεσπάσθη.</p>
           <p><milestone unit="epimythiumprose"/>&lt;Ὁ&gt; λόγος δηλοῖ ὅτι οὐ δεῖ τοῖς κρείττοσιν ἐρίζειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 37.</p>
+          <bibl>Cod. Pe 37.</bibl>
         </div>
         <div>
           <head>Chambry 101.3</head>
@@ -2967,14 +2966,14 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Δρῦν ἄνεμος ἐκριζώσας ἐν ποταμῷ ἔρριψεν. Ἡ δὲ φερομένη τοὺς καλάμους ἠρώτα· « Πῶς ὑμεῖς, ἀσθενεῖς ὄντες καὶ λεπτοί, ὑπὸ τῶν βιαίων ἀνέμων οὐκ ἐκριζοῦσθε ; » Οἱ δὲ εἶπον· « Ὑμεῖς τοῖς ἀνέμοις μάχεσθε καὶ ἀνθίστασθε, καὶ διὰ τοῦτο ἐκριζοῦσθε· ἡμεῖς δὲ παντὶ ἀνέμῳ ὑποπίπτοντες ἀϐλαϐεῖς διαμένομειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ ἀνθίστασθαι τοῖς κρατοῦσιν [ἐνδόξοις], ἀλλ’ ὑποτάσσεσθαι καὶ ὑπείκειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 29 Bb 18 Mg 52.</p>
+          <bibl>Codd. Ba 29 Bb 18 Mg 52.</bibl>
         </div>
         <div>
           <head>Chambry 101.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Δρῦν καταϐαλὼν ἐν ποταμῷ ἔρριψεν ἄνεμος. Ἡ δὲ φερομένη τοὺς ποταμίους καλάμους ἠρώτα· « Πῶς ὑμεῖς ἀσθενεῖς ὄντες ὑπὸ τῶν ἀνέμων οὐ καταϐάλλεσθε ; » Οἱ δὲ εἶπον· « Ἡμεῖς παντὶ ἀνέμῳ ὑποπίπτοντες ἀϐλαϐεῖς διαμένομεν· ὑμεῖς δὲ παντὶ ἀνθιστάμενοι ἀπὸ ῥιζῶν καταϐάλλεσθε. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 12.</p>
+          <bibl>Cod. Bd 12.</bibl>
         </div>
         <div>
           <head>Chambry 101.5</head>
@@ -2982,7 +2981,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Τὰ δένδρα ποτὲ κατεασσόμενα ὑπὸ τῶν ἀνέμων, ὡς ἑώρα τοὺς καλάμους ἀϐλαϐεῖς διαμένοντας, ἐπυνθάνετο αὐτῶν πῶς αὐτὰ μὲν ἰσχυρὰ καὶ ἐμϐριθῆ ὄντα οὕτως κατακλᾶται, οἱ δὲ λεπτοὶ καὶ ἀσθενεῖς ὄντες οὐδὲν πάσχουσι. Κἀκεῖνοι ἔφασαν ὅτι « ἡμεῖς συνειδότες ἑαυτοῖς ἀσθένειαν εἴκομεν τῇ τῶν ἀνέμων ἐμϐολῇ καὶ οὕτω τὰς ὁρμὰς ἐκκλίνομεν· ὑμεῖς δὲ πεποιθότες τῇ ἰδίᾳ δυνάμει ἀντιτείνετε καὶ διὰ τοῦτο κατεάσσεσθε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πρὸς τὰ χαλεπὰ τῶν πραγμάτων τὸ εἴκειν τοῦ ἀνθίστασθαι ἀσφαλέστερον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 221 Pb 213 Ma 133 Ca 180 Ce 114 Cf 122.</p>
+          <bibl>Codd. Pa 221 Pb 213 Ma 133 Ca 180 Ce 114 Cf 122.</bibl>
         </div>
         <div>
           <head>Chambry 101.6</head>
@@ -2990,7 +2989,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Διὰ καρτερίαν καὶ ἡσυχίαν καὶ ἰσχὺν κάλαμος καὶ ἐλαία ἤριζον. Τοῦ δὲ καλάμου ὀνειδιζομένου ὑπὸ τῆς ἐλαίας ὡς ἀδύνατός ἐστι καὶ ῥᾳδίως ὑποκλίνεται πᾶσι τοῖς ἀνέμοις, ὁ κάλαμος οὐδὲν ἐφθέγξατο. Καὶ μικρὸν ὑπομείνας, ἐπειδὴ, ἀνέμου ἰσχυροῦ γενομένου, ὁ μὲν κάλαμος σεισθεὶς καὶ ὑποκλιθεὶς τοῖς ἀνέμοις ῥᾳδίως διεσώθη· ἡ δὲ ἐλαία ῥιζωθεῖσα, ἐπειδὴ ἀντέτεινε τοῖς ἀνέμοις, τῇ βίᾳ κατεκλάσθη, ἤλεγξεν αὐτὴν ὅτι ματαίως καὶ μάτην ἐπαίρεται ἐπὶ τῇ οἰκείᾳ δυνάμει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ οἱ πρὸς τὸν καιρὸν καὶ τοὺς κρείττονας αὐτῶν μὴ ἀνθιστάμενοι κρείττονές εἰσι τῶν πρὸς μείζονας φιλονεικούντων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 59 Cb 41 Ce 43 Cf 47 Ch 48 Ma 51.</p>
+          <bibl>Codd. Ca 59 Cb 41 Ce 43 Cf 47 Ch 48 Ma 51.</bibl>
         </div>
         <div>
           <head>Chambry 101.7</head>
@@ -2998,7 +2997,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Διὰ καρτερίαν καὶ ἰσχὺν καὶ ἡσυχίαν κάλαμος καὶ ἐλαία ἤριζον. Τοῦ δὲ καλάμου ὀνειδιζομένου ὑπὸ τῆς ἐλαίας ὡς ἀδυνάτου καὶ ῥᾳδίως ὑποκλινομένου πᾶσι τοῖς ἀνέμοις, ὁ κάλαμος σιωπῶν οὐκ ἐφθέγξατο. Καὶ μικρὸν ὑπομείνας, ἐπειδὴ ἄνεμος ἔπνευσεν ἰσχυρός, ὁ μὲν κάλαμος ὑποσεισθεὶς καὶ ὑποκλινθεὶς τοῖς ἀνέμοις ῥᾳδίως διεσώθη· ἡ δ’ ἐλαία, ἐπειδὴ ἀντέτεινε τοῖς ἀνέμοις, κατεκλάσθη τῇ βίᾳ.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῷ καιρῷ καὶ τοῖς κρείττοσιν αὐτῶν μὴ ἀνθιστάμενοι κρείττους εἰσὶ τῶν πρὸς μείζονας φιλονεικούντων.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 147 Lc 59 Ld 19 Lg 59 Mc 39 Md 46 Mh 41 Mi 81 Mk 43 Ml 52 Mm 58 Mn 19.</p>
+          <bibl>Codd. La 147 Lc 59 Ld 19 Lg 59 Mc 39 Md 46 Mh 41 Mi 81 Mk 43 Ml 52 Mm 58 Mn 19.</bibl>
         </div>
         <div>
           <head>Chambry 101.8</head>
@@ -3006,7 +3005,7 @@
           <pb ed="perry" n="P70"/>
           <p><milestone unit="recitprose"/>Κάλαμοι παρεπεφύτευντο κυπαρίττοις, καὶ αἱ κυπάριττοι, τὸ αὐτῶν ἀνεκρίζωτον διὰ τὸ εὖ κλίνειν ἀνέμοις ἐνορώμεναι, σφοδρῶς ἐπέκειντο τοῖς καλάμοις, « Πῶς ἡμεῖς, λέγουσαι, τὴν ἐκρίζωσιν ἀθρόαν δεινῶς ὑφιστάμεθα, ὑμεῖς δὲ καὶ ἅπασαι διαδρᾶναι τὸν κίνδυνον εὐκρινῶς μεμαθήκατε ; » Τί οὖν οἱ κάλαμοι ; « Ταῖς ὑπερτερούσαις ἡμῶν δυναστείαις μὴ ἀντιϐαίνειν μεμαθηκυῖαι, ἀλλὰ ταύταις ῥᾳδίως τὸν τράχηλον ὑποκλίνουσαι, τὴν αἰτίαν τοῦ ἀφανισμοῦ διαδιδράσκομεν ἔκρίζωσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς κρατοῦσιν οὐ δεῖ ἀνθίστασθαι, ἀλλὰ μᾶλλον ὑπείκειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 23.</p>
+          <bibl>Cod. Bc 23.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-102">
@@ -3017,7 +3016,7 @@
           <pb ed="perry" n="P304"/>
           <p><milestone unit="recitprose"/>Ἐλάτη καυχωμένη τῇ βάτῳ ἔλεγεν· « Ἐν οὐδενὶ οὐδὲν χρησιμεύεις, ὅτε ἐγὼ ἐν στέγεσί που χρησιμεύω καὶ οἴκοις. » Ἡ δὲ βάτος ἔφη· « Ὦ ἐλεεινή, εἰ μνησθείης τῶν πελέκεων καὶ πριόνων τῶν κοπτόντων σε, βάτος ἂν ἔχοις θελῆσαι γενέσθαι, οὐκ ἐλάτη. »</p>
           <p><milestone unit="epimythiumprose"/>Κρείσσων πενία ἄφοϐος ἢ πλουσιότης μετὰ ἀναγκῶν καὶ ἐπηρειῶν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 164.</p>
+          <bibl>Cod. Ma 164.</bibl>
         </div>
         <div>
           <head>Chambry 102.2</head>
@@ -3025,7 +3024,7 @@
           <pb ed="perry" n="P304"/>
           <p><milestone unit="recitprose"/>Ἤριζον πρὸς ἀλλήλας ἐλάτη καὶ βάτος. Ἡ δὲ ἐλάτη ἑαυτὴν ἐπαινοῦσα ἔφη ὅτι « καλή εἰμι καὶ εὐμήκης καὶ ὑψηλὴ καὶ χρησιμεύω εἰς ναῶν στέγη καὶ εἰς πλοῖα· καὶ πῶς ἐμοὶ συγκρίνῃ ; » Ἡ δὲ βάτος εἶπεν· « Εἰ μνησθῇς τῶν πελέκεων καὶ τῶν πριόνων τῶν σε κοπτόντων, βάτος γενέσθαι καὶ σὺ μᾶλλον θελήσεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ ἐν βίῳ ὄντας ἐπαίρεσθαι ἐν τῇ δόξῃ· τῶν γὰρ εὐτελῶν ἀκίνδυνός ἐστιν ὁ βίος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 48.</p>
+          <bibl>Cod. Ba 48.</bibl>
           <p><milestone unit="traduction"/>Le sapin et la ronce disputaient ensemble. Le sapin se vantait et disait : « Je suis beau, élancé et haut, et je sers à construire des toits aux temples et des vaisseaux. Comment oses-tu te comparer à moi ? — Si tu te souvenais, répliqua la ronce, des haches et des scies qui te coupent, tu préférerais toi aussi le sort de la ronce. »</p>
           <p><milestone unit="traduction"/>Il ne faut pas dans la vie s’enorgueillir de sa réputation ; car la vie des humbles est sans danger.</p>
         </div>
@@ -3034,7 +3033,7 @@
           <head type="sub">Aliter — Autre version. </head>
           <pb ed="perry" n="P304"/>
           <p><milestone unit="recitprose"/>Ἤριζον πρὸς ἀλλήλας ἐλάτη καὶ βάτος. Ἐπαινοῦσα δὲ αὑτὴν ἡ ἐλάτη ἔλεγεν ὅτι « εὐμήκης εἰμι καὶ ὑψηλὴ καὶ εἰς τὰς κατασκευὰς τῶν νεῶν καὶ εἰς τὰ στέγη [καὶ] τῶν μεγάλων καὶ βασιλικῶν οἰκιῶν χρησιμεύω· σοῦ δέ, ὦ βάτε, οὐδὲν ὄφελος· ἄχρηστος γὰρ ὑπάρχεις παντάπασιν. » Ἡ δὲ βάτος εἶπεν· « Ὦ ἐλάτη, εἰ ἀναμνησθείης τῶν πελέκεων καὶ τῶν πριόνων τῶν σε κοπτόντων, τάχ’ ἂν καὶ σὺ βάτος γενέσθαι θελήσειας. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 25.</p>
+          <bibl>Cod. Bd 25.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-103">
@@ -3045,7 +3044,7 @@
           <pb ed="perry" n="P74"/>
           <p><milestone unit="recitprose"/>Ἔλαφος δίψῃ συσχεθεῖσα παρεγένετο ἐπί τινα πηγήν· πιοῦσα δέ, ὡς ἐθεάσατο τὴν ἑαυτῆς σκιὰν ἐπὶ τοῦ ὕδατος, ἐπὶ μὲν τοῖς κέρασιν ἠγάλλετο, ὁρῶσα τὸ μέγεθος καὶ τὴν ποικιλίαν, ἐπὶ δὲ τοῖς ποσὶ πάνυ ἤχθετο ὡς λεπτοῖς οὖσι καὶ ἀσθενέσιν. Ἔτι δὲ αὐτῆς διανοουμένης, λέων ἐπιφανεὶς ἐδίωκεν αὐτήν· κἀκείνη εἰς φυγὴν τραπεῖσα κατὰ πολὺ αὐτοῦ προεῖχεν· ἀλκὴ γὰρ ἐλάφων μὲν ἐν τοῖς ποσί, λεόντων δὲ ἐν καρδίᾳ. Μέχρι μὲν οὖν ψιλὸν ἦν τὸ πεδίον, ἡ μὲν προθέουσα διεσῴζετο· ἐπειδὴ δὲ ἐγένετο κατά τινα ὑλώδη τόπον, τηνικαῦτα συνέϐη, τῶν κεράτων αὐτῆς ἐμπλακέντων τοῖς κλάδοις, μὴ δυναμένην τρέχειν συλληφθῆναι. Μέλλουσα δὲ ἀναιρεῖσθαι ἔφη πρὸς ἑαυτήν· « Δειλαία ἔγωγε, ἥτις ὑφ’ ὧν μὲν προδοθήσεσθαι ἔμελλον, ὑπὸ τούτων ἐσῳζόμην, οἷς δὲ καὶ σφόδρα ἐπεποίθειν, ὑπὸ τούτων ἀπόλλυμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις ἐν κινδύνοις οἱ μὲν ὕποπτοι τῶν φίλων σωτῆρες ἐγένοντο, οἱ δὲ σφόδρα ἐμπιστευθέντες προδόται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 71 Pb 75 Pe 41 Pg 48 Ma 54 Mb 42.</p>
+          <bibl>Codd. Pa 71 Pb 75 Pe 41 Pg 48 Ma 54 Mb 42.</bibl>
           <p><milestone unit="traduction"/>Un cerf pressé par la soif arriva près d’une source. Après avoir bu, il aperçut son ombre dans l’eau. Il se sentit fier de ses cornes, en voyant leur grandeur et leur diversité ; mais il était mécontent de ses jambes, parce qu’elles étaient grêles et faibles, Il était encore plongé dans ces pensées, quand un lion apparut qui le poursuivit. Il prit la fuite, et le devança d’une longue distance ; car la force des cerfs est dans leurs jambes, celle des lions dans leur cœur. Tant que la plaine fut nue, il maintint l’avance qui le sauvait ; mais étant parvenu à un endroit boisé, il arriva que ses cornes se prirent aux branches et que, ne pouvant plus courir, il fut pris par le lion. Sur le point de mourir, il se dit en lui-même : « Malheureux que je suis ! Ce sont mes pieds, qui devaient me trahir, qui me sauvaient ; et ce sont mes cornes, en qui j’avais toute confiance, qui me perdent. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que souvent dans le danger les amis que nous suspectons nous sauvent, et ceux sur qui nous comptons fermement nous trahissent.</p>
         </div>
@@ -3056,7 +3055,7 @@
           <p><milestone unit="recitprose"/>Ἔλαφος δίψει συσχεθεῖσα παρεγένετο ἐπί τινα πηγὴν τοῦ πιεῖν. Ἐν ὅσῳ δὲ ἔπινεν, εἶδε τὴν ἑαυτῆς σκιὰν ἐπὶ τοῦ ὕδατος. Καὶ ἐπὶ μὲν τοῖς κέρασιν αὐτῆς ηὐφραίνετο, ὁρῶσα τὸ μέγεθος καὶ τὴν ποικιλίαν· ἐπὶ δὲ τοῖς ποσὶ σφόδρα ἤχθετο καὶ ἐδυσφόρει, ὡς λεπτοῖς οὖσι καὶ ἀσθενέσιν. Ἔτι δὲ αὐτῆς διανοουμένης, λέων ἐπιφανεὶς ἤρξατο διώκειν αὐτήν, κἀκείνη εἰς φυγὴν τραπεῖσα κατὰ πολὺ αὐτοῦ προεῖχεν· ἀλκὴ γὰρ ἐλάφων ἐν τοῖς ποσί, λέοντος δὲ ἐν καρδίᾳ. Καὶ μέχρι μὲν ἐν πεδίῳ ἐδιώκετο, ἀκατάληπτος ἦν ἠ ἔλαφος, ἐπεὶ προέθεεν· ἐπεὶ δὲ κατά τινα δρυμὸν καὶ ὑλώδη τόπον παρεγένετο, συνέϐη τοῖς κέρασιν αὐτῆς ἐμπλακῆναι τοῖς κλάδοις, καὶ μὴ δυναμένην τρέχειν συλληφθῆναι ὑπὸ τοῦ λέοντος. Μέλλουσα δὲ ἀναιρεῖσθαι ἔφη· « Δειλαία ἔγωγε ἥτις ὑφ’ ὧν ᾠόμην προδοθήσεσθαι, ὑπὸ τούτων ἐσῳζόμην καὶ ἔχαιρον, οἷς δὲ σφόδρα ἐπεποίθειν, ὑπὸ τούτων ἀπόλλυμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁμοίως πολλάκις τινὲς δοκοῦντες ἔχειν τι χρήσιμον, λανθάνουσιν ἑαυτοὺς βλαπτόμενοι δι’ ἐκείνου.</p>
           <p><milestone unit="epimythiumprose"/>Ἢ οὕτως· Πολλάκις ἐν κινδύνοις οἱ μὲν ὕποπτοι τῶν φίλων σωτῆρες γίνονται, οἱ δὲ σφόδρα ἐμπιστευθέντες προδόται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 66 Cb 46 Cd 43 Ce 48 Cf 52 Ch 53 Mc 45 Md 51 Mh 46 Mi 86 Mk 49 Ml 69 Mm 64.</p>
+          <bibl>Codd. Ca 66 Cb 46 Cd 43 Ce 48 Cf 52 Ch 53 Mc 45 Md 51 Mh 46 Mi 86 Mk 49 Ml 69 Mm 64.</bibl>
         </div>
         <div>
           <head>Chambry 103.3</head>
@@ -3064,14 +3063,14 @@
           <pb ed="perry" n="P74"/>
           <p><milestone unit="recitprose"/>Ἔλαφος διψήσας ἐπὶ πηγὴν ἦλθεν. Ἰδὼν δὲ τὴν ἑαυτοῦ σκιάν, τοὺς μὲν πόδας ἐμέμφετο, ὡς λεπτοὺς καὶ ἀσθενεῖς ὄντας, τὰ δὲ κέρατα αὐτοῦ ἐπῄνει, ὡς μέγιστα καὶ εὐμήκη. Μηδέπω δὲ πιών, κυνηγοῦ καταλαϐόντος, ἔφευγεν. Ἐπὶ πολὺν δὲ τόπον δραμὼν καὶ εἰς ὕλην ἐμϐὰς τοῖς κέρασιν ἐμπλακεὶς ἐθηρεύθη. Ἔφη δέ· « Ὦ μάταιος ἐγώ, ὃς ἐκ μὲν τῶν ποδῶν ἐσώθην οἷς ἐμεμφόμην, ἐκ δὲ τῶν κεράτων προεδόθην οἷς ἐκαυχώμην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι περὶ πράγματός τινος, ἐὰν διακρίνῃς καλὸν εἶναι, μὴ ἔχῃς βέϐαιον περὶ τούτου· πολλάκις γὰρ σφάλλουσιν αἱ ἐλπίδες εἰς ἃς ἐπερειδόμεθα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 34 Bb 23 Mg 60.</p>
+          <bibl>Codd. Ba 34 Bb 23 Mg 60.</bibl>
         </div>
         <div>
           <head>Chambry 103.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P74"/>
           <p><milestone unit="recitprose"/>Ἔλαφος ἐπὶ ὕδατος τὴν σκιὰν αὑτῆς κατιδοῦσα τῶν σκελῶν αὑτῆς ὡς ἀσθενῶν κατεμέμφετο, ἐπῄνει δὲ μᾶλλον τὰ ἐν τῷ μετώπῳ αὑτῆς κέρατα διὰ τὴν στερρότητα. Αἰφνίδιον δὲ κυνηγοῦ καταλαϐόντος αὐτήν, καὶ πρὸς φυγὴν ὁρμήσασα, τὰ μὲν σκέλη διέσωσαν αὐτὴν ἐν κρησφυγέτῳ τινί. Ἡ δὲ τῶν κεράτων ἰσχὺς αὐτὴν προέδωκεν εἰς τὴν πυκνότητα τοῦ ἄλσους περιπλακέντων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 27.</p>
+          <bibl>Cod. Bc 27.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-104">
@@ -3082,7 +3081,7 @@
           <pb ed="perry" n="P77"/>
           <p><milestone unit="recitprose"/>Ἔλαφος διωκομένη ὑπὸ κυνηγῶν ἐκρύπτετο ὑπό τινα ἄμπελον. Διελθόντων δὲ τῶν κυνηγῶν, στραφεῖσα κατήσθιε τὰ φύλλα τῆς ἀμπέλου. Εἷς δέ τις τῶν κυνηγῶν στραφεὶς καὶ θεασάμενος, ὃ εἶχεν ἀκόντιον βαλών, ἔτρωσεν αὐτήν. Ἡ δὲ μέλλουσα τελευτᾶν στενάξασα πρὸς ἑαυτὴν ἔφη· « Δίκαιά γε πάσχω, ὅτι τὴν σώσασάν με ἄμπελον ἠδίκησα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος λεχθείη ἂν κατὰ ἀνδρῶν οἵτινες τοὺς εὐεργέτας ἀδικοῦντες ὑπὸ θεοῦ κολάζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 74 et 91bis Pb 78 Pc 39 Pe 44 Pf 37 Pg 50 Ph 39 Ma 57 Mb 46 Ca 65.</p>
+          <bibl>Codd. Pa 74 et 91bis Pb 78 Pc 39 Pe 44 Pf 37 Pg 50 Ph 39 Ma 57 Mb 46 Ca 65.</bibl>
         </div>
         <div>
           <head>Chambry 104.2</head>
@@ -3090,7 +3089,7 @@
           <pb ed="perry" n="P77"/>
           <p><milestone unit="recitprose"/>Ἔλαφος κυνηγοὺς φεύγουσα ὑπ’ ἀμπέλῳ ἐκρύϐη. Παρελθόντων δ’ ὀλίγον ἐκείνων, ἡ ἔλαφος τελέως ἤδη λαθεῖν δόξασα, τῶν τῆς ἀμπέλου φύλλων ἐσθίειν ἤρξατο. Τούτων δὲ σειομένων, οἱ κυνηγοὶ ἐπιστραφέντες καί, ὅπερ ἦν ἀληθές, νομίσαντες τῶν ζῴων ὑπὸ τοῖς φύλλοις τι κρύπτεσθαι, βέλεσιν ἀνεῖλον τὴν ἔλαφον. Ἡ δὲ θνῄσκουσα τοιαῦτ’ ἔλεγε· « Δίκαια πέπονθα· οὐ γὰρ ἔδει τὴν σώσασάν με λυμαίνεσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ ἀδικοῦντες τοὺς εὐεργέτας ὑπὸ θεοῦ κολάζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 65 Lb 45 Lc 33 Le 45 Lf 65 Lg 33 Md 117 Me 52 Mf 47 Mg 68 Mi 34 Mj 55 Ml 57 Mm 67.</p>
+          <bibl>Codd. La 65 Lb 45 Lc 33 Le 45 Lf 65 Lg 33 Md 117 Me 52 Mf 47 Mg 68 Mi 34 Mj 55 Ml 57 Mm 67.</bibl>
           <p><milestone unit="traduction"/>Une biche, poursuivie par des chasseurs, se cacha sous une vigne. Ceux-ci l’ayant un peu dépassée, elle se crut dès lors parfaitement cachée, et se mit à brouter les feuilles de la vigne. Comme les feuilles remuaient, les chasseurs s’étant retournés et pensant, ce qui était vrai, qu’il y avait une bête cachée dessous, tuèrent la biche à coups de traits. Celle-ci se sentant mourir prononça ces paroles : « Je l’ai bien mérité ; car je ne devais pas endommager celle qui m’avait sauvée. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui font du mal à leurs bienfaiteurs sont punis de Dieu.</p>
         </div>
@@ -3103,7 +3102,7 @@
           <pb ed="perry" n="P76"/>
           <p><milestone unit="recitprose"/>Ἔλαφος κυνηγοὺς φεύγουσα ἐγένετο κατά τι σπήλαιον, ἐν ᾧ λέων ἦν, καὶ ἐνταῦθα εἰσῄει κρυϐησομένη. Συλληφθεῖσα δὲ ὑπὸ τοῦ λέοντος καὶ ἀναιρουμένη ἔφη· « Βαρυδαίμων ἔγωγε, ἥτις ἀνθρώπους φεύγουσα ἐμαυτὴν θηρίῳ ἐνεχείρισα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων διὰ φόϐον ἐλάττονος εἰς κίνδυνον μείζονα ἑαυτοὺς ἐμϐάλλουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 73 Pb 77 Pc 38 Pf 36 Pg 49 Ph 38 Ma 56 Mb 45 Me 51 Mf 46 Ca 64.</p>
+          <bibl>Codd. Pa 73 Pb 77 Pc 38 Pf 36 Pg 49 Ph 38 Ma 56 Mb 45 Me 51 Mf 46 Ca 64.</bibl>
           <p><milestone unit="traduction"/>Une biche poursuivie par des chasseurs arriva à l’entrée d’un antre où se trouvait un lion. Elle y entra pour s’y cacher ; mais elle fut prise par le lion et, tandis qu’il la tuait, elle s’écria : « Malheureuse que je suis ! en fuyant les hommes, je me suis jetée dans les pattes d’une bête féroce. »</p>
           <p><milestone unit="traduction"/>Ainsi parfois les hommes, par crainte d’un moindre danger, se jettent dans un plus grand.</p>
         </div>
@@ -3113,7 +3112,7 @@
           <pb ed="perry" n="P76"/>
           <p><milestone unit="recitprose"/>Ἔλαφος κυνηγοὺς φεύγουσα ἐγένετο κατά τι σπήλαιον, ἐφ’ ᾧ λέων ἦν κατοικούμενος, καὶ ἐνταῦθα εἰσιοῦσα καὶ νομίζουσα κρυϐῆναι συνελήφθη ὑπὸ τοῦ λέοντος καὶ ἀναιρουμένη πρὸς ἑαυτὴν ἔφη· « Δειλαία ἔγωγε ἥτις ἀνθρώπους φεύγουσα ἐμαυτὴν θηρίῳ παρέδωκα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τῶν ἀνθρώπων παῖδες διὰ φόϐον ἐλάττονος κινδύνου ἑαυτοὺς εἰς μεῖζον κακὸν ἐμϐάλλουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 43.</p>
+          <bibl>Cod. Pe 43.</bibl>
         </div>
         <div>
           <head>Chambry 105.3</head>
@@ -3121,7 +3120,7 @@
           <pb ed="perry" n="P76"/>
           <p><milestone unit="recitprose"/>Ἔλαφος κυνηγοὺς φεύγουσα εἰς ἄντρον εἰσέδυ· λέοντι δ’ ἐκεῖ περιτυχοῦσα ὑπ’ αὐτοῦ συνελήφθη· θνῄσκουσα δ’ ἔλεγεν· « Οἴμοι ὅτι ἀνθρώπους φεύγουσα τῷ τῶν θηρίων ἀγριωτάτῳ περιέπεσον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ τῶν ἀνθρώπων μικροὺς κινδύνους φεύγοντες μεγάλων ἐπειράθησαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 64 Lb 44 Le 44 Lf 64 Md 119 Mg 67 Mi 35 Mj 53 Ml 56.</p>
+          <bibl>Codd. La 64 Lb 44 Le 44 Lf 64 Md 119 Mg 67 Mi 35 Mj 53 Ml 56.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-106">
@@ -3132,7 +3131,7 @@
           <pb ed="perry" n="P75"/>
           <p><milestone unit="recitprose"/>Ἔλαφος πηρωθεῖσα τὸν ἕτερον τῶν ὀφθαλμῶν παρεγένετο εἴς τινα αἰγιαλὸν καὶ ἐνταῦθα ἐνέμετο, τὸν μὲν ὁλόκληρον πρὸς τὴν γῆν ἔχουσα καὶ τὴν τῶν κυνηγῶν ἔφοδον παρατηρουμένη, τὸν δὲ πεπηρωμένον πρὸς τὴν θάλασσαν· ἔνθεν γὰρ οὐδένα ὑφωρᾶτο κίνδυνον. Καὶ δή τινες παραπλέοντες ἐκεῖνον τὸν τόπον καὶ θεασάμενοι αὐτὴν κατηυστόχησαν. Καὶ ἐπειδὴ ἐλιποψύχει, εἶπε πρὸς αὑτήν· « Ἀλλ’ ἐγὼ ἀθλία, ἥτις τὴν γῆν ὡς ἐπίϐουλον φυλαττομένη πολὺ χαλεπωτέραν ἔσχον τὴν θάλασσαν ἐφ’ ἣν κατέφυγον. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις παρὰ τὴν ἡμετέραν ὑπόληψιν τὰ μὲν χαλεπὰ τῶν πραγμάτων δοκοῦντα εἶναι ὠφέλιμα εὑρίσκεται, τὰ δὲ σωτήρια νομιζόμενα ἐπισφαλῆ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 72 Pb 76 Pc 37 Pe 42 Pf 35 Ph 37 Ma 55 Mb 43 Me 50 Mf 45 Ca 63.</p>
+          <bibl>Codd. Pa 72 Pb 76 Pc 37 Pe 42 Pf 35 Ph 37 Ma 55 Mb 43 Me 50 Mf 45 Ca 63.</bibl>
           <p><milestone unit="traduction"/>Une biche qui avait un œil crevé se rendit sur le rivage de la mer et se mit à y paître, tournant son œil intact vers la terre pour surveiller l’arrivée des chasseurs, et l’œil mutilé vers la mer, d’où elle ne soupçonnait aucun danger. Mais voilà que des gens qui naviguaient le long de cet endroit l’aperçurent, l’ajustèrent et l’abattirent. Tout en rendant l’âme, elle se dit à elle-même : « Vraiment je suis bien malheureuse ; je surveillais la terre que je croyais pleine d’embûches, et la mer, où je comptais trouver un refuge, m’a été beaucoup plus funeste. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que souvent notre attente est trompée : les choses qui nous semblaient fâcheuses tournent à notre avantage, et celles que nous tenions pour salutaires se montrent préjudiciables.</p>
         </div>
@@ -3142,7 +3141,7 @@
           <pb ed="perry" n="P75"/>
           <p><milestone unit="recitprose"/>Ἔλαφος τὸν ἕτερον πεπηρωμένη τῶν ὀφθαλμῶν ἐπ’ ἠϊόνος ἐνέμετο, τὸν μὲν ὑγιᾶ τῶν ὀφθαλμῶν πρὸς τὴν ξηρὰν διὰ τοὺς κυνηγετοῦντας ἔχουσα, τὸν δὲ λοιπὸν πρὸς θάλατταν, ὅθεν οὐδὲν ὑπώπτευε. Παραπλέοντες δέ τινες καὶ τούτου στοχασάμενοι αὐτῆς κατετόξευσαν. Ἡ δ’ ἑαυτὴν ὠλοφύρετο ὡς ὑφ’ ἧς μὲν ἐδεδοίκει μηδὲν παθοῦσα, ἣν δ’ οὐκ ᾤετο κακὸν ἐπάξειν, ὑπὸ ταύτης προδεδομένη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἡμῖν τὰ μὲν βλαϐερὰ δοκοῦντα ὠφέλιμα γίνεται, τὰ δ’ ὠφέλιμα βλαϐερά.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 63 Lb 43 Le 43 Lf 63 Md 118 Mg 66 Mi 33 Mj 52 Ml 58 Mm 66.</p>
+          <bibl>Codd. La 63 Lb 43 Le 43 Lf 63 Md 118 Mg 66 Mi 33 Mj 52 Ml 58 Mm 66.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-107">
@@ -3153,7 +3152,7 @@
           <pb ed="perry" n="P98"/>
           <l><milestone unit="recitvers"/>Ἔριφος ἐπί τινος δώματος ἑστώς, ἐπειδὴ λύκον παριόντα εἶδεν, ἐλοιδόρει καὶ ἔσκωπτεν αὐτόν. Ὁ δὲ λύκος ἔφη· « Ὦ οὗτος, οὐ σύ με λοιδορεῖς, ἀλλ’ ὁ τόπος. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις καὶ ὁ τόπος καὶ ὁ καιρὸς δίδωσι τὸ θράσος κατὰ τῶν ἀμεινόνων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pg 62 Ma 71 Mb 57 et 242.</p>
+          <bibl>Codd. Pg 62 Ma 71 Mb 57 et 242.</bibl>
           <p><milestone unit="traduction"/>Un chevreau qui se trouvait à l’intérieur d’une maison vit passer un loup. Il se mit à l’injurier et à le railler, Le loup répliqua : « Pauvre hère, ce n’est pas toi qui m’injuries, c’est le lieu où tu es. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent c’est le lieu et l’occasion qui donnent l’audace de braver les puissants.</p>
         </div>
@@ -3163,7 +3162,7 @@
           <pb ed="perry" n="P98"/>
           <p><milestone unit="recitprose"/>Ἔριφος ἐπί τινος δώματος ἑστώς, ἐπειδὴ λύκον παριόντα εἶδεν, ἐλοιδόρει καὶ ἔσκωπτεν αὐτόν. Ὁ δὲ λύκος ἔφη· « Ὦ οὗτος, οὐ σύ με λοιδορεῖς, ἀλλ’ ὁ τόπος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις καὶ ὁ τόπος καὶ ὁ καιρὸς δίδωσι τὸ θράσος κατὰ τῶν ἀμεινόνων.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 143 Lc 52 Lg 52 Md 52 Mm 65 — Ca 75 Cb 48 Cd 45 Ce 50 Cf 54 Ch 55 Mc 47 Ml 70.</p>
+          <bibl>Codd. La 143 Lc 52 Lg 52 Md 52 Mm 65 — Ca 75 Cb 48 Cd 45 Ce 50 Cf 54 Ch 55 Mc 47 Ml 70.</bibl>
         </div>
         <div>
           <head>Chambry 107.3</head>
@@ -3171,7 +3170,7 @@
           <pb ed="perry" n="P98"/>
           <p><milestone unit="recitprose"/>Ἔριφος ἑστὼς ἐπί τινος δώματος λύκον τινὰ παριόντα καὶ τὴν πορείαν ἐκεῖθεν ποιούμενον ἐλοιδόρει καὶ αἱμοϐόρον ἐκάλει καὶ ὠμόφαγον. Ὁ δὲ ἔφη· « Οὐ σύ με λοιδορεῖς, ἀλλ’ ὁ τόπος ἐν ᾧ ἵστασαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις καὶ ὁ τόπος καὶ ὁ χρόνος δίδωσι τοῖς ἥττοσι θράσος κατὰ τῶν ἀμεινόνων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Mk 51 Mh 47.</p>
+          <bibl>Codd. Mk 51 Mh 47.</bibl>
         </div>
         <div>
           <head>Chambry 107.4</head>
@@ -3179,7 +3178,7 @@
           <pb ed="perry" n="P98"/>
           <p><milestone unit="recitprose"/>Λύκος διήρχετο ἔξω τοῦ τείχους, ἔνθα ἀρνὸς παρακύψας ὕϐριζε πολλὰ τὸν λύκον. Κἀκεῖνος τοὺς ὀδόντας τρίζων εἶπεν· « Ὁ τόπος με λοιδορεῖ· σὺ μὴ καυχῶ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καὶ καιροὶ φέρουσι καὶ τόπων διαστάσεις εὐτελίζεσθαι καὶ ἀτιμάζεσθαι παρὰ εὐτελῶν καὶ ἀγενῶν ἐνδόξους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 81 Bb 51.</p>
+          <bibl>Codd. Ba 81 Bb 51.</bibl>
         </div>
         <div>
           <head>Chambry 107.5</head>
@@ -3192,7 +3191,7 @@
           <l><milestone unit="recitvers"/>« Αὐτὸς ὁ τόπος κατακρατεῖ με κάτω·</l>
           <l><milestone unit="recitvers"/>μὴ μάλα καυχῶ, ἀτυχέστατον ζῷον. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι καιροὶ φέρουσι καὶ τόπων διαστάσεις εὐτελίζεσθαι καὶ ἀτιμάζεσθαι παρὰ εὐτελῶν καὶ ἀγενῶν ἀνθρώπων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 106.</p>
+          <bibl>Cod. Mb 106.</bibl>
         </div>
         <div>
           <head>Chambry 107.6</head>
@@ -3200,7 +3199,7 @@
           <pb ed="perry" n="P98"/>
           <p><milestone unit="recitprose"/>Ἀρνὸς ἐφ’ ὑψηλοῦ πύργου ἱστάμενος λύκον κάτωθεν παρίοντα τὴν ὁδὸν ἔσκωπτε, καὶ θηρίον κακὸν ἀπεκάλει καὶ αἱμοϐόρον. Ὁ δὲ λύκος στραφεὶς εἶπε πρὸς αὐτόν· « Οὐ σύ με λοιδορεῖς, ἀλλ’ ὁ πύργος ἐν ᾧ ἵστασαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς ὑπομένοντας ὕϐριν ἀπὸ ἀναξίων ἀνθρώπων διὰ φόϐον ὑψηλοτέρων.</p>
-          <p><milestone unit="manuscrits"/>Cod. T 4.</p>
+          <bibl>Cod. T 4.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-108">
@@ -3211,7 +3210,7 @@
           <pb ed="perry" n="P97"/>
           <p><milestone unit="recitprose"/>Ἔριφος ὑστερήσας ἀπὸ ποίμνης ὑπὸ λύκου κατεδιώκετο· ἐπιστραφεὶς δὲ ὁ ἔριφος λέγει τῷ λύκῳ· « Πέπεισμαι, λύκε, ὅτι σὸν βρῶμά εἰμι· ἀλλ’ ἵνα μὴ ἀδόξως ἀποθάνω, αὔλησον, ὅπως ὀρχήσωμαι. » Αὐλοῦντος δὲ τοῦ λύκου καὶ ὀρχουμένου τοῦ ἐρίφου, οἱ κύνες ἀκούσαντες καὶ ἐξελθόντες κατεδίωκον τὸν λύκον. Ἐπιστραφεὶς δὲ ὁ λύκος λέγει τῷ ἐρίφῳ· « Ταῦτα ἐμοὶ καλῶς γίνεται· ἔδει γάρ με μακελλάριον ὄντα αὐλητὴν μὴ μιμεῖσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ παρὰ γνώμην τοῦ καιροῦ τι πράττοντες καὶ ὧν ἐν χερσὶν ἔχουσιν ὑστεροῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 92 Pb 98 Pe 58 Pg 59 Ma 70 Mb 56 Ca 74.</p>
+          <bibl>Codd. Pa 92 Pb 98 Pe 58 Pg 59 Ma 70 Mb 56 Ca 74.</bibl>
           <p><milestone unit="traduction"/>Un chevreau, étant resté en arrière du troupeau, était poursuivi par un loup. Il se retourna et lui dit : « Je sais bien, loup, que je suis destiné à ton repas ; mais pour que je ne meure pas sans honneur, joue de la flûte et fais-moi danser. » Tandis que le loup jouait et que le chevreau dansait, les chiens accoururent au bruit et donnèrent la chasse au loup. Celui-ci, se retournant, dit au chevreau : « C’est bien fait pour moi ; car, étant boucher, ce n’était pas à moi à faire le flûtiste. »</p>
           <p><milestone unit="traduction"/>Ainsi quand on fait quelque chose sans avoir égard aux circonstances, on se voit enlever même ce qu’on tient dans la main.</p>
         </div>
@@ -3221,7 +3220,7 @@
           <pb ed="perry" n="P97"/>
           <p><milestone unit="recitprose"/>Ἔριφος πλανηθεῖσα τῆς ποίμνης ὑπὸ λύκου ἐδιώκετο. Τῆς δὲ ἐρίφου ἀτονησάσης καὶ τοῦ λύκου καταλαϐόντος, στραφεῖσα ἡ ἔριφος πρὸς τὸν λύκον εἶπεν· « Ὅτι μὲν σὸν βρῶμά εἰμι ἀκριϐῶς ἐπίσταμαι, ἀλλὰ ἵνα μὴ ἀδόξως ἀποθάνω, αὔλει μοι ὡς ὀρχῶμαι. » Τοῦ δὲ λύκου αὐλοῦντος καὶ τῆς ἐρίφου ὀρχουμένης, οἱ κύνες τοῦ ποιμένος ἀκούσαντες τὸν λύκον κατέλαϐον καὶ ἐδίωκον, κἀκεῖνος φεύγων ἐφώνει· « Ἀξίως πάσχω· ἔδει γάρ με ἀντ’ αὐλητοῦ μακελλάριον εἶναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καὶ τοῖς φύσει πονηροῖς ἡ διὰ λόγων ταπείνωσις οἶδε κατάνυξιν ἐμποιεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 43 Ph 45 Me 60 Mf 54.</p>
+          <bibl>Codd. Pf 43 Ph 45 Me 60 Mf 54.</bibl>
         </div>
         <div>
           <head>Chambry 108.3</head>
@@ -3229,7 +3228,7 @@
           <pb ed="perry" n="P97"/>
           <p><milestone unit="recitprose"/>Ἔριφος ὑστερήσασα τῆς ποίμνης ὑπὸ λύκου κατεδιώκετο· ἐπιστραφεῖσα δὲ πρὸς αὐτὸν εἶπεν· « Ὦ λύκε, ἐπεὶ πέπεισμαι ὅτι σὸν βρῶμα γενήσομαι, ἵνα μὴ ἀηδῶς ἀποθάνω, αὔλησον πρῶτον, ὅπως ὀρχήσωμαι. » Τοῦ δὲ λύκου αὐλοῦντος καὶ τῆς ἐρίφου ὀρχουμένης, οἱ κύνες ἀκούσαντες τὸν λύκον ἐδίωκον. Ὁ δὲ ἐπιστραφεὶς τῇ ἐρίφῳ φησί· « Δικαίως ταῦτά μοι γίνεται· ἔδει γάρ με μάγειρον ὄντα αὐλητὴν μὴ μιμεῖσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τῶν μὲν πρὸς ἃ πεφύκασι ἀμελοῦντες, τὰ δὲ ἑτέρων ἐπιτηδεύειν πειρώμενοι δυστυχίαις περιπίπτουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 98 Lb 53 Le 53 Lf 98 Lh 20 Mg 76 Mi 87 Mj 63 Ml 64.</p>
+          <bibl>Codd. La 98 Lb 53 Le 53 Lf 98 Lh 20 Mg 76 Mi 87 Mj 63 Ml 64.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-109">
@@ -3240,7 +3239,7 @@
           <pb ed="perry" n="P88"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς βουλόμενος γνῶναι ἐν τίνι τιμῇ παρὰ ἀνθρώποις ἐστίν, ἧκεν ἀφομοιωθεὶς ἀνθρώπῳ εἰς ἀγαλματοποιοῦ ἐργαστήριον. Καὶ θεασάμενος Διὸς ἄγαλμα ἐπυνθάνετο πόσου. Εἰπόντος δὲ αὐτοῦ ὅτι δραχμῆς, γελάσας ἠρώτα τὸ τῆς Ἥρας πόσου. Εἰπόντος δὲ ἔτι μείζονος, θεασάμενος καὶ αὑτοῦ ἄγαλμα ὑπέλαϐεν ὅτι αὐτόν, ἐπειδὴ καὶ ἄγγελός ἐστι καὶ ἐπικερδής, περὶ πολλοῦ ποιοῦνται οἱ ἄνθρωποι. Διόπερ ἐπυνθάνετο ὁ Ἑρμῆς πόσου, καὶ ὁ ἀγαλματογλύφος ἔφη· « Ἀλλ’ ἐὰν τούτους ἀγοράσῃς, τοῦτόν σοι προσθήκην δώσω. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα κενόδοξον ἐν οὐδεμίᾳ μοίρᾳ παρὰ τοῖς ἄλλοις ὄντα ὁ λόγος ἁρμόζει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 85 Pb 89 Pc 46 Pe 53 Pg 56.</p>
+          <bibl>Codd. Pa 85 Pb 89 Pc 46 Pe 53 Pg 56.</bibl>
           <p><milestone unit="traduction"/>Hermès, voulant savoir en quelle estime il était parmi les hommes, se rendit, sous la figure d’un mortel, dans l’atelier d’un statuaire, et, avisant une statue de Zeus, il demanda : « Combien ? » On lui répondit : « Une drachme. » Il sourit et demanda : « Combien la statue de Héra ? — C’est plus cher, » lui dit-on. Apercevant aussi une statue qui le représentait, il présuma qu’étant à la fois messager de Zeus et dieu du gain, il était en haute estime chez les hommes. Aussi s’informa-t-il du prix. Le sculpteur répondit : « Eh bien ! si tu achètes les deux premières, je te donnerai celle-ci par-dessus le marché. »</p>
           <p><milestone unit="traduction"/>Cette fable convient à un homme vaniteux qui ne jouit d’aucune considération chez autrui.</p>
         </div>
@@ -3250,7 +3249,7 @@
           <pb ed="perry" n="P88"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς γνῶναι βουλόμενος ἐν τίνι τιμῇ παρ’ ἀνθρώποις ἐστίν, ἧκεν εἰς ἀγαλματοποιοῦ, ἑαυτὸν εἰκάσας ἀνθρώπῳ, καὶ θεασάμενος ἄγαλμα τοῦ Διὸς ἠρώτα πόσου τις αὐτὸ πρίασθαι δύναται. Τοῦ δὲ εἰπόντος δραχμῆς, γελάσας πόσου τὸ τῆς Ἥρας ἔφη. Εἰπόντος δὲ πλείονος, ἰδὼν καὶ τὸ ἑαυτοῦ ἄγαλμα, καὶ νομίσας ὡς, ἐπειδὴ ἄγγελός ἐστι θεῶν καὶ κερδῷος, πολὺν αὐτοῦ παρὰ τοῖς ἀνθρώποις εἶναι τὸν λόγον, ἤρετο περὶ αὐτοῦ. Ὁ δ’ ἀγαλματοποιὸς ἔφη· « Ἐὰν τούτους ὠνήσῃ, καὶ τοῦτον προσθήκην σοι δίδωμι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρα κενόδοξον οὐδεμίᾳ παρ’ ἄλλοις ὄντα τιμῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 94 Lb 49 Le 49 Lf 94 Me 56 Mf 50 Mg 72 Mj 59 Ml 65.</p>
+          <bibl>Codd. La 94 Lb 49 Le 49 Lf 94 Me 56 Mf 50 Mg 72 Mj 59 Ml 65.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-110">
@@ -3259,7 +3258,7 @@
         <pb ed="perry" n="P102"/>
         <p><milestone unit="recitprose"/>Ζεὺς πλάσας ἄνδρα καὶ γυναῖκα ἐκέλευσεν Ἑρμῆν ἀγαγεῖν αὐτοὺς ἐπὶ τὴν Γῆν καὶ δεῖξαι ὅθεν ὀρύσσοντες τροφὴν ἑαυτοῖς πορίσουσι. Τοῦ δὲ τὸ προσταχθὲν ποιήσαντος, ἡ Γῆ τὸ μὲν πρῶτον ἐκώλυεν. Ὡς δὲ Ἑρμῆς ἠνάγκαζε λέγων τὸν Δία προστεταχέναι, ἔφη· « Ἀλλ’ ὀρυσσέτωσαν ὅσον βούλονται· στένοντες γὰρ αὐτὸ καὶ κλαίοντες ἀποδώσουσι. »</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς ῥᾳδίως δανειζομένους, μετὰ λύπης δὲ ἀποδιδόντας ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 95 Pb 102 Pc 52 Pf 51 Pg 66 Ma 74 Me 66 Mf 58 Mj 66.</p>
+        <bibl>Codd. Pa 95 Pb 102 Pc 52 Pf 51 Pg 66 Ma 74 Me 66 Mf 58 Mj 66.</bibl>
         <p><milestone unit="traduction"/>Zeus, ayant façonné l’homme et la femme dit à Hermès de les mener sur la terre et de leur montrer à quel endroit ils devaient creuser la terre pour se procurer des aliments. Hermès ayant rempli sa mission, la terre fit d’abord résistance ; mais Hermès insista en disant que c’était l’ordre de Zeus. « Eh bien ! dit-elle, qu’ils creusent tant qu’ils voudront : ils me le paieront de leurs soupirs et de leurs larmes. »</p>
         <p><milestone unit="traduction"/>La fable convient à ceux qui empruntent facilement et s’acquittent avec peine.</p>
       </div>
@@ -3271,7 +3270,7 @@
           <pb ed="perry" n="P89"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς βουλόμενος τὴν Τειρεσίου μαντικὴν πειρᾶσαι εἰ ἀληθής ἐστι, κλέψας αὐτοῦ τοὺς βόας ἐξ ἀγροῦ, ἧκε πρὸς αὐτὸν εἰς ἄστυ, ὁμοιωθεὶς ἀνθρώπῳ, καὶ ἐπεξενώθη παρ’ αὐτῷ. Παραγγελθείσης δὲ τῷ Τειρεσίᾳ τῆς τοῦ ζεύγους ἀπωλείας, παραλαϐὼν τὸν Ἑρμῆν, ἧκεν εἰς τὸ προαστεῖον, οἰωνόν τινα περὶ τῆς κλοπῆς σκεψόμενος, καὶ τούτῳ παρῄνει λέγειν ὅ τι ἂν θεάσηται ὄρνεον. Καὶ ὁ Ἑρμῆς τὸ μὲν πρῶτον θεασάμενος ἀετὸν ἐξ ἀριστερῶν ἐπὶ δεξιὰ παριπτάμενον, ἀπήγγειλεν αὐτῷ. Τοῦ δὲ εἰπόντος μὴ πρὸς αὐτοὺς τοῦτον εἶναι, ἐκ δευτέρου ἰδὼν κορώνην ἐπί τινος δένδρου καθημένην, καὶ ποτὲ μὲν ἄνω βλέπουσαν, ποτὲ δὲ εἰς γῆν κύπτουσαν, ἐδήλωσεν αὐτῷ. Ὁ δὲ ὑποτυχὼν ἔφη· « Ἀλλ’ αὕτη γε ἡ κορώνη διόμνυται τόν τε Οὐρανὸν καὶ τὴν Γῆν ὅτι, ἂν σὺ θέλῃς, τοῦς ἐμαυτοῦ βόας ἀπολήψομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα κλέπτην.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 90 Pf 44 Ph 46.</p>
+          <bibl>Codd. Pb 90 Pf 44 Ph 46.</bibl>
           <p><milestone unit="traduction"/>Hermès voulant mettre à l’épreuve l’art divinatoire de Tirésias et voir s’il était véridique, lui vola ses bœufs à la campagne, puis vint le trouver à la ville, sous la figure d’un mortel, et descendit chez lui. Averti de la perte de son attelage, Tirésias prit avec lui Hermès, se rendit au faubourg pour observer un augure au sujet du vol, et il pria Hermès de lui dire l’oiseau qu’il apercevrait. Hermès vit d’abord un aigle qui passait en volant de gauche à droite, et il le lui dit. Tirésias répondit que cet oiseau ne les concernait pas. À la deuxième fois, le dieu vit une corneille perchée sur un arbre, qui tantôt levait les yeux en haut, tantôt se penchait vers le sol, et il le lui annonça. Le devint reprit alors : « Eh bien ! cette corneille jure par le ciel et la terre qu’il ne tient qu’à toi que je recouvre mes bœufs. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à un voleur.</p>
         </div>
@@ -3281,7 +3280,7 @@
           <pb ed="perry" n="P89"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς βουλόμενος τὴν Τειρεσίου μαντικὴν εἰ ἀληθής ἐστι γνῶναι, κλέψας τὰς αὐτοῦ βοῦς ἐξ ἀγροικίας, ἧκεν ὡς αὐτὸν εἰς ἄστυ, ὁμοιωθεὶς ἀνθρώπῳ, καὶ παρ’ αὐτῷ κατήχθη. Τῆς δὲ τῶν βοῶν ἀπωλείας ἀγγελθείσης τῷ Τειρεσίᾳ, ἐκεῖνος παραλαϐὼν τὸν Ἑρμῆν ἐξῆλθεν, οἰωνόν τινα περὶ τοῦ κλέπτου σκεψόμενος καὶ τούτῳ παρῄνει φράζειν αὐτῷ ὅντινα ἂν τῶν ὀρνίθων θεάσηται. Ὁ δὲ Ἑρμῆς τὸ μὲν πρῶτον θεασάμενος ἀετὸν ἐξ ἀριστερῶν ἐπὶ τὰ δεξιὰ διιπτάμενον, ἔφρασε. Τοῦ δὲ φήσαντος μὴ πρὸς αὐτοὺς εἶναι τοῦτον, ἐκ δευτέρου κορώνην εἶδεν ἐπί τινος δένδρου καθημένην, καὶ ποτὲ μὲν ἄνω βλέπουσαν, ποτὲ δὲ πρὸς τὴν γῆν κατακύπτουσαν, καὶ τῷ μάντει φράζει. Καὶ ὃς ὑποτυχὼν εἶπεν· « Ἀλλ’ αὕτη γε ἡ κορώνη διόμνυται τόν τε Οὐρανὸν καὶ τὴν Γῆν ὡς, ἐὰν σὺ θέλῃς, τὰς ἐμὰς ἀπολήψομαι βοῦς. »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα κλέπτην.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 95 Lb 50 Le 50 Lf 95 Me 57 Mf 51 Mg 73 Mj 60 Ml 66.</p>
+          <bibl>Codd. La 95 Lb 50 Le 50 Lf 95 Me 57 Mf 51 Mg 73 Mj 60 Ml 66.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-112">
@@ -3290,7 +3289,7 @@
         <pb ed="perry" n="P103"/>
         <p><milestone unit="recitprose"/>Ζεὺς Ἑρμῇ προσέταξε πᾶσι τοῖς τεχνίταις ψεύδους φάρμακον χέαι. Ὁ δὲ τοῦτο τρίψας καὶ μέτρον ποιήσας ἴσον ἑκάστῳ ἐνέχει. Ἐπεὶ δέ, μόνου τοῦ σκυτέως ὑπολειφθέντος, πολὺ φάρμακον κατελείπετο, λαϐὼν ὅλην τὴν χύσιν κατ’ αὐτοῦ κατέχεεν. Ἐκ τούτου συνέϐη τοὺς τεχνίτας πάντας ψεύδεσθαι, μάλιστα δὲ πάντων τοὺς σκυτέας.</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ψευδολόγον ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 96 et 101 Pf 52 Ph 53 Ma 75 Mb 58 Me 67 Mf 59 Mj 67 — La 107 Lb 55 Le 55 Lf 107 Lh 19 Ml 72.</p>
+        <bibl>Codd. Pa 96 et 101 Pf 52 Ph 53 Ma 75 Mb 58 Me 67 Mf 59 Mj 67 — La 107 Lb 55 Le 55 Lf 107 Lh 19 Ml 72.</bibl>
         <p><milestone unit="traduction"/>Zeus avait chargé Hermès de verser à tous les artisans le poison du mensonge. Hermès le broya, et faisant la part égale pour chacun, il le leur versa. Mais, comme il ne restait plus que le cordonnier et qu’il y avait encore beaucoup de poison, il prit tout le mortier et le versa sur lui. C’est depuis lors que tous les artisans sont menteurs, mais plus que tous les cordonniers.</p>
         <p><milestone unit="traduction"/>Cette fable s’applique à un homme qui tient des propos mensongers.</p>
       </div>
@@ -3302,7 +3301,7 @@
           <pb ed="perry" n="P309"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς ποτε ἅμαξαν ψευσμάτων καὶ πανουργίας καὶ ἀπάτης μεστὴν διὰ πάσης ἤλαυνε γῆς, κατὰ χώραν μικρόν τι διανέμων τοῦ φόρτου. Ὡς δὲ εἰς τὴν τῶν Ἀράϐων χώραν ἦλθε, λέγεται ἐξαίφνης συντριϐῆναι τὴν ἅμαξαν. Οἱ δὲ ὥσπερ πολύτιμον φόρτον τὰ ἐξ αὐτῆς ἁρπάσαντες οὐκ ἀφῆκαν εἰς ἀλλους ἀνθρώπους προελθεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι Ἄραϐες ὑπὲρ πᾶν ἔθνος ψευσταὶ καὶ ἀπατεῶνές εἰσιν· ἐν γλώσσῃ γὰρ αὐτῶν οὐκ ἔστιν ἀλήθεια.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 40.</p>
+          <bibl>Cod. Ba 40.</bibl>
           <p><milestone unit="traduction"/>Un jour Hermès conduisait par toute la terre un chariot rempli de mensonges, de fourberies et de tromperies, et dans chaque pays il distribuait une petite portion de son chargement. Mais, quand il fut arrivé dans le pays des Arabes, le chariot, dit-on, se brisa soudain ; et les Arabes, comme s’il s’agissait d’un chargement précieux, pillèrent le contenu du chariot, et ne laissèrent pas le dieu aller chez d’autres peuples.</p>
           <p><milestone unit="traduction"/>Plus que tout autre peuple les Arabes sont menteurs et trompeurs ; leur langue en effet ne connaît pas la vérité.</p>
         </div>
@@ -3311,7 +3310,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P309"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς ποτε ψεύσματα καὶ πανουργίας θεὶς εἴς ἅμαξαν εἰς πᾶσαν γῆν ἀπῄει. Ὡς δὲ Ἀράϐων κατήντησε τὴν χώραν, συντρίϐει τὴν ἅμαξαν κενὴν φορτίων· οἱ δὲ εἰς ἄλλους τόπους οὐκ εἴασαν ὀδεῦσαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 52.</p>
+          <bibl>Cod. Mb 52.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-114">
@@ -3319,7 +3318,7 @@
         <head type="sub">Εὔνουχος καὶ ἱερεύς — L’eunuque et le sacrificateur.</head>
         <pb ed="perry" n="P310"/>
         <p><milestone unit="recitprose"/>Εὔνουχος προσῆλθε ἱερεῖ, θυσίαν ὑπὲρ αὐτοῦ ποιῆσαι παρακαλῶν εἰς τὸ γενέσθαι παίδων πατέρα. Ὁ δὲ ἱερεὺς ἔφη· « Ὅτε μὲν πρὸς τὴν θυσίαν ἀπίδω, πατέρα σε γενέσθαι παίδων παρακαλῶ· ὅτε δὲ τὴν σὴν ὄψιν ἴδω, οὐδ’ ἀνὴρ φαίνῃ. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Bd 19.</p>
+        <bibl>Cod. Bd 19.</bibl>
         <p><milestone unit="traduction"/>Un eunuque alla trouver un sacrificateur et le pria de faire un sacrifice en sa faveur, afin qu’il devînt père. Le sacrificateur lui dit : « Quand je considère le sacrifice, je prie pour que tu deviennes père ; mais quand je vois ta personne, tu ne parais même pas être un homme. »</p>
       </div>
       <div type="poem" xml:id="chambry-115">
@@ -3330,7 +3329,7 @@
           <pb ed="perry" n="P68"/>
           <p><milestone unit="recitprose"/>Δύο ἐχθροὶ ἐν μιᾷ νηῒ ἔπλεον· καὶ βουλόμενοι πολὺ ἀλλήλων διεζεῦχθαι ὥρμησαν ὁ μὲν ἐπὶ τὴν πρώραν, ὁ δὲ ἐπὶ τὴν πρύμναν καὶ ἐνταῦθα ἔμενον. Χειμῶνος δὲ σφοδροῦ καταλαϐόντος καὶ τῆς νηὸς περιτρεπομένης, ὁ ἐν τῇ πρύμνῃ ἐπυνθάνετο παρὰ τοῦ κυϐερνήτου περὶ ποῖον μέρος καταδύεσθαι τὸ σκάφος πρῶτον κινδυνεύει. Τοῦ δὲ εἰπόντος· « Κατὰ τὴν πρώραν, » ἔφη· « Ἀλλ’ ἐμοίγε οὐκέτι λυπηρὸς ὁ θάνατός ἐστιν, εἴγε ὁρᾶν μέλλω τὸν ἐχθρόν μου ἀποπνιγόμενον πρῶτον. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων διὰ τὴν πρὸς τοὺς πέλας δυσμένειαν αἱροῦνται καὶ αὐτοί τι δεινὸν πάσχειν ὑπὲρ τοῦ κἀκείνους ὁρᾶν συνδυστυχοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 67 Pb 68 Pc 34 Pe 35 Pf 32 Pg 44 Ph 34 Ma 48.</p>
+          <bibl>Codd. Pa 67 Pb 68 Pc 34 Pe 35 Pf 32 Pg 44 Ph 34 Ma 48.</bibl>
         </div>
         <div>
           <head>Chambry 115.2</head>
@@ -3338,7 +3337,7 @@
           <pb ed="perry" n="P68"/>
           <p><milestone unit="recitprose"/>Δύο τινὲς πρὸς ἀλλήλους ἔχθραν ἔχοντες ἐν μιᾷ νηῒ ἔπλεον. Βουλόμενοι δὲ πολὺ ἀπ’ ἀλλήλων διεζεῦχθαι, ὥρμησεν ὁ μὲν εἷς ἐπὶ τὴν πρώραν, ὁ δὲ ἕτερος ἐπὶ τὴν πρύμναν, καὶ ἐνταῦθα ἔμενον. Χειμῶνος δὲ σφοδροῦ καταλαϐόντος καὶ τῆς νηὸς καταποντίζεσθαι μελλούσης, ὁ ἐπὶ τῇ πρύμνῃ καθήμενος ἐπυνθάνετο, τῷ κυϐερνήτῃ λέγων· « Ὦ οὗτος, ποῖον μέρος μέλλει πρότερον καταποντίζεσθαι τοῦ σκάφους ; » Τοῦ δὲ εἰπόντος· « Ἡ πρώρα, » ἔφη· « Ἀλλ’ ἔμοιγε οὐκέτι λυπηρὸς ὁ θάνατος ἔσται, εἴγε ὁρᾶν μέλλω τὸν ἐχθρόν μου προαποπνιγόμενον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ τῶν ἀνθρώπων διὰ τὴν πρὸς τοὺς ἐχθροὺς μῆνιν αἱροῦνται τὸ πρῶτον ἰδεῖν αὐτοὺς ἐπὶ συμφορὰν διὰ τὴν δυσμένειαν· ἔπειτα καὶ αὐτοὶ μετὰ ταῦτα, ἐάν τι δεινὸν πάσχωσιν, ὑπομένουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 58 Cb 40 Cd 37 Ce 42 Cf 46 Ch 47 Mc 40 Mh 40 Mk 44.</p>
+          <bibl>Codd. Ca 58 Cb 40 Cd 37 Ce 42 Cf 46 Ch 47 Mc 40 Mh 40 Mk 44.</bibl>
         </div>
         <div>
           <head>Chambry 115.3</head>
@@ -3346,7 +3345,7 @@
           <pb ed="perry" n="P68"/>
           <p><milestone unit="recitprose"/>Δύο τινὲς ἀλλήλοις ἐχθραίνοντες ἐπὶ τῆς αὐτῆς νεὼς ἔπλεον, ὧν ἅτερος μὲν ἐπὶ τῆς πρύμνης, ἅτερος δὲ ἐπὶ τῆς πρώρας ἐκάθητο. Χειμῶνος δὲ ἐπιγενομένου καὶ τῆς νεὼς μελλούσης ἤδη καταποντίζεσθαι, ὁ ἐπὶ τῆς πρύμνης τὸν κυϐερνήτην ἤρετο πότερον τῶν μερῶν τοῦ πλοίου πρότερον μέλλει καταϐαπτίζεσθαι. Τοῦ δὲ τὴν πρώραν εἰπόντος· « Ἀλλ’ ἔμοιγε οὐκ ἔστι λυπηρόν, εἶπεν, ὁ θάνατος, εἴγε ὁρᾶν μέλλω πρὸ ἐμοῦ τὸν ἐχθρὸν ἀποθνῄσκοντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ τῶν ἀνθρώπων οὐδὲν τῆς ἑαυτῶν βλάϐης φροντίζουσιν, ἐὰν τοὺς ἐχθροὺς μόνον ἴδωσι πρὸ αὐτῶν κακουμένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 27 Lb 38 Lc 15 Le 38 Lf 27 Lg 15 Md 45 Me 45 Mf 40 Mg 47 Mi 80 Mj 44 Ml 49 Mm 57.</p>
+          <bibl>Codd. La 27 Lb 38 Lc 15 Le 38 Lf 27 Lg 15 Md 45 Me 45 Mf 40 Mg 47 Mi 80 Mj 44 Ml 49 Mm 57.</bibl>
           <p><milestone unit="traduction"/>Deux hommes qui se haïssaient naviguaient sur le même vaisseau ; l’un s’était posté à la poupe et l’autre à la proue. Une tempête étant survenue et le vaisseau étant sur le point de couler, l’homme qui était à la poupe demanda au pilote quelle partie du navire devait sombrer la première. « La proue, » dit le pilote. « Alors, reprit l’homme, la mort n’a rien de triste pour moi, si je dois voir mon ennemi mourir avant moi. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que beaucoup de gens ne s’inquiètent aucunement du dommage qui leur arrive, pourvu qu’ils voient leurs ennemis endommagés avant eux.</p>
         </div>
@@ -3359,7 +3358,7 @@
           <pb ed="perry" n="P96"/>
           <p><milestone unit="recitprose"/>Ἔχις ἐπὶ παλιούρων δέσμῃ ὑπὲρ ποταμὸν παρεφέρετο. Ἀλώπηξ δὲ παριοῦσα, ὡς ἐθεάσατο αὐτόν, εἶπεν· « Ἄξιος τῆς νηὸς ὁ ναύκληρος. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα πονηρὸν μοχθηροῖς πράγμασιν ἐγχειρήσαντα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 91 Pb 97 Pc 49 Pe 57 Pg 58 Ma 69.</p>
+          <bibl>Codd. Pa 91 Pb 97 Pc 49 Pe 57 Pg 58 Ma 69.</bibl>
           <p><milestone unit="traduction"/>Une vipère était emportée sur un fagot d’épines par le courant d’une rivière. Un renard qui passait, l’ayant vue, s’écria : « Le pilote vaut le vaisseau. »</p>
           <p><milestone unit="traduction"/>Ceci s’adresse à un méchant homme qui se livre à des entreprises perverses.</p>
         </div>
@@ -3369,7 +3368,7 @@
           <pb ed="perry" n="P96"/>
           <p><milestone unit="recitprose"/>Ἔχις ἐπί τινος φραγμοῦ ἐκ παλιούρων εὐνάζετο, ὃς ἦν ἐπ’ ἀμπέλῳ τοῦ ποταμοῦ πλησίον. Τοῦ δὲ ποταμοῦ ὑπὸ συνεχῶν ὄμϐρων δεινῶς φυσηθέντος, ἤρθη ὁ φραγμὸς καὶ κάτωθεν ἀπῄει. Τοῖς δὲ παλιούροις ἡ ἔχις συνεπλάκη καὶ ἐφέρετο τοῦ ποταμοῦ εἰς μέσον καί τις κατιδοῦσα ἀλώπηξ σφόδρα γελάσασα ἔφη· « Κακὴ μὲν ἡ ναῦς, ἀξία δὲ τοῦ ναύτου καὶ ἄξιος τῆς νηὸς ὁ ναύκληρος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καὶ [ὡς] κακοὶ σὺν κακοῖς ἀπολοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 54.</p>
+          <bibl>Cod. Mb 54.</bibl>
         </div>
         <div>
           <head>Chambry 116.3</head>
@@ -3384,7 +3383,7 @@
           <l><milestone unit="recitvers"/>Καί τις δὲ ἰδὼν μέγα γελάσας ἔφη·</l>
           <l><milestone unit="recitvers"/>« Ἡ μὲν ναῦς κακή, ἀξία δὲ τοῦ ναύτου. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δικαίως οἱ κακοὶ ἐν κακοῖς ἀπολοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 65 Cd 56 Ma 171 Md 62 Mh 57 Mm 128.</p>
+          <bibl>Codd. Ch 65 Cd 56 Ma 171 Md 62 Mh 57 Mm 128.</bibl>
         </div>
         <div>
           <head>Chambry 116.4</head>
@@ -3392,7 +3391,7 @@
           <pb ed="perry" n="P96"/>
           <p><milestone unit="recitprose"/>Ποταμοῦ πλησίον ἄμπελος ἦν· φραγμὸς δὲ ἦν αὐτῇ παλίουροι. Πλημμύρας δὲ ὁ ποταμὸς ἐξέσυρε παλίουρον. Συνέϐη δὲ δράκοντα ταῖς φολίσι συμπλακέντα τῇ παλιούρῳ φέρεσθαι. Εἶπε δέ τις ἰδών· « Κακὴ μὲν ἡ ναῦς, ἀξία δὲ τοῦ ναύτου. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δικαίως κακοὶ σὺν κακοῖς ἀπόλλυνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 125 Bb 75.</p>
+          <bibl>Codd. Ba 125 Bb 75.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-117">
@@ -3401,7 +3400,7 @@
         <pb ed="perry" n="P93"/>
         <p><milestone unit="recitprose"/>Ἔχις εἰσελθὼν εἰς χαλκουργοῦ ἐργαστήριον παρὰ τῶν σκευῶν ἔρανον ᾔτει· λαϐὼν δὲ παρ’ αὐτῶν ἧκε πρὸς τὴν ῥίνην καὶ αὐτὴν παρεκάλει δοῦναί τι αὐτῷ. Ἡ δὲ ὑποτυχοῦσα εἶπεν· « Ἀλλ’ εὐηθὴς εἶ παρ’ ἐμοῦ τι ἀποίσεσθαι οἰόμενος, ἥτις οὐ διδόναι, ἀλλὰ λαμϐάνειν παρὰ πάντων εἴωθα. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι μάταιοί εἰσιν οἱ παρὰ φιλαργύρων τι κερδανεῖν προσδοκῶντες.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 89 Pb 94 Pf 46 Ph 48 Mb 55 Me 64.</p>
+        <bibl>Codd. Pa 89 Pb 94 Pf 46 Ph 48 Mb 55 Me 64.</bibl>
         <p><milestone unit="traduction"/>Une vipère, s’étant glissée dans l’atelier d’un forgeron, demanda aux outils de lui faire une aumône. Après l’avoir reçue des autres, elle vint à la lime et la pria de lui donner quelque chose. « Tu es bonne, répliqua la lime, de croire que tu obtiendras quelque chose de moi : j’ai l’habitude, non pas de donner, mais de prendre de chacun. »</p>
         <p><milestone unit="traduction"/>Cette fable fait voir que c’est sottise de s’attendre à tirer quelque profit des avares.</p>
       </div>
@@ -3411,7 +3410,7 @@
         <pb ed="perry" n="P90"/>
         <p><milestone unit="recitprose"/>Ἔχις φοιτῶν ἐπί τινα κρήνην ἔπινεν. Ὁ δὲ ἐνταῦθα οἰκῶν ὕδρος ἐκώλυεν αὐτόν, ἀγανακτῶν ὅτι μὴ ἀρκεῖται τῇ ἰδίᾳ νομῇ, ἀλλὰ καὶ ἐπὶ τὴν αὐτοῦ δίαιταν ἀφικνεῖται. Ἀεὶ δὲ τῆς φιλονεικίας αὐξανομένης, συνέθεντο ὅπως εἰς μάχην ἀλλήλοις καταστῶσι καὶ τοῦ νικῶντος ἥ τε τοῦ ὕδατος καὶ τῆς γῆς νομὴ γίνηται. Ταξαμένων δὲ αὐτῶν προθεσμίαν, οἱ βάτραχοι διὰ μῖσος τοῦ ὕδρου παραγενόμενοι πρὸς τὸν ἔχιν παρεθάρσυνον αὐτόν, ἐπαγγελλόμενοι καὶ αὐτοὶ συμμαχήσειν αὐτῷ. Ἐνστάσης δὲ τῆς μάχης, ὁ μὲν ἔχις πρὸς τὸν ὕδρον ἐπολέμει, οἱ δὲ βάτραχοι μηδὲν περαιτέρω δρᾶν δυνάμενοι μεγάλα ἐκεκράγεισαν. Καὶ ὁ ἔχις νικήσας ᾐτιᾶτο αὐτοὺς ὅτι γε συμμαχήσειν αὐτῷ ὑποσχόμενοι παρὰ τὴν μάχην οὐ μόνον οὐκ ἐϐοήθουν, ἀλλὰ καὶ ᾖδον. Οἱ δὲ ἔφασαν πρὸς αὐτόν· « Ἀλλ’ εὖ γε ἴσθι, ὦ οὗτος, ὅτι ἡ ἡμετέρα συμμαχία οὐ διὰ χειρῶν, διὰ δέ μόνης φωνῆς συνέστηκεν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι, ἔνθα χειρῶν χρεία ἐστίν, ἡ διὰ λόγων βοήθεια οὐδὲν λυσιτελεῖ.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 86 Pb 91 Pf 45 Pg 57 Ph 47 Me 63 Mf 56 Mj 64.</p>
+        <bibl>Codd. Pa 86 Pb 91 Pf 45 Pg 57 Ph 47 Me 63 Mf 56 Mj 64.</bibl>
         <p><milestone unit="traduction"/>Une vipère venait régulièrement boire à une source. Une hydre qui l’habitait voulait l’en empêcher, s’indignant que la vipère, non contente de son propre pâtis, envahit encore son domaine à elle. Comme la querelle ne faisait que s’envenimer, elles convinrent de se livrer bataille : celle qui serait victorieuse aurait la possession de la terre et de l’eau. Elles avaient fixé le jour, quand les grenouilles, par haine de l’hydre, vinrent trouver la vipère et l’enhardirent en lui promettant de se ranger de son côté. Le combat s’engagea, et la vipère luttait contre l’hydre, tandis que les grenouilles, ne pouvant faire davantage, poussaient de grands cris. La vipère ayant remporté la victoire leur adressa des reproches : elles avaient, disait-elle, promis de combattre avec elle, et, pendant la bataille, au lieu de la secourir, elles n’avaient fait que chanter. Les grenouilles répondirent : « Sache bien, camarade, que notre aide ne se donne point par les bras, mais par la voix seule. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que, quand on a besoin des bras, les secours en paroles ne servent de rien.</p>
       </div>
@@ -3423,7 +3422,7 @@
           <pb ed="perry" n="P109"/>
           <p><milestone unit="recitprose"/>Ζεὺς πλάσας ἀνθρώπους τὰς μὲν ἄλλας διαθέσεις εὐθὺς αὐτοῖς ἐνέθηκε, μόνης δὲ αἰσχύνης ἐπελάθετο. Διόπερ ἀμηχανῶν πόθεν αὐτὴν εἰσαγάγῃ, ἐκέλευσεν αὐτὴν διὰ τοῦ ἀρχοῦ εἰσελθεῖν. Ἡ δὲ τὸ μὲν πρῶτον ἀντέλεγε καὶ ἠναξιοπάθει. Ἐπεὶ δὲ σφόδρα αὐτῇ ἐπέκειτο, ἔφη· « Ἀλλ’ ἔγωγε ἐπὶ ταύταις ταῖς ὁμολογίαις εἴσειμι ὡς, ἂν ἕτερόν μοι ἐπεισέλθῃ, εὐθέως ἐξελεύσομαι. » Ἀπὸ τούτου συνέϐη πάντας τοὺς πόρνους ἀναισχύντους εἶναι.</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα πόρνον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 108 Pc 55 Pg 69.</p>
+          <bibl>Codd. Pb 108 Pc 55 Pg 69.</bibl>
         </div>
         <div>
           <head>Chambry 119.2</head>
@@ -3431,7 +3430,7 @@
           <pb ed="perry" n="P109"/>
           <p><milestone unit="recitprose"/>Ζεὺς πλάσας τοὺς ἀνθρώπους τὰς μὲν ἄλλας διαθέσεις αὐτοῖς ἐνέθηκε, μόνην δ’ ἐνθεῖναι τὴν αἰσχύνην ἐπελάθετο. Διὸ καὶ μὴ ἔχων πόθεν [ἂν] αὐτὴν εἰσαγάγῃ, διὰ τοῦ ἀρχοῦ αὐτὴν εἰσελθεῖν ἐκέλευσεν. Ἡ δὲ τὸ μὲν πρῶτον ἀντέλεγεν ἀναξιοπαθοῦσα. Ἐπεὶ δὲ σφόδρα αὐτῇ ἐνέκειτο, ἔφη· « Ἀλλ’ ἔγωγε ἐπὶ ταύταις εἰσέρχομαι ταῖς ὁμολογίαις ὡς Ἔρως μὲ εἰσελεύσεται· ἂν δ’ εἰσέλθῃ, αὐτὴ ἐχελεύσομαι παραυτίκα. » Ἀπὸ δὴ τούτου συνέϐη πάντας τοὺς πόρνους ἀναισχύντους εἶναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς ὑπ’ ἔρωτος κατεχομένους ἀναισχύντους εἶναι συμϐαίνει.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 108 Lb 56 Le 56 Lf 108 Me 70 Mf 62 Mg 78 Mj 70 Ml 73.</p>
+          <bibl>Codd. La 108 Lb 56 Le 56 Lf 108 Me 70 Mf 62 Mg 78 Mj 70 Ml 73.</bibl>
           <p><milestone unit="traduction"/>Zeus, ayant façonné l’homme, mit aussitôt en lui les diverses inclinations ; mais il oublia d’y mettre la pudeur. Aussi ne sachant par où l’introduire, il lui ordonna d’entrer par le fondement. Elle regimba tout d’abord contre cet ordre qui l’indignait ; enfin sur les instances pressantes de Zeus, elle dit : « Eh bien ! j’entre, mais à condition qu’Éros n’entrera pas par là ; s’il y entre, moi, j’en sortirai aussitôt. » De là vient que depuis lors tous les débauchés sont sans pudeur.</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui sont la proie de l’amour en perdent toute pudeur.</p>
         </div>
@@ -3442,7 +3441,7 @@
         <pb ed="perry" n="P107"/>
         <p><milestone unit="recitprose"/>Ζεὺς ἀγασάμενος ἀλώπεκος τὸ συνετὸν τῶν φρενῶν καὶ τὸ ποικίλον τὸ βασίλειον αὐτῇ τῶν ἀλόγων ζῴων ἐνεχείρισε. Βουλόμενος δὲ γνῶναι εἰ τὴν τύχην μεταλλάξασα μετεϐάλετο καὶ τὴν γλισχρότητα, φερομένης αὐτῆς ἐν φορείῳ κάνθαρον παρὰ τὴν ὄψιν ἀφῆκεν. Ἡ δὲ ἀντισχεῖν μὴ δυναμένη, ἐπειδὴ περιίπτατο τῷ φορείῳ, ἀναπηδήσασα ἀκόσμως συλλαϐεῖν αὐτὸν ἐπειρᾶτο. Καὶ ὁ Ζεὺς ἀγανακτήσας κατ’ αὐτῆς πάλιν αὐτὴν εἰς τὴν ἀρχαίαν τάξιν ἀποκατέστησεν.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φαῦλοι τῶν ἀνθρώπων, κἂν τὰ προσχήματα λαμπρότερα ἀναλάϐωσιν, τὴν γοῦν φύσιν οὐ μετατίθενται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 99 Pb 106 Pf 53 Ph 54 Mb 236 Me 68 Mf 60 Mj 68.</p>
+        <bibl>Codd. Pa 99 Pb 106 Pf 53 Ph 54 Mb 236 Me 68 Mf 60 Mj 68.</bibl>
         <p><milestone unit="traduction"/>Zeus, émerveillé de l’intelligence et de la souplesse d’esprit du renard, lui conféra la royauté des bêtes. Toutefois il voulut savoir si, en changeant de fortune, il avait aussi changé ses habitudes de convoitise ; et, tandis que le nouveau roi passait en litière, il lâcha un escarbot sous ses yeux. Alors, incapable de se tenir, en voyant l’escarbot voltiger autour de sa litière, le renard sauta dehors, et, au mépris de toute convenance, il essaya de l’attraper. Zeus, indigné de sa conduite, le remit dans son ancien état.</p>
         <p><milestone unit="traduction"/>Cette fable montre que les gens de rien ont beau prendre des dehors plus brillants, ils ne changent pas de nature.</p>
       </div>
@@ -3452,7 +3451,7 @@
         <pb ed="perry" n="P108"/>
         <p><milestone unit="recitprose"/>Ζεὺς πλάσας ἀνθρώπους ἐκέλευσεν Ἑρμῇ νοῦν αὐτοῖς ἐγχέαι. Κἀκεῖνος μέτρον ποιήσας ἴσον ἐνέχεεν ἑκάστῳ. Συνέϐη δὲ τοὺς μὲν μικροφυεῖς πληρωθέντας τοῦ μέτρου φρονίμους γενέσθαι, τοὺς δὲ μακρούς, ἅτε μὴ ἐφικομένου τοῦ ποτοῦ [μηδὲ μέχρι γονάτων] εἰς πᾶν τὸ σῶμα, ἀφρονεστέρους γενέσθαι.</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα εὐμεγέθη μὲν σώματι, κατὰ ψυχὴν δὲ ἀλόγιστον ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 100 Pb 107 Pc 54 Pf 54 Pg 68 Ph 55 Mb 59 Me 69 Mf 61 Mj 69.</p>
+        <bibl>Codd. Pa 100 Pb 107 Pc 54 Pf 54 Pg 68 Ph 55 Mb 59 Me 69 Mf 61 Mj 69.</bibl>
         <p><milestone unit="traduction"/>Zeus, ayant modelé les hommes, chargea Hermès de leur verser de l’intelligence. Hermès, en ayant fait des parts égales, versa à chacun la sienne. Il arriva par là que les hommes de petite taille, remplis par leur portion, furent des gens sensés, mais que les hommes de grande taille, le breuvage n’arrivant pas dans tout leur corps, eurent moins de raison que les autres.</p>
         <p><milestone unit="traduction"/>Cette fable s’applique à un homme grand de taille, mais dépourvu d’esprit.</p>
       </div>
@@ -3462,7 +3461,7 @@
         <pb ed="perry" n="P104"/>
         <p><milestone unit="recitprose"/>Ζεὺς καὶ Ἀπόλλων περὶ τοξικῆς ἤριζον. Τοῦ δὲ Ἀπόλλωνος ἐντείναντος τὸ τόξον καὶ τὸ βέλος ἀφέντος, Ζεὺς τοσοῦτον διέϐη ὅσον Ἀπόλλων ἐτόξευσεν.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοῖς κρείττοσιν ἀνθαμιλλώμενοι, πρὸς τῷ ἐκείνων μὴ ἐφικέσθαι, καὶ γέλωτα ὀφλισκάνουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 97 Pb 103 Pc 53 Ma 76.</p>
+        <bibl>Codd. Pa 97 Pb 103 Pc 53 Ma 76.</bibl>
         <p><milestone unit="traduction"/>Zeus et Apollon disputaient du tir à l’arc. Apollon ayant tendu son arc et décoché sa flèche, Zeus avança la jambe aussi loin qu’Apollon avait lancé son trait.</p>
         <p><milestone unit="traduction"/>De même quand on lutte avec des rivaux plus forts que soi, outre qu’on ne les atteint pas, on s’expose encore à la moquerie.</p>
       </div>
@@ -3474,7 +3473,7 @@
           <pb ed="perry" n="P221"/>
           <p><milestone unit="recitprose"/>Τοῦ διὸς γαμοῦντος, πάντα τὰ ζῷα ἀνήνεγκαν δῶρα. Ὄφις δὲ ἕρπων ῥόδον ἀναλαϐὼν τῷ στόματι ἀνέϐη. Ἰδὼν δὲ αὐτὸν ὁ Ζεὺς ἔφη· « Τῶν ἄλλων ἁπάντων καὶ ἐκ ποδῶν δῶρα δέχομαι· ἀπὸ δὲ τοῦ σοῦ στόματος οὐ λαμϐάνω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πάντων τῶν πονηρῶν αἱ χάριτες φοϐεραί.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 218 Pd 39 Mb 34.</p>
+          <bibl>Codd. Pb 218 Pd 39 Mb 34.</bibl>
         </div>
         <div>
           <head>Chambry 123.2</head>
@@ -3482,7 +3481,7 @@
           <pb ed="perry" n="P221"/>
           <p><milestone unit="recitprose"/>Τοῦ Διὸς γάμους ποιοῦντος, πάντα τὰ ζῷα ἤνεγκαν δῶρα, ἕκαστον κατὰ τὴν οἰκείαν δύναμιν. Ὄφις δὲ ἕρπων ῥόδον λαϐὼν ἐν τῷ στόματι ἀνέϐη. Ἰδὼν δὲ αὐτὸν ὁ Ζεὺς ἔφη· « Τῶν ἄλλων πάντων τὰ δῶρα λαμϐάνω, ἀπὸ δὲ τοῦ σοῦ στόματος λαμϐάνω οὐδ’ ὅλως. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν πονηρῶν αἱ χάριτες φοϐεραί εἰσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 184 Cb 98 Cd 114 Ce 112 Cf 120 Ch 121 Mc 91 Ml 151bis.</p>
+          <bibl>Codd. Ca 184 Cb 98 Cd 114 Ce 112 Cf 120 Ch 121 Mc 91 Ml 151bis.</bibl>
           <p><milestone unit="traduction"/>Comme Zeus se mariait, tous les animaux lui apportèrent des présents, chacun suivant ses moyens. Le serpent monta jusqu’à lui, en rampant, une rose à la bouche. En le voyant Zeus dit : « De tous les autres j’accepte des présents ; mais de ta bouche à toi je les refuse absolument. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut craindre les gracieusetés des méchants.</p>
         </div>
@@ -3495,7 +3494,7 @@
           <pb ed="perry" n="P312"/>
           <p><milestone unit="recitprose"/>Ζεὺς ἐν πίθῳ τὰ ἀγαθὰ πάντα συγκλείσας ἀφῆκε παρὰ ἀνθρώπῳ τινί. Ὁ δὲ λίχνος ἄνθρωπος εἰδέναι θέλων τί ἐστιν ἐν αὐτῷ, τὸ πῶμα ἐκίνησε· πάντα δὲ ἐπετάσθησαν πρὸς τοὺς θεούς.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς ἀνθρώποις ἐλπὶς μόνη σύνεστι τῶν πεφευγότων ἀγαθῶν ἐγγυωμένη δώσειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 44.</p>
+          <bibl>Cod. Ba 44.</bibl>
           <p><milestone unit="traduction"/>Zeus ayant enfermé tous les biens dans un tonneau, le laissa entre les mains d’un homme. Cet homme, qui était curieux, voulut savoir ce qu’il y avait dedans ; il souleva le couvercle, et tous les biens s’envolèrent chez les dieux.</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’espérance seule reste avec les hommes, qui leur promet les biens enfuis.</p>
         </div>
@@ -3504,7 +3503,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P312"/>
           <p><milestone unit="recitprose"/>Ζεὺς ἐν πίθῳ τὰ ἀγαθὰ πάντα ἐγκατακλείσας ἀφῆκεν παρὰ ἀνθρώπῳ τινί. Ὁ δὲ ἀκρατὴς ὢν εἰδέναι ἠθέλησεν τίνα εἰσὶν ἐν αὐτῷ, καὶ ἀφελὼν τὴν σφραγῖδα καὶ ἀποκαλύψας τὸ ἀγγεῖον, πάντα ὅσα ἦν ἔνδον ἐξέφυγεν· μόνη δὲ ἡ ἐλπὶς ὑπελείφθη καὶ διὰ τοῦτο τοῖς ἀνθρώποις ἐστὶ παραμόνιμος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 22.</p>
+          <bibl>Cod. Bd 22.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-125">
@@ -3515,7 +3514,7 @@
           <pb ed="perry" n="P100"/>
           <p><milestone unit="recitprose"/>Ζεὺς καὶ Προμηθεὺς καὶ Ἀθηνᾶ κατασκευάσαντες, ὁ μὲν ταῦρον, Προμηθεὺς δὲ ἄνθρωπον, ἡ δὲ οἶκον, Μῶμον κριτὴν εἵλοντο. Ὁ δὲ φθονήσας τοῖς δημιουργήμασιν ἀρξάμενος ἔλεγε τὸν μὲν Δία ἡμαρτηκέναι, τοῦ ταῦρου τοὺς ὀφθαλμοὺς ἐπὶ τοῖς κέρασιν μὴ θέντα, ἵνα βλέπῃ ποῦ τύπτει· τὸν δὲ Προμηθέα, διότι τοῦ ἀνθρώπου τὰς φρένας οὐκ ἔξωθεν ἀπεκρέμασεν, ἵνα μὴ λανθάνωσιν οἱ πονηροί, φανερὸν δὲ ᾖ τί ἕκαστος κατὰ νοῦν ἔχει, τρίτον δὲ ἔλεγεν ὡς ἔδει τὴν Ἀθηνᾶν τὸν οἶκον τροχοῖς ἐπιθεῖναι, ἵνα, ἐὰν πονηρός τις παροικισθῇ γείτων, ῥᾳδίως μεταϐαίνῃ. Καὶ ὁ Ζεὺς ἀγανακτήσας κατ’ αὐτοῦ ἐπὶ τῇ βασκανίᾳ τοῦ Ὀλύμπου αὐτὸν ἐξέϐαλεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐδὲν οὕτως ἐστὶν ἐνάρετον ὅ μὴ πάντως περὶ τι ψόγον ἐπιδέχεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 93 Pb 100 Pc 50 Ma 72.</p>
+          <bibl>Codd. Pa 93 Pb 100 Pc 50 Ma 72.</bibl>
           <p><milestone unit="traduction"/>Zeus, Prométhée et Athéna, ayant fait, l’un un taureau, Prométhée un homme, et la déesse une maison, prirent Momos pour arbitre. Momos, jaloux de leurs ouvrages, commença par dire que Zeus avait fait une bévue en ne mettant pas les yeux du taureau sur ses cornes, afin qu’il vît où il frappait, et Prométhée aussi en ne suspendant pas dehors le cœur de l’homme, afin que la méchanceté ne restât pas cachée et que chacun laissât voir ce qu’il a dans l’esprit. Quant à Athéna, il dit qu’elle aurait dû mettre sur roues sa maison, afin que, si un méchant s’établissait dans le voisinage, on pût se déplacer facilement. Zeus indigné de sa jalousie, le chassa de l’Olympe.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il n’y a rien de si parfait qui ne donne prise à la critique.</p>
         </div>
@@ -3525,14 +3524,14 @@
           <pb ed="perry" n="P100"/>
           <p><milestone unit="recitprose"/>Ζεὺς καὶ Ποσειδῶν καὶ Ἀθηνᾶ ἔριν ἐποιήσαντο τίς κάλλιόν τι ποιήσει. Καὶ ὁ μὲν Ζεὺς ἄνθρωπον εὐπρεπέστατον ἐποίησεν, ὁ δὲ Ποσειδῶν ταῦρον, ἡ δὲ Ἀθηνᾶ οἶκον ἀνθρώποις. Κριτὴς δὲ ἦν ἐπὶ τούτοις ὁ Μῶμος. Καὶ πρῶτον μὲν ἔψεγε τὴν θέσιν τῶν κεράτων τοῦ ταύρου, κάτωθεν τῶν ὀμμάτων λέγων ὀφείλειν κεῖσθαι, ὡς ἂν βλέπῃ ποῦ τύπτει· τοῦ δέ γε τὰς φρένας ἀνθρώπου καὶ τὰς βουλὰς φανερὰς εἶναι καὶ ἔξωθεν, ἀλλὰ μὴ ἔνδον, ὡς ἂν διαγινώσκηται τί βουλεύεται ἕκαστος· τῆς δὲ οἰκίας ὅτι μὴ τροχοὺς σιδηροῦς αὐτῇ ἐποίησεν, ἵνα καὶ τοῖς δεσπόταις συνεξεδήμει καὶ γείτονα πονηρὸν ἐξέφευγεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, ἐάν τις ἀγαθόν τι ποιήσῃ, τὸν φθόνον οὐκ ἐκφεύγει· οὐδὲν γὰρ ἀρεστὸν τῷ μώμῳ καθέστηκε.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 43.</p>
+          <bibl>Cod. Ba 43.</bibl>
         </div>
         <div>
           <head>Chambry 125.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P100"/>
           <p><milestone unit="recitprose"/>Ζεὺς καὶ Ποσειδῶν καὶ Ἀθηνᾶ ἔριν περί τινος δημιουργίας πρὸς ἀλλήλους ἐστήσαντο. Ὁ μὲν οὖν Ζεὺς ἄνθρωπον ἐποίησεν εὐπρεπέστατον, ὁ δὲ Ποσειδῶν ταῦρον, Ἀθηνᾶ ἀνθρώποις εὐκατασκευαστὸν &lt;οἶκον&gt;· κριτὴν δὲ τῶν ἔργων τὸν Μῶμον προὐϐάλλοντο. Ὁ δὲ τοῦ μὲν ἀνθρώπου κατεμέμφετο τὴν τῶν φρενῶν εἰς τὸ ἔνδον ἀπόκρυψιν, δεῖν λέγων τὰς βουλὰς τῶν ἀνθρώπων ἔξωθεν εἶναι καὶ τὰ διανοήματα, ὡς ἂν ἕκαστος εἴδῃ τί ποτε ὁ ἕτερος βούλεται, καὶ οὕτω τὰς παρ’ ἀλλήλων βλάϐας ἐκφεύγωσιν ἢ καὶ τὰς χρείας ἐξ ἑτοίμου ἀποπληρῶσι· τοῦ δὲ ταύρου τὴν τῶν κεράτων θέσιν ἐκάκιζε, ὅτι ἄνω τῶν ὀμμάτων ἐμφύεται, ὀφείλειν εἶναι ταῦτα λέγων περὶ τὰ στέρνα, ἵνα βλέπῃ ποῦ τύπτει τὸν παροξύνοντα· τῆς οἰκίας δὲ κατεγίγνωσκε ὅτι μὴ τροχοὺς ἔχει καὶ μετακινεῖται ὅπου ἂν ὁ δεσπότης θελήσῃ, ἢ δι’ ἀνάπαυσιν ἴσως, ἢ διὰ τὸ φυγεῖν πονηροὺς καὶ κακούργους γείτονας καὶ ἀγνώμονας.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 21.</p>
+          <bibl>Cod. Bd 21.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-126">
@@ -3543,7 +3542,7 @@
           <pb ed="perry" n="P106"/>
           <p><milestone unit="recitprose"/>Ζεὺς γαμῶν πάντα τὰ ζῷα εἱστία. Μόνης δὲ χελώνης ὑστερησάσης, διαπορῶν τὴν αἰτίαν, τῇ ὑστεραίᾳ ἐπυνθάνετο αὐτῆς διὰ τί μόνη ἐπὶ τὸ δεῖπνον οὐκ ἦλθε. Τῆς δὲ εἰπούσης· « Οἶκος φίλος, οἶκος ἄριστος, » ἀγανακτήσας κατ’ αὐτῆς παρεσκεύασεν αὐτὴν τὸν οἶκον αὐτὸν βαστάζουσαν περιφέρειν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ τῶν ἀνθρώπων αἱροῦνται μᾶλλον λιτῶς οἰκεῖν ἢ παρ’ ἄλλοις πολυτελῶς διαιτᾶσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 98 Pb 105 Ma 77 Ca 79.</p>
+          <bibl>Codd. Pa 98 Pb 105 Ma 77 Ca 79.</bibl>
           <p><milestone unit="traduction"/>Zeus, célébrant ses noces, régalait tous les animaux. Seule, la tortue fit défaut. Intrigué de son absence, il la questionna le lendemain : « Pourquoi, seule des animaux, n’es-tu pas venue à mon festin ? — Logis familial, logis idéal ! » répondit la tortue. Zeus indigné contre elle la condamna à porter partout sa maison sur son dos.</p>
           <p><milestone unit="traduction"/>C’est ainsi que beaucoup préfèrent vivre simplement chez eux que de manger richement à la table d’autrui.</p>
         </div>
@@ -3553,7 +3552,7 @@
           <pb ed="perry" n="P106"/>
           <p><milestone unit="recitprose"/>Ζεὺς γάμους τελῶν πάντα τὰ ζῷα εἱστία· Μόνης δὲ τῆς χελώνης ὑστερησάσης, διαπορῶν τὴν αἰτίαν τῆς ὑστερήσεως, ἐπυνθάνετο αὐτῆς τίνος χάριν αὐτὴ ἐπὶ τὸ δεῖπνον οὐ παρεγένετο. Τῆς δὲ εἰπούσης· « Οἶκος φίλος, οἶκος ἄριστος », ἀγανακτήσας κατ’ αὐτῆς κατεδίκασε τὸν οἶκον βαστάζουσαν περιφέρειν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πολλοὶ τῶν ἀνθρώπων αἱροῦνται μᾶλλον λιτῶς παρ’ ἑαυτοῖς ζῆν ἢ παρ’ ἄλλοις πολυτελῶς.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 109 Lb 57 Le 57 Lf 109 Lh 21 Me 71 Mg 79 Mj 71 Ml 74.</p>
+          <bibl>Codd. La 109 Lb 57 Le 57 Lf 109 Lh 21 Me 71 Mg 79 Mj 71 Ml 74.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-127">
@@ -3564,7 +3563,7 @@
           <pb ed="perry" n="P313"/>
           <p><milestone unit="recitprose"/>Ὁ Ζεὺς τὰς τῶν ἀνθρώπων ἁμαρτίας ἐν ὀστράκοις τὸν Ἑρμῆν ὥρισε γράφειν, καὶ εἰς κιϐώτιον ἀποτιθέναι πλησίον αὐτοῦ, ὅπως ἑκάστου τὰς δίκας ἀναπράσσῃ. Συγκεχυμένων δὲ τῶν ὀστράκων ἐπ’ ἀλλήλοις, τὸ μὲν βράδιον, τὸ δὲ τάχιον ἐμπίπτει εἰς τὰς τοῦ Διὸς χεῖρας, εἴποτε καλῶς κρίνοιτο.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ χρὴ θαυμάζειν διὰ τοὺς ἀδίκους καὶ πονηροὺς ὅτι τάχιον οὐκ ἀπολαμϐάνουσιν ὑπὲρ τῶν ἀδικιῶν αὐτῶν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 105.</p>
+          <bibl>Cod. Ba 105.</bibl>
           <p><milestone unit="traduction"/>Zeus a décidé jadis qu’Hermès inscrirait sur des coquilles les fautes des hommes et déposerait ces coquilles près de lui dans une cassette, afin qu’il fasse justice à chacun. Mais les coquilles s’entremêlent, et les unes viennent plus tôt, les autres plus tard entre les mains de Zeus, pour subir ses justes jugements.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas s’étonner si les malfaiteurs et les méchants ne reçoivent pas plus vite le châtiment de leurs méfaits.</p>
         </div>
@@ -3574,7 +3573,7 @@
           <pb ed="perry" n="P313"/>
           <p><milestone unit="recitprose"/>&lt;Ἐν&gt; ὀστράκῳ γράφοντα τὸν Ἑρμῆν ἁμαρτίας ἐκέλευσεν ὁ Ζεὺς εἰς κιϐωτὸν ταύτας σωρεύειν, ἵν’ ἐρανίσας ἑκάστου τὰς δίκας ἀναπράσσῃ. Τῶν ὀστράκων δὲ συγκεχυμένων ἀλλήλοις, τὸ μὲν βράδιον, τὸ δὲ τάχιον ἐμπίπτει εἰς τοῦ Διὸς τὰς χεῖρας, εἴποτ’ εὐθύνοι.</p>
           <p><milestone unit="epimythiumprose"/>Τῶν οὖν πονηρῶν οὐ προσήκει θαυμάζειν, ἂν θᾶσσον ἀδικῶν ὀψέ τις κακῶς πράσσῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 135.</p>
+          <bibl>Cod. Mb 135.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-128">
@@ -3585,7 +3584,7 @@
           <pb ed="perry" n="P314"/>
           <p><milestone unit="recitprose"/>Γάμοι τοῦ Ἡλίου θέρους ἐγίγνοντο· πάντα δὲ τὰ ζῷα ἔχαιρον ἐπὶ τούτῳ, ἠγάλλοντο δὲ καὶ οἱ βάτραχοι. Εἷς δὲ τούτων εἶπεν· « Ὦ μῶροι, εἰς τί ἀγάλλεσθε ; εἰ γὰρ μόνος ὢν ὁ Ἥλιος πᾶσαν ἰλὺν ἀποξηραίνει, εἰ γήμας ὅμοιον αὐτῷ παιδίον γεννήσει, τί οὐ πάθωμεν κακόν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ τῶν τὸ φρόνημα κουφότερον ἐχόντων χαίρουσιν ἐπὶ πράγμασιν τοῖς μὴ χαρὰν ἔχουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 21 Mg 38.</p>
+          <bibl>Codd. Ba 21 Mg 38.</bibl>
           <p><milestone unit="traduction"/>C’était l’été, et l’on célébrait les noces du Soleil. Tous les animaux se réjouissaient de l’événement, et il n’était pas jusqu’aux grenouilles qui ne fussent en liesse. Mais l’une d’elles, s’écria : « Insensées, à quel propos vous réjouissez-vous ? À lui seul, le Soleil dessèche tous les marécages ; s’il prend femme et fait un enfant semblable à lui, que n’aurons-nous pas à souffrir ? »</p>
           <p><milestone unit="traduction"/>Beaucoup de gens à tête légère se réjouissent de choses qui n’ont rien de réjouissant.</p>
         </div>
@@ -3606,7 +3605,7 @@
           <l><milestone unit="recitvers"/>εἰ γήμας παῖδα ἀνθόμοιον ποιήσει,</l>
           <l><milestone unit="recitvers"/>τί μὴ πάθωμεν ἡμεῖς κακόν, εἰπέ μοι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ τῶν τὸ φρόνημα κουφότερον ἐχόντως χαίρουσιν ἐπ’ αδήλοις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 63.</p>
+          <bibl>Cod. Mb 63.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-129">
@@ -3617,7 +3616,7 @@
           <pb ed="perry" n="P315"/>
           <p><milestone unit="recitprose"/>Ἡμίονός τις ἐκ κριθῆς παχυνθεῖσα ἀνεσκίρτησε καθ’ ἑαυτὴν βοῶσα· « Πατήρ μού ἐστιν ἵππος ὁ ταχυδρόμος, κἀγὼ δὲ αὐτῷ ὅλη ἀφωμοιώθην. » Καὶ δὴ ἐν μιᾷ ἀνάγκης ἐπελθούσης, ἠναγκάζετο ἡ ἡμίονος τρέχειν. Ὡς δὲ τοῦ δρόμου ἐπέπαυτο, σκυθρωπάζουσα πατρὸς τοῦ ὄνου εὐθὺς ἀνεμνήσθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ, κἂν ὁ χρόνος ἐνέγκῃ τινὰ εἰς δόξαν, τῆς ἑαυτοῦ ἀρχῆς μὴ ἐπιλαθέσθαι· ἀϐέϐαιος γάρ ἐστιν ὁ βίος οὗτος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 83 Cb 52 Cd 49 Ce 54 Cf 58 Ch 59 Ma 168 Md 62 Mc 51 Md 56 Mh 51 Mi 91 Mm 72 Lc 56 Lg 56.</p>
+          <bibl>Codd. Ca 83 Cb 52 Cd 49 Ce 54 Cf 58 Ch 59 Ma 168 Md 62 Mc 51 Md 56 Mh 51 Mi 91 Mm 72 Lc 56 Lg 56.</bibl>
           <p><milestone unit="traduction"/>Une mule engraissée d’orge se mit à gambader, se disant à elle-même : « J’ai pour père un cheval rapide à la course, et moi je lui ressemble de tout point. » Mais un jour l’occasion vint où la mule se vit forcée de courir. La course terminée, elle se renfrogna et se souvint soudain de son père l’âne.</p>
           <p><milestone unit="traduction"/>Cette fable montre que, même si les circonstances mettent un homme en vue, il ne doit pas oublier son origine ; car cette vie n’est qu’incertitude.</p>
         </div>
@@ -3627,7 +3626,7 @@
           <pb ed="perry" n="P315"/>
           <p><milestone unit="recitprose"/>Ἡμίονός τις ἐκ κριθῆς παχυνθεῖσα ἀνεσκίρτα τε καὶ ἐϐόα καθ’ ἑαυτήν· « Πατήρ μοι ὑπάρχει ἵππος ὁ ταχυδρόμος, ὃν ἐγὼ ὅλη διόλου ἀπεμιμήθην. » Καὶ δὴ ἐν μιᾷ ἠναγκάζετο τρέχειν ἡ ἡμίονος. Ὡς δὲ τοῦ δρόμου ἐπαύσατο, σκυθρωπάσασα τοῦ πατρὸς ὄνου αὐτῆς εὐθὺς ὑπανεμνήσθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, εἰ καὶ ὁ χρόνος ἐνέγκοι τινὰ εἰς δόξαν, οὐ δεῖ ἐπιλανθάνεσθαι τὴν τάξιν τοῦ οἰκείου γένους· ἀϐέϐαιος γάρ ἐστιν ὁ παρὼν βίος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 55.</p>
+          <bibl>Cod. Mk 55.</bibl>
         </div>
         <div>
           <head>Chambry 129.3</head>
@@ -3635,7 +3634,7 @@
           <pb ed="perry" n="P315"/>
           <p><milestone unit="recitprose"/>Ἡμίονος ἐκ κριθῆς παχύνθεὶς ἀνεσκίρτησε βοῶν καὶ λέγων· « Πατήρ μού ἐστιν ἵππος ὁ ταχυδρόμος κἀγὼ αὐτῷ ὅλος ἀφωμοιώθην. » Καί ποτε ἀνάγκης ἐπελθούσης τρέχειν, ἐπειδὴ τοῦ δρόμου ἐπαύσατο, τοῦ πατρὸς ὄνου εὐθὺς ὑπεμνήσθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, κἂν ὁ χρόνος εἰς δόξαν φέρῃ τινά, τῆς ἑαυτοῦ γε μὴν τύχης μὴ ἐπιλανθανέσθω· ἀϐέϐαιος γάρ ἐστιν ὁ βίος οὗτος.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 144 Mg 80.</p>
+          <bibl>Codd. La 144 Mg 80.</bibl>
         </div>
         <div>
           <head>Chambry 129.4</head>
@@ -3643,14 +3642,14 @@
           <pb ed="perry" n="P315"/>
           <p><milestone unit="recitprose"/>Ἡμίονος ἐκ κριθῆς παχεῖα γενομένη ἔτρεχε σκιρτῶσα καὶ ἔλεγεν· « Ἵππος ἐστί μοι μήτηρ· ἐγὼ δὲ οὐδὲν αὐτῆς εἰς τὸν δρόμον ἐλάττων &lt;ὑπάρχω&gt; ». Ὅτε δὲ ἔπαυσε τοῦ δρόμου, ἐσκυθρώπασεν· ὄνου γὰρ εὐθὺς πατρὸς οὖσα ἀνεμνήσθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, κἂν ὁ χρόνος εἰς δόξαν ἐνέγκῃ τινά, μηδεὶς τὴν ἑαυτοῦ φύσιν ἀγνοείτω· ἀϐέϐαια γὰρ τὰ ἀγαθὰ τοῦ βίου.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 46 Bb 30.</p>
+          <bibl>Codd. Ba 46 Bb 30.</bibl>
         </div>
         <div>
           <head>Chambry 129.5</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P315"/>
           <p><milestone unit="recitprose"/>Ἡμίονος ἐκ πολλῆς κριθῶν τροφῆς παχυνθεῖσα ἐν πεδίῳ σκιρτῶσα ἔλεγεν· « Ἵππος ἐστί μοι μήτηρ καὶ κατ’ οὐδὲν ἐλάττων αὐτῆς κατὰ τὸν δρόμον ὑπάρχω. » Μόλις δὲ ἀπὸ τοῦ δρόμου κατάκοπος γενομένη ἡσύχασεν καὶ τότε πατρὸς οὖσα ὄνου ἀνεμνήσθη.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 24.</p>
+          <bibl>Cod. Bd 24.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-130">
@@ -3661,7 +3660,7 @@
           <pb ed="perry" n="P316"/>
           <p><milestone unit="recitprose"/>Διὰ στενῆς ὁδοῦ ὥδευεν Ἡρακλῆς. Ἰδὼν δὲ ἐπὶ γῆς μήλῳ ὅμοιόν τι ἐπειρᾶτο συντρῖψαι. Ὡς δὲ εἶδε διπλοῦν γενόμενον, ἔτι μᾶλλον ἐπέϐαινεν, καὶ τῷ ῥοπάλῳ ἔπαιεν. Τὸ δὲ φυσηθὲν εἰς μέγεθος τὴν ὁδὸν ἀπέφραξεν. Ὁ δὲ ῥίψας τὸ ῥόπαλον ἵστατο θαυμάζων. Ἀθηνᾶ δὲ αὐτῷ ἐπιφανεῖσα εἶπε· « Πέπαυσο δέ, ἄδελφε, τοῦτό ἐστι φιλονεικία καὶ ἔρις· ἄν τις αὐτὸ καταλείπῃ ἀμάχητον, μένει οἷον ἦν πρῶτον· ἐν δὲ ταῖς μάχαις οὕτως οἰδεῖται. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πᾶσι φανερὸν καθέστηκεν ὡς αἱ μάχαι καὶ ἔριδες αἰτίαι μεγάλης βλάϐης ὑπάρχουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 26 Mg 50.</p>
+          <bibl>Codd. Ba 26 Mg 50.</bibl>
           <p><milestone unit="traduction"/>Le long d’une route étroite Hercule cheminait. Il aperçut à terre un objet qui ressemblait à une pomme, et voulut l’écraser. L’objet doubla de volume. À cette vue, Héraclès le piétina plus violemment encore et le frappa de sa massue. L’objet s’enflant en volume obstrua le chemin. Le héros alors jeta sa massue, et resta là, en proie à l’étonnement. Sur ces entrefaites Athéna lui apparut et lui dit : « Arrête, frère ; cet objet, c’est l’esprit de dispute et de querelle ; si on le laisse tranquille, il reste tel qu’il était d’abord ; si on le combat, voilà comment il s’enfle. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les combats et les querelles sont cause de grands dommages.</p>
         </div>
@@ -3670,7 +3669,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P316"/>
           <p><milestone unit="recitprose"/>Διὰ στενῆς ὁδοῦ ὥδευεν Ἡρακλῆς. Μήλῳ δέ τι ὅμοιον κατὰ γῆς καθήμενον ἰδὼν ἐπειρᾶτο τῷ ῥοπάλῳ συντρίϐειν. Τὸ δὲ [μᾶλλον] διπλοῦν ἀπὸ τῆς ψαύσεως τοῦ ῥοπάλου ἐγένετο. Ὁ δὲ μᾶλλον τῷ ῥοπάλῳ καὶ αὖθις ἔπαιε. Τὸ &lt;δ’&gt; εἰς μέγεθος ἀρθὲν τὴν ὁδὸν τούτῳ ἀπέφραξε. ὁ δὲ ῥίψας τὸ ῥόπαλον ἵστατο ἐκπληττόμενος. Ἀθηνᾶ δὲ τοῦτον ἰδοῦσα ἔφη· « Ὦ Ἡράκλεις, παῦσαι θαυμάζων· τὸ γὰρ νῦν τὴν ἀπορίαν σοι προξενῆσαν ἡ φιλονεικία καὶ ἔρις ἐστίν. Ἂν οὖν τις ταύτην οἵαν εὗρεν ἀφήσῃ, ἐπὶ μικροῦ μένει· ἂν δὲ μάχεσθαι θέλῃ πρὸς ταύτην, οὕτως ἐκ μικροῦ οἰδεῖ καὶ εἰς μέγα προέρχεται. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 9.</p>
+          <bibl>Cod. Bd 9.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-131">
@@ -3679,7 +3678,7 @@
         <pb ed="perry" n="P111"/>
         <p><milestone unit="recitprose"/>Ἡρακλῆς ἰσοθεωθεὶς καὶ παρὰ Διὶ ἑστιώμενος ἕνα ἕκαστον τῶν θεῶν μετὰ πολλῆς φιλοφροσύνης ἠσπάζετο. Καὶ δὴ τελευταίου εἰσελθόντος τοῦ Πλούτου, κατὰ τοῦ ἐδάφους κύψας ἀπεστρέψατο αὐτόν. Ὁ δὲ Ζεὺς θαυμάσας τὸ γεγονὸς ἐπυνθάνετο αὐτοῦ τὴν αἰτίαν δι’ ἣν πάντας τοὺς δαίμονας προσαγορεύσας ἀσμένως μόνον τὸν Πλοῦτον ὑποϐλέπεται. Ὁ δὲ εἶπεν· « Ἀλλ’ ἔγωγε διὰ τοῦτο αὐτὸν ὑποϐλέπομαι ὅτι παρ’ ὃν καιρὸν ἐν ἀνθρώποις ἤμην, ἑώρων αὐτὸν ὡς ἐπὶ τὸ πλεῖστον τοῖς πονηροῖς συνόντα. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος λεχθείη ἂν ἐπ’ ἀνδρὸς πλουσίου μὲν τὴν τύχην, πονηροῦ δὲ τὸν τρόπον.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 103 Pb 110 Pc 57 Pf 55 Pg 70 Ph 56 Ma 78 Me 72 Mf 63 Mj 72.</p>
+        <bibl>Codd. Pa 103 Pb 110 Pc 57 Pf 55 Pg 70 Ph 56 Ma 78 Me 72 Mf 63 Mj 72.</bibl>
         <p><milestone unit="traduction"/>Héraclès, admis au rang des dieux et reçu à la table de Zeus, saluait avec beaucoup de bonne grâce chacun des dieux. Mais Plutus étant arrivé le dernier, Héraclès baissa les yeux sur le pavé et se détourna de lui. Zeus étonné de son attitude lui demanda pourquoi, après avoir salué complaisamment tous les dieux, il détournait les yeux du seul Plutus. Il répondit : « Si je détourne les yeux de lui, c’est qu’au temps où j’étais parmi les hommes, je le voyais presque toujours acoquiné aux méchants. »</p>
         <p><milestone unit="traduction"/>Cette fable pourrait se conter à propos d’un homme enrichi par la fortune, mais méchant de caractère.</p>
       </div>
@@ -3689,7 +3688,7 @@
         <pb ed="perry" n="P110"/>
         <p><milestone unit="recitprose"/>Ἥρωά τις ἐπὶ τῆς οἰκίας ἔχων, τούτῳ πολυτελῶς ἔθυεν. Ἀεὶ δὲ αὐτοῦ ἀναλισκομένου καὶ πολλὰ εἰς θυσίας δαπανῶντος, ὁ ἥρως ἐπιστὰς αὐτῷ νύκτωρ ἔφη· « Ἀλλ’, ὦ οὗτος, πέπαυσο τὴν οὐσίαν διαφθείρων· ἐὰν γὰρ πάντα ἀναλώσας πένης γένῃ, ἐμὲ αἰτιάσῃ. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ διὰ τὴν ἑαυτῶν ἀϐουλίαν δυστυχοῦντες τὴν αἰτίαν ἐπὶ τοὺς θεοὺς ἀναφέρουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 102 Pb 109 Pc 56 Pg 71 Ph 57 Mb 61 Ca 80.</p>
+        <bibl>Codd. Pa 102 Pb 109 Pc 56 Pg 71 Ph 57 Mb 61 Ca 80.</bibl>
         <p><milestone unit="traduction"/>Un homme, ayant un demi-dieu dans sa maison, lui offrait de riches sacrifices. Comme il ne cessait de dépenser et de consommer en sacrifices des sommes considérables, le demi-dieu lui apparut la nuit, et lui dit : « Cesse, mon ami, de dilapider ton bien ; car, si tu dépenses tout et que tu deviennes pauvre, c’est à moi que tu t’en prendras. »</p>
         <p><milestone unit="traduction"/>Ainsi beaucoup de gens, tombés dans le malheur par leur sottise, en rejettent la responsabilité sur les dieux.</p>
       </div>
@@ -3701,7 +3700,7 @@
           <pb ed="perry" n="P113"/>
           <p><milestone unit="recitprose"/>Θύννος διωκόμενος ὑπὸ δελφῖνος καὶ πολλῷ τῷ ῥοίζῳ φερόμενος, ἐπειδὴ καταλαμϐάνεσθαι ἔμελλεν, ἔλαθεν ὑπὸ σφοδρᾶς ὁρμῆς ἐκϐρασθεὶς εἴς τινα ἠϊόνα. Ὑπὸ δὲ τῆς αὐτῆς φορᾶς ἐλαυνόμενος καὶ ὁ δελφὶς αὐτῷ συνεξώσθη. Καὶ ὁ θύννος, ὡς ἐθεάσατο ἐπιστραφεὶς αὐτὸν λιποθυμοῦντα ἔφη· « Ἀλλ’ ἔμοιγε οὐκέτι λυπηρὸς ὁ θάνατος· ὁρῶ γὰρ καὶ τὸν αἴτιόν μοι θανάτου γενόμενον συναποθνῄσκοντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ῥᾴδιον φέρουσι τὰς συμφορὰς οἱ ἄνθρωποι, ὅταν ἴδωσι καὶ τοὺς αἰτίους τούτων γεγονότας δυστυχοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 105 Pb 112 Pc 58 Pf 56 Pg 73 Ph 58 Mb 64 Me 73 Mf 64 Mj 73.</p>
+          <bibl>Codd. Pa 105 Pb 112 Pc 58 Pf 56 Pg 73 Ph 58 Mb 64 Me 73 Mf 64 Mj 73.</bibl>
           <p><milestone unit="traduction"/>Un thon poursuivi par un dauphin se sauvait à grand bruit. Cependant il allait être pris, quand la violence de son élan le jeta, sans qu’il s’en doutât, sur le rivage. Emporté par la même impulsion, le dauphin aussi fut projeté au même endroit. Le thon se retournant le vit rendre l’âme et dit : « Je ne suis plus chagrin de mourir, du moment que je vois mourir avec moi celui qui est cause de ma mort. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’on supporte facilement les malheurs, quand on les voit partagés par ceux qui en sont la cause.</p>
         </div>
@@ -3711,7 +3710,7 @@
           <pb ed="perry" n="P113"/>
           <p><milestone unit="recitprose"/>Θύννος διωκόμενος ὑπὸ δελφῖνος καὶ πολλῷ τῷ ῥοίζῳ φερόμενος, ἐπειδὴ καταλαμϐάνεσθαι ἔμελλεν, ἔλαθεν ὑπὸ σφοδρᾶς ὁρμῆς ἐμπεσὼν εἴς τινα νῆσον. Ὑπὸ δὲ τῆς αὐτῆς φορᾶς ἐλαυνόμενος καὶ ὁ δελφὶς σὺν αὐτῷ εἰς τὴν νῆσον ἐξῆλθεν. Ἐπιστραφεὶς δὲ ὁ θύννος καὶ τὸν δελφῖνα λειποψυχοῦντα θεασάμενος ἔφη· « Ἀλλ’ ἔμοιγε οὐκέτι λυπηρὸς ὁ θάνατος· ὁρῶ γὰρ καὶ τὸν αἴτιον τοῦ θανάτου μοι γεγονότα σὺν ἐμοῖ ἀποθνῄσκοντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ῥᾳδίως φέρουσι τὰς συμφορὰς οἱ ἄνθρωποι, ὅταν ἴδωσι τοὺς αἰτίους τούτων δυστυχοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 60 Ca 85 Cb 53 Cd 51 Ce 56 Cf 60 Mh 52.</p>
+          <bibl>Codd. Ch 60 Ca 85 Cb 53 Cd 51 Ce 56 Cf 60 Mh 52.</bibl>
         </div>
         <div>
           <head>Chambry 133.3</head>
@@ -3719,7 +3718,7 @@
           <pb ed="perry" n="P113"/>
           <p><milestone unit="recitprose"/>Θύννος διωκόμενος ὑπὸ δελφῖνος καὶ πολλῷ τῷ ῥοίζῳ φερόμενος, ἐπειδὴ καταλαμϐάνεσθαι ἔμελλεν, ἔλαθεν ὑπὸ σφοδρᾶς ῥύμης ἐκπεσὼν εἴς τινα νῆσον. Ὑπὸ δὲ τῆς ὁμοίας ῥύμης καὶ ὁ δελφὶν αὐτῷ συνεξώκειλεν. Ὁ δὲ θύννος ἐπιστραφεὶς καὶ λειποψυχοῦντα τὸν δελφῖνα ἑωρακὼς εἶπεν· « Οὐκέτι μοι ὁ θάνατος λυπηρὸς ὁρῶντι τὸν αἴτιον γεγονότα μοι τούτου σὺν ἐμοὶ ἀποθνῄσκοντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ῥᾳδίως τὰς συμφορὰς οἱ ἄνθρωποι φέρουσι, τοὺς τούτων αἰτίους δυστυχοῦντας ὁρῶντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 30 Lb 58 Ld 21 Le 58 Lf 30 Lh 22 Ma 77bis et 169 Mc 52 Md 57 Mg 81 Mi 92 Mk 56 Ml 76 Mm 73 Mn 21.</p>
+          <bibl>Codd. La 30 Lb 58 Ld 21 Le 58 Lf 30 Lh 22 Ma 77bis et 169 Mc 52 Md 57 Mg 81 Mi 92 Mk 56 Ml 76 Mm 73 Mn 21.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-134">
@@ -3730,7 +3729,7 @@
           <pb ed="perry" n="P317"/>
           <p><milestone unit="recitprose"/>Ἰατρὸς ἦν ἄτεχνος. Οὗτος ἀρρώστῳ παρακολουθῶν, πάντων ἰατρῶν λεγόντων αὐτὸν μὴ κινδυνεύειν, ἀλλὰ χρονίσειν ἐν τῇ νόσῳ, οὗτος μόνος ἔφη αὐτῷ πάντα τὰ αὐτοῦ ἑτοιμάσαι· « τὴν αὔριον γὰρ οὐκ ὑπερϐήσῃ. » Ταῦτα εἰπὼν ὑπεχώρησε. Μετὰ χρόνον δέ τινα ἀναστὰς ὁ νοσῶν προῆλθεν, ὠχρὸς καὶ μόλις βαίνων. Ὁ δὲ ἰατρὸς συναντήσας αὐτῷ· « Χαῖρε, ἔφη· πῶς ἔχουσιν οἱ κάτω ; » Κἀκεῖνος εἶπεν· « Ἠρεμοῦσι πιόντες τὸ τῆς Λήθης ὕδωρ. Πρὸ ὀλίγου δὲ ὁ Θάνατος καὶ ὁ Ἅιδης δεινῶς ἠπείλουν τοὺς ἰατροὺς πάντας, ὅτι τοὺς νοσοῦντας οὐκ ἐῶσιν ἀποθνῄσκειν, καὶ κατεγράφοντο πάντας. Ἔμελλον δὲ καὶ σὲ γράψαι, ἀλλ’ ἐγὼ προσπεσὼν αὐτοῖς καὶ δυσωπήσας, ἐξωμοσάμην αὐτοῖς μὴ ἀληθῆ ἰατρὸν εἶναί σε, ἀλλὰ μάτην διεϐλήθης. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς ἀπαιδεύτους καὶ ἀμαθεῖς καὶ κομψολόγους ἰατροὺς ὁ παρὼν μῦθος στηλιτεύει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 53 Bb 33 Mb 70.</p>
+          <bibl>Codd. Ba 53 Bb 33 Mb 70.</bibl>
           <p><milestone unit="traduction"/>Un médecin ignorant traitait un malade. Tous les autres médecins affirmaient que ce malade n’était pas en danger, mais que son mal serait long à guérir ; seul l’ignorant lui dit de prendre toutes ses dispositions, qu’il ne passerait pas le lendemain. Là-dessus, il se retira. Au bout d’un certain temps, le malade se leva et sortit, pâle et marchant avec peine. Notre médecin le rencontra : « Bonjour, dit-il, comment vont les habitants des enfers ? — Ils sont tranquilles, répondit-il, parce qu’ils ont bu l’eau du Léthé. Mais dernièrement la Mort et Hadès faisaient de terribles menaces contre tous les médecins, parce qu’ils ne laissent pas mourir les malades, et ils les inscrivaient tous sur un registre. Ils allaient aussi t’inscrire ; mais je me suis jeté à leurs pieds, en les suppliant, et leur ai juré que tu n’étais pas un vrai médecin, et qu’on t’avait incriminé sans motif. »</p>
           <p><milestone unit="traduction"/>La fable présente met au pilori les médecins dont toute la science et le talent consistent en belles paroles.</p>
         </div>
@@ -3739,7 +3738,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P317"/>
           <p><milestone unit="recitprose"/>Ἰατρὸς ἄπειρος ἀρρώστῳ προσελθὼν πάντα πρὸς ταφὴν εὐτρεπίσαι τοῖς πρὸς αὐτὸν ἐκέλευε· τὴν γὰρ αὔριον οὐχ ὑπερϐήσεσθαι αὐτόν. Μετὰ δὲ τινα χρόνον ὁ ἀρρωστῶν ἀναστὰς καὶ συναντήσας τῷ ἰατρῷ, ἀσπασίως ὁ ἰατρὸς προσηγόρευσε καὶ πῶς ἔχουσιν οἱ περὶ τὸν Ἅιδην ἠρώτα. Ὁ δὲ εἶπεν· « Ἠρεμοῦσι πάντες, πλήν γε ὅτι ὁ Θάνατος καὶ ὁ Ἅιδης ἠπείλουν πᾶσι τοῖς ἰατροῖς τὰ ἀνήκεστα, ὅτι τοὺς νοσοῦντας οὐκ ἐῶσιν ἀποθνῄσκειν· ἔγραφον δὲ αὐτῶν τὰ ὀνόματα ἐπὶ τιμωρίᾳ. Μελλόντων δὲ καὶ σὲ γράψαι, προσπεσὼν αὐτοῖς ἐγὼ καὶ δυσωπήσας ἐξωμοσάμην μὴ εἶναί σε ἀληθῆ ἰατρόν, ἀλλὰ μάτην διεϐλήθης.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 26.</p>
+          <bibl>Cod. Bd 26.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-135">
@@ -3750,7 +3749,7 @@
           <pb ed="perry" n="P114"/>
           <p><milestone unit="recitprose"/>Ἰατρὸς ἐκκομιζομένῳ τινὶ τῶν οἰκείων ἐπακολουθῶν ἔλεγε πρὸς τοὺς προπέμποντας ὡς οὗτος ὁ ἄνθρωπος, εἰ οἴνου ἀπείχετο καὶ κλυστῆρσιν ἐχρήσατο, οὐκ ἂν ἀπέθανε. Τούτων δέ τις ὑποτυχὼν ἔφη· « Ὦ οὗτος, ἀλλ’ οὐ νῦν σε ἔδει ταῦτα λέγειν, ὅτε οὐδὲν ὄφελος, τότε δὲ παραινεῖν, ὅτε καὶ χρῆσθαι ἠδύνατο. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοῖς φίλοις παρὰ τὰς χρείας τὰς βοηθείας παρέχεσθαι, ἀλλὰ μὴ μετὰ τὴν τῶν πραγμάτων ἀπόγνωσιν κατειρωνεύεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 106 Pb 113 Pc 59 Pf 57 Pg 74 Ph 59 Ma 79 Mb 67 Me 74 Mf 65 Mj 74.</p>
+          <bibl>Codd. Pa 106 Pb 113 Pc 59 Pf 57 Pg 74 Ph 59 Ma 79 Mb 67 Me 74 Mf 65 Mj 74.</bibl>
         </div>
         <div>
           <head>Chambry 135.2</head>
@@ -3758,7 +3757,7 @@
           <pb ed="perry" n="P114"/>
           <p><milestone unit="recitprose"/>Ἰατρός τις ἐπισκεπτόμενος ἄρρωστον, συνέϐη ἀποθανεῖν αὐτόν. Ὁ δὲ ἰατρὸς ἔλεγε πρὸς τοὺς ἐκκομίζοντας αὐτόν· « Οὗτος ὁ ἄνθρωπος, εἰ οἴνου ἀπείχετο καὶ κλυστῆρσιν ἔχρητο, οὐκ ἂν ἀπέθανε. » Τῶν δὲ παρόντων τις ὑπολαϐὼν ἔφη αὐτῷ· « Ὦ οὗτος, οὐκ ἔδει σε νῦν τοῦτο λέγειν, ὅτε οὐδὲν ὄφελός ἐστιν, ἀλλὰ τότε παραινεῖν σε ἔδει, ὅτε καὶ χρῆσθαι ἠδύνατο. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοῖς φίλοις ἐν καιρῷ ἀνάγκης τὰς βοηθείας παρέχειν καὶ μὴ μετὰ τὴν τῶν πραγμάτων ἀπόγνωσιν κατειρωνεύεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 61 Cb 54 Ce 57 Cf 61 Mc 53 Mh 53 Mk 57.</p>
+          <bibl>Codd. Ch 61 Cb 54 Ce 57 Cf 61 Mc 53 Mh 53 Mk 57.</bibl>
         </div>
         <div>
           <head>Chambry 135.3</head>
@@ -3766,7 +3765,7 @@
           <pb ed="perry" n="P114"/>
           <p><milestone unit="recitprose"/>Ἰατρὸς νοσοῦντα ἐθεράπευε. Τοῦ δὲ νοσοῦντος ἀποθανόντος, ἐκεῖνος πρὸς τοὺς ἐκκομίζοντας ἔλεγεν· « Οὗτος ὁ ἄνθρωπος, εἰ οἴνου ἀπείχετο καὶ κλυστῆρσιν ἔχρητο, οὐκ ἂν ἐτεθνήκει. » Τῶν δὲ παρόντων ὑπολαϐών τις ἔφη· « Ὦ βέλτιστε, οὐκ ἔδει σε ταῦτα νῦν λέγειν, ὅτε μηδὲν ὄφελός ἐστιν, ἀλλὰ τότε παραινεῖν, ὅτε τούτοις χρῆσθαι ἠδύνατο. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοὺς φίλους ἐν καιρῷ ἀνάγκης τὰς βοηθείας παρέχειν καὶ μὴ μετὰ τῶν πραγμάτων ἀπόγνωσιν κατειρωνεύεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 31 Lb 59 Lc 24 Le 59 Lf 31 Lg 24 Lh 23 Md 58 Mg 82 Mi 93 Ml 77 Mm 74.</p>
+          <bibl>Codd. La 31 Lb 59 Lc 24 Le 59 Lf 31 Lg 24 Lh 23 Md 58 Mg 82 Mi 93 Ml 77 Mm 74.</bibl>
           <p><milestone unit="traduction"/>Un médecin soignait un malade. Celui-ci étant mort, le médecin disait aux gens du cortège : « Cet homme, s’il s’était abstenu de vin et avait pris des lavements, ne serait pas mort. — Hé ! mon bel ami, reprit l’un d’eux, ce n’est pas à présent qu’il fallait dire cela, alors que cela ne sert plus à rien ; c’est quand il pouvait encore en profiter que tu devais lui donner ce conseil. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que c’est au moment où ils en ont besoin qu’il faut prêter son aide à ses amis, au lieu de faire l’habile homme, quand leurs affaires sont désespérées.</p>
         </div>
@@ -3786,7 +3785,7 @@
           <l><milestone unit="recitvers"/>Τί γὰρ ὠφελεῖ ψυχρὰ τῷ τεθνηκότι ;</l>
           <l><milestone unit="recitvers"/>ἀλλ’ ὅτε ἔζη, τότε χρῆν διαιτᾶσθαι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τῶν φίλων οἱ ἄρρωστοι εἰς τὰς ἀνάγκας τὴν βοηθείαν φέρωσιν ὡς ἐπὶ τὸ πλεῖστον· οὐ γὰρ εἰρωνεύονται μετὰ τὴν τύχην.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 52.</p>
+          <bibl>Cod. Cd 52.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-136">
@@ -3797,7 +3796,7 @@
           <pb ed="perry" n="P128"/>
           <p><milestone unit="recitprose"/>Ἰκτῖνος ὄφιν ἁρπάσας ἀπέπτατο. Ὁ δὲ ἐπιστραφεὶς καὶ δακὼν καὶ ἀμφότεροι &lt;ἐκ&gt; τοῦ ὕψους κατενεχθέντες, ὁ μὲν ἰκτῖνος ἐτεθνήκει· ὁ δὲ ὄφις ἔφη αὐτῷ· « Τί τοσοῦτον ἐμάνης, ὅτι τοὺς μηδὲν ἀδικοῦντας βλάπτειν ἠϐούλου ; ἀλλὰ δίκην ἔδωκας τῆς ἁρπαγῆς δικαίαν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πλεονεξίᾳ τις προσέχων καὶ τοὺς ἀσθενεστέρους ἀδικῶν, ἰσχυροτέρῳ προσπεσών, ὡς οὐκ ἐλπίζει, ἐκτίσει τότε καὶ ἃ πρότερον ἐποίησε κακά.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 56.</p>
+          <bibl>Cod. Ba 56.</bibl>
           <p><milestone unit="traduction"/>Un milan ayant enlevé un serpent s’envola dans les airs. Le serpent se retourna et le mordit ; tous les deux furent alors précipités du haut des airs, et le milan périt. « Pourquoi, lui dit le serpent, as-tu été si fou que de faire du mal à qui ne t’en faisait pas : tu es justement puni de m’avoir enlevé. »</p>
           <p><milestone unit="traduction"/>Un homme qui se livre à sa convoitise et fait du mal à de plus faibles que lui peut tomber sur un plus fort : il expiera alors, contre son attente, tous les maux qu’il a faits auparavant.</p>
         </div>
@@ -3813,14 +3812,14 @@
           <l><milestone unit="recitvers"/>βλάπτειν ἐϐούλου καὶ θάνατον προσάγειν ;</l>
           <l><milestone unit="recitvers"/>Ὅμως πέπονθας ὃ ἐϐούλου μοι πρᾶξαι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πλεονεξίᾳ τις προσέχων καὶ τοὺς ἀσθενεῖς ἀδικῶν, ἰσχυροτέροις ἐμπεσών ποτε, καὶ μὴ ἐλπίζων, ἐκτίσει ἃ πρότερον πεποίηκε κακά.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 72.</p>
+          <bibl>Cod. Mb 72.</bibl>
         </div>
         <div>
           <head>Chambry 136.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P128"/>
           <p><milestone unit="recitprose"/>Ἰκτῖνος ὄφιν ἁρπάσας εἰς ὕψος ἀπέπτη. Ὁ δὲ ὄφις ἐπιστραφεὶς καὶ πλήξας τοῦτον, ἀμφοτέρους εἰς γῆν ἀφ’ ὕψους πεσεῖν συμϐέϐηκε. Τοῦ οὖν ἰκτίνου ἐκ τῆς πληγῆς τεθνηκότος, ὁ ὄφις πρὸς αὐτὸν ἔφη· « Τί τοσοῦτον ἐμεμήνεις, ταλαίπωρε, ὅτι τοὺς μηδὲν ἀδικοῦντας βλάπτειν ἐϐούλου ; Δικαίως οὖν ἔδωκας γνώμης δίκην ἀξίαν. »</p>
-          <p><milestone unit="manuscrits"/>Codd. Bd 28.</p>
+          <bibl>Codd. Bd 28.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-137">
@@ -3831,7 +3830,7 @@
           <pb ed="perry" n="P396"/>
           <p><milestone unit="recitprose"/>Ἰκτῖνος φωνὴν εἶχεν ἄλλην ὀξείαν. Ἵππου δὲ ἀκούσας καλῶς χρεμετίζοντος, μιμούμενος τὸν ἵππον καὶ συνεχῶς τοῦτο ποιῶν καὶ ταύτην μὴ καλῶς ἐκμαθών, καὶ τῆς ἰδίας φωνῆς ἐστέρηται, καὶ οὔτε τὴν τοῦ ἵππου ἔσχεν οὔτε τήν πρώτην.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ εὐτελεῖς καὶ φθονεροὶ ζηλοῦντες τοῦ παρὰ τὴν ἑαυτῶν φύσιν καὶ τῶν κατὰ φύσιν στεροῦνται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 55.</p>
+          <bibl>Cod. Ba 55.</bibl>
           <p><milestone unit="traduction"/>Le milan eut jadis une autre voix, qui était perçante. Mais un jour il entendit un cheval qui hennissait admirablement, et il voulut l’imiter. Mais il eut beau répéter ses essais : il ne réussit pas à prendre exactement la voix du cheval et il perdit en outre sa propre voix. De cette manière il n’eut ni la voix du cheval ni sa voix de jadis.</p>
           <p><milestone unit="traduction"/>Les gens vulgaires et jaloux envient les qualités contraires à leur nature et perdent celles qui y sont conformes.</p>
         </div>
@@ -3848,7 +3847,7 @@
           <l><milestone unit="recitvers"/>τὴν φωνὴν &lt;τὴν&gt; τοῦ ἵππου καταλαϐέσθαι,</l>
           <l><milestone unit="recitvers"/>καὶ τῆς ἰδίας φωνῆς ἀπεστερήθη.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ φθονεροὶ ζητοῦντες τὰ παρὰ τὴν φύσιν ὑστεροῦνται καὶ τῶν κατὰ φύσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 71.</p>
+          <bibl>Cod. Mb 71.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-138">
@@ -3859,7 +3858,7 @@
           <pb ed="perry" n="P115"/>
           <p><milestone unit="recitprose"/>Ἰξευτὴς ἀναλαϐὼν ἰξὸν καὶ τοὺς καλάμους ἐξῆλθεν ἐπ’ ἄγραν. Θεασάμενος δὲ κίχλαν ἐπί τινος ὑψηλοῦ δένδρου καθημένην, ταύτην συλλαϐεῖν ἠϐουλήθη. Καὶ δὴ συνάψας εἰς μῆκος τοὺς καλάμους ἀτενὲς ἔϐλεπεν, ὅλος ὢν πρὸς τῷ ἀέρι τὸν νοῦν. Τοῦτον δὲ τὸν τρόπον ἄνω νεύων ἔλαθεν ἀσπίδα πρὸ τῶν ἑαυτοῦ ποδῶν κοιμωμένην πατήσας· ἥτις ἐπιστραφεῖσα δῆξιν εἰς αὐτὸν ἀνῆκεν. Ὁ δὲ λιποψυχῶν ἔφη πρὸς ἑαυτόν· « Ἄθλιος ἔγωγε, ὃς ἕτερον θηρεῦσαι βουλόμενος ἔλαθον αὐτὸς ἀγρευθεὶς εἰς θάνατον. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοῖς πέλας ἐπιϐουλὰς ῥάπτοντες φθάνουσιν αὐτοὶ συμφοραῖς περιπίπτοντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 107 Pb 114 Pc 60 Pf 58 Pg 75 Ph 60 Ma 80 Me 75 Mf 66 Mj 75.</p>
+          <bibl>Codd. Pa 107 Pb 114 Pc 60 Pf 58 Pg 75 Ph 60 Ma 80 Me 75 Mf 66 Mj 75.</bibl>
           <p><milestone unit="traduction"/>Un oiseleur, prenant avec lui de la glu et ses gluaux, partit pour la chasse. Ayant aperçu une grive sur un arbre élevé, il se mit en tête de l’attraper. En conséquence, ayant ajusté ses bâtonnets les uns au bout des autres, il regardait fixement, tournant vers les airs toute son attention. Tandis qu’il levait ainsi la tête en l’air, il ne s’aperçut pas qu’il mettait le pied sur un aspic endormi, qui se retourna et lui lança un coup de dent. Et lui, se sentant mourir se dit : « Malheureux que je suis ! je voulais attraper une proie, et je ne me suis pas aperçu que je devenais moi-même la proie de la mort. »</p>
           <p><milestone unit="traduction"/>C’est ainsi qu’en ourdissant des embûches à son prochain on tombe le premier dans le malheur.</p>
         </div>
@@ -3869,7 +3868,7 @@
           <pb ed="perry" n="P115"/>
           <p><milestone unit="recitprose"/>Ἰξευτὴς ἀναλαϐὼν ἰξὸν καὶ τοὺς καλάμους ἐξῆλθε πρὸς ἄγραν. Θεασάμενος δὲ κίχλαν ἐπί τινος δένδρου ὑψηλοῦ καθημένην, ταύτην συλλαϐεῖν ἠϐουλήθη. Καὶ δὴ συνάψας εἰς μῆκος τοὺς καλάμους ἀτενὲς ἔϐλεπεν πρὸς τὸν ἀέρα. Καὶ δὴ πρὸς τοὺς πόδας αὐτοῦ ἀσπὶς κοιμωμένη εὑρεθεῖσα, ἐπάτησεν αὐτήν. Ἡ δὲ στραφεῖσα ἔδακεν αὐτόν. Ὁ δὲ λιποψυχῶν ἔφη μετὰ στεναγμοῦ· « Ἄθλιος ἐγώ, ὃς ἕτερον θηρεῦσαι βουλόμενος αὐτὸς ἠγρεύθην εἰς θάνατον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοῖς πέλας ἐπιϐουλεύοντες λανθάνουσι πολλάκις καὶ μεταστρέφεται ἐπ’ αὐτοὺς ἡ κακία αὐτῶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 62 Cb 55 Ce 58 Cf 62 Mh 54.</p>
+          <bibl>Codd. Ch 62 Cb 55 Ce 58 Cf 62 Mh 54.</bibl>
         </div>
         <div>
           <head>Chambry 138.3</head>
@@ -3888,7 +3887,7 @@
           <l><milestone unit="recitvers"/>« Θηρεῦσαι θέλων ἄλλον αὐτὸς ἠγρεύθην. »</l>
           <l><milestone unit="epimythiumenvers"/>[Ὁ λόγος οὗτος δηλοῖ ὅτι]</l>
           <l><milestone unit="epimythiumenvers"/>βόθρον ἄλλῳ ὀρύσσων αὐτὸς ἐμπέσῃ.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 53.</p>
+          <bibl>Cod. Cd 53.</bibl>
         </div>
         <div>
           <head>Chambry 138.4</head>
@@ -3896,7 +3895,7 @@
           <pb ed="perry" n="P115"/>
           <p><milestone unit="recitprose"/>Ἰξευτὴς ἰξὸν ἀναλαϐὼν καὶ καλάμους πρὸς ἄγραν ἐξῆλθεν. Ἰδὼν δὲ κίχλαν ἐφ’ ὑψηλοῦ δένδρου καθεζομένην καὶ τοὺς καλάμους ἀλλήλοις ἐπὶ μῆκος συνάψας, ἄνω πρὸς αὐτὴν συλλαϐεῖν βουλόμενος ἐφεώρα. Καὶ δὴ λαθὼν ἔχιν κοιμωμένην ὑπὸ πόδας ἐπάτησε. Τῆς δ’ ὀργισθείσης καὶ δακούσης αὐτόν, ἐκεῖνος ἤδη λειποψυχῶν ἔλεγε· « Δύστηνος ἐγώ· ἕτερον γὰρ θηρεῦσαι βουλόμενος, αὐτὸς ὑφ’ ἑτέρου ἠγρεύθην εἰς θάνατον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοῖς πέλας ἐπιϐουλεύοντες λανθάνουσι πολλάκις ὑφ’ ἑτέρων τοῦτ’ αὐτὸ πάσχοντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 32 Lb 60 Lc 60 Ld 22 Le 60 Lf 32 Lg 60 Lh 24 Mc 54 Md 59 Mg 83 Ml 78 Mm 75 Mn 22.</p>
+          <bibl>Codd. La 32 Lb 60 Lc 60 Ld 22 Le 60 Lf 32 Lg 60 Lh 24 Mc 54 Md 59 Mg 83 Ml 78 Mm 75 Mn 22.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-139">
@@ -3907,7 +3906,7 @@
           <pb ed="perry" n="P318"/>
           <p><milestone unit="recitprose"/>Γέρων ἵππος ἐπράθη πρὸς τὸ ἀλήθειν. Ζευχθεὶς δὲ ἐν τῷ μυλῶνι στενάζων εἶπεν· « Ἐκ ποίων δρόμων εἰς οἵους καμπτῆρας ἦλθον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι μὴ λίαν ἐπαιρέσθω τις πρὸς τὸ τῆς ἀκμῆς ἢ τῆς δόξης δυνατόν· πολλοῖς γὰρ τὸ γῆρας ἐν κόποις ἀνηλώθη.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 22 Bb 14.</p>
+          <bibl>Codd. Ba 22 Bb 14.</bibl>
           <p><milestone unit="traduction"/>Un vieux cheval fut vendu pour tourner la meule. Quand il se vit attelé au moulin, il gémit et s’écria : « Après les tours de la carrière, à quels tours me voilà réduit ! »</p>
           <p><milestone unit="traduction"/>Ne soyez pas trop fier de la force que donne la jeunesse ou la renommée : pour bien des gens le temps de la vieillesse s’est consumé en pénibles travaux.</p>
         </div>
@@ -3917,7 +3916,7 @@
           <pb ed="perry" n="P318"/>
           <p><milestone unit="recitprose"/>Γέροντι ἵππῳ πολλὰ κεκμηκότι ταῖς στρατηγίαις τε καὶ ἱππηλασίαις ἡ τοῦ μυλῶνος ἀτέλεστος καὶ σφαιροειδὴς διεδέξατο χώρα, πολλὴν ἔχουσα τὴν δυσπάθειαν. Ὁ δὲ στενάζων εἶπεν· « Οἴμοι ἐγώ· ἐκ ποίας ταχυδρόμου ὁρμῆς ἐν ποίῳ μεθηρμόσθην καμπτῆρι πολυμόχθῳ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δίκαιον τὸ ἐπαίρεσθαι ἐπί τινι εὐημερίᾳ ἢ γενναιότητι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 17.</p>
+          <bibl>Cod. Bc 17.</bibl>
         </div>
         <div>
           <head>Chambry 139.3</head>
@@ -3930,7 +3929,7 @@
           <l><milestone unit="recitvers"/>καὶ εὐκλείας γε ἧς εἶχον ὁ πανώλης,</l>
           <l><milestone unit="recitvers"/>νῦν δὲ προσδοῦμαι τοῖς ξυλίνοις καμπτῆρσιν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα ἐπαίρεσθαι ἐν δόξῃ· πολλοὶ γὰρ ἐν γήρᾳ ἀνηλώθησαν κόπῳ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pd 43.</p>
+          <bibl>Cod. Pd 43.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-140">
@@ -3941,7 +3940,7 @@
           <pb ed="perry" n="P105"/>
           <p><milestone unit="recitprose"/>Ζεὺς ἄνθρωπον ποιήσας ὀλιγοχρόνιον αὐτὸν ἐποίησεν. Ὁ δὲ τῇ ἑαυτοῦ συνέσει χρώμενος, ὅτε ἐνίστατο ὁ χειμών, οἶκον ἑαυτῷ κατεσκεύαζε καὶ ἐνταῦθα διέτριϐε. Καὶ δή ποτε σφοδροῦ κρύους γενομένου, καὶ τοῦ Διὸς ὕοντος, ἵππος ἀντέχειν μὴ δυνάμενος ἧκε δρομαῖος πρὸς τὸν ἄνθρωπον, καὶ τούτου ἐδεήθη ὅπως σκέπῃ αὐτόν. Ὁ δ’ οὐκ ἄλλως ἔφη τοῦτο ποιήσειν, ἐὰν μὴ τῶν οἰκείων ἐτῶν μέρος αὐτῷ δῷ. Τοῦ δὲ ἀσμένως παραχωρήσαντος, παρεγένετο μετ’ οὐ πολὺ καὶ βοῦς, οὐδ’ αὐτὸς δυνάμενος ὑπομένειν τὸν χειμῶνα. Ὁμοίως δὲ τοῦ ἀνθρώπου μὴ πρότερον ὑποδέξεσθαι φάσκοντος, ἐὰν μὴ τῶν ἰδίων ἐτῶν ἀριθμόν τινα παράσχῃ, καὶ αὐτὸς μέρος δοὺς ὑπεδέχθη. Τὸ δὲ τελευταῖον κύων ψύχει διαφθειρόμενος ἧκε, καὶ τοῦ ἰδίου χρόνου μέρος ἀπονείμας σκέπης ἔτυχε. Οὕτω τε συνέϐη τοὺς ἀνθρώπους, ὅταν μὲν ἐν τῷ τοῦ Διὸς χρόνῳ γένωνται, ἀκεραίους τε καὶ ἀγαθοὺς εἶναι· ὅταν δὲ εἰς τὰ τοῦ ἵππου ἔτη γένωνται, ἀλάζονάς τε καὶ ὑψαύχενας εἶναι· ἀφικνουμένους δὲ εἰς τὰ τοῦ βοὸς ἔτη, ἀρχικοὺς ὑπάρχειν· τοὺς δὲ τὸν τοῦ κυνὸς χρόνον ἀνύοντας ὀργίλους καὶ ὑλακτικοὺς γίνεσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς πρεσϐύτην θυμώδη καὶ δύστροπον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 104 Pg 67.</p>
+          <bibl>Codd. Pb 104 Pg 67.</bibl>
           <p><milestone unit="traduction"/>Quand Zeus créa l’homme, il ne lui accorda qu’une courte existence. Mais l’homme, tirant parti de son intelligence, quand vint l’hiver, se bâtit une maison et y vécut. Or un jour le froid étant devenu violent et la pluie s’étant mise à tomber, le cheval, ne pouvant y durer, vint en courant chez l’homme et lui demanda de l’abriter. Mais l’homme déclara qu’il ne le ferait qu’à une condition, c’est que le cheval lui donnerait une partie des années qui lui étaient départies. Le cheval en fit l’abandon volontiers. Peu après le bœuf aussi se présenta : lui non plus ne pouvait soutenir le mauvais temps. L’homme répondit de même qu’il ne le recevrait pas, s’il ne lui donnait un certain nombre de ses propres années ; le bœuf en donna une partie et fut admis. Enfin le chien mourant de froid vint aussi, et, en cédant une partie du temps qu’il avait à vivre, il obtint un abri. Voici ce qui en est résulté : quand les hommes accomplissent le temps que leur a donné Zeus, ils sont purs et bons ; quand ils arrivent aux années qu’ils tiennent du cheval, ils sont glorieux et hautains ; quand ils en sont aux années du bœuf, ils s’entendent à commander ; mais quand ils achèvent leur existence, le temps du chien, ils deviennent irascibles et grondeurs.</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à un vieillard colère et morose.</p>
         </div>
@@ -3951,7 +3950,7 @@
           <pb ed="perry" n="P105"/>
           <p><milestone unit="recitprose"/>Ἵππος καὶ βοῦς καὶ κύων ὑπὸ ψύχους στενούμενοι ἦλθον εἰς ἀνθρώπου τινὸς οἰκίαν. Ὁ δὲ δεξάμενος αὐτοὺς καὶ πῦρ ἀνάψας ἔθαλψεν. Καὶ τῷ μὲν ἵππῳ κριθὰς παρετίθει, τῷ δὲ ταύρῳ ἄχυρα· τῷ δὲ κυνὶ τὰ ἀπὸ τῆς τραπέζης ἐδίδου. Διὰ δὲ τὴν τοιαύτην φιλοξενίαν ἀντημείψαντο αὐτῷ χάριτας, μερίσαντες αὐτῷ καὶ χαρισάμενοι τῶν ἐτῶν ἐφ’ ὧν ἔζων· ὁ μὲν ἵππος εὐθὺς τοὺς πρώτους χρόνους· διὰ τοῦτο ἕκαστος θερμὸς καὶ γαυρός ἐστι τῇ γνώμη· ὁ δὲ βοῦς μετ’ αὐτὸν τοὺς μέσους χρόνους· διὰ τοῦτο μοχθηρὸς καὶ φιλεργός ἐστι πλοῦτον ἀθροίζων· τρίτος δὲ ὁ κύων τοὺς τελευταίους χρόνους· διὰ τοῦτο πᾶς γηράσκων δύσκολός ἐστι τῇ γνώμῃ, καὶ τὸν διδόντα μόνον τροφὴν ἀγαπᾷ καὶ σαίνει καὶ ἐπιχαίρει, τοῖς δὲ μὴ διδοῦσι καθυλακτεῖ καὶ καθάπτεται.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τινὲς τῶν ἀνθρώπων φαῦλοι ὄντες καὶ κακοὶ [ἐκείνους] εἰώθασι μόνους φιλεῖν τοὺς διατρέφοντας αὐτούς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 58 Bb 35 Mb 68.</p>
+          <bibl>Codd. Ba 58 Bb 35 Mb 68.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-141">
@@ -3962,7 +3961,7 @@
           <pb ed="perry" n="P319"/>
           <p><milestone unit="recitprose"/>Κριθὴν τὴν τοῦ ἵππου ὁ ἱπποκόμος κλέπτων καὶ πωλῶν τὸν ἵππον ἔτριϐεν, ἐκτένιζεν πᾶσαν ἡμέραν. Ἔφη δὲ ὁ ἵππος· « Εἰ θέλεις ἀληθῶς καλὸν εἶναί με, τὴν κριθὴν τὴν τρέφουσάν με μὴ πώλει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ πλεονέκται τοῖς πιθανοῖς λόγοις καὶ ταῖς κολακείαις τοὺς πένητας δελεάζοντες ἀποστεροῦσιν αὐτοὺς καὶ τῆς ἀναγκαίας χρείας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 67 Bb 43.</p>
+          <bibl>Codd. Ba 67 Bb 43.</bibl>
           <p><milestone unit="traduction"/>Un palefrenier volait l’orge de son cheval et la vendait ; en revanche il passait toute la journée à le frotter, à l’étriller. Le cheval lui dit : « Si tu veux vraiment me voir beau, ne vends plus l’orge destinée à ma nourriture. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les gens cupides amorcent les pauvres gens par leurs discours séducteurs et leurs flatteries, tandis qu’ils leur ôtent jusqu’au nécessaire.</p>
         </div>
@@ -3971,7 +3970,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P319"/>
           <p><milestone unit="recitprose"/>Κριθὰς τοῦ ἵππου ὁ ἱπποκόμος κλέπτων διεπώλει, τὸν δὲ ἵππον ψήκτραις διέτριϐε. Ὁ δὲ εἶπεν· « Εἰ θέλεις ὡραῖον εἶναί με, τὰς κριθὰς ἃς ἐσθίω μὴ κλέπτε. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 33.</p>
+          <bibl>Cod. Bd 33.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-142">
@@ -3982,7 +3981,7 @@
           <pb ed="perry" n="P181"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις εἶχεν ἵππον καὶ ὄνον. Ὁδευόντων δέ, ἐν τῇ ὁδῷ εἶπεν ὁ ὄνος τῷ ἵππῳ· « Ἆρον ἐκ τοῦ ἐμοῦ βάρους, εἰ θέλεις εἶναί με σῶν. » Ὁ δὲ οὐκ ἐπείσθη· ὁ δὲ ὄνος πεσὼν ἐκ τοῦ κόπου ἐτελεύτησε. Τοῦ δὲ δεσπότου πάντα ἐπιθέντος αὐτῷ καὶ αὐτὴν τὴν τοῦ ὄνου δοράν, θρηνῶν ὁ ἵππος ἐϐόα· « Οἴμοι τῷ παναθλίῳ, τί μοι συνέϐη τῷ ταλαιπώρῳ ; μὴ θελήσας γὰρ μικρὸν βάρος λαϐεῖν, ἰδοῦ ἅπαντα βαστάζω, καὶ τὸ δέρμα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοῖς μικροῖς οἱ μεγάλοι συγκοινωνοῦντες οἱ ἀμφότεροι σωθήσονται ἐν βίῳ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 129 Ld 9 Lf 129 Ma 153 Mc 16 Md 23 Me 27 Mf 26 Mh 16 Mi 58 Mk 17 Mm 23 Mn 9.</p>
+          <bibl>Codd. La 129 Ld 9 Lf 129 Ma 153 Mc 16 Md 23 Me 27 Mf 26 Mh 16 Mi 58 Mk 17 Mm 23 Mn 9.</bibl>
           <p><milestone unit="traduction"/>Un homme avait un cheval et un âne. Un jour qu’ils étaient en route, l’âne, pendant le trajet, dit au cheval : « Prends une partie de ma charge, si tu tiens à ma vie. » Le cheval fit la sourde oreille, et l’âne tomba, épuisé de fatigue, et mourut. Alors le maître chargea tout sur le cheval, même la peau de l’âne. Et le cheval dit en soupirant : « Ah ! je n’ai pas de chance ; que m’est-il arrivé là, hélas ! Pour n’avoir pas voulu me charger d’un léger fardeau, voilà que je porte tout, avec la peau en plus. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que, si les grands font cause commune avec les petits, les uns et les autres assureront ainsi leur vie.</p>
         </div>
@@ -4007,7 +4006,7 @@
           <l><milestone unit="epimythiumenvers"/>[Ὁ μῦθος δηλοῖ ὅτι]</l>
           <l><milestone unit="epimythiumenvers"/>τοῖς μικροῖς οἱ μεγάλοι συγκοινωνοῦντες</l>
           <l><milestone unit="epimythiumenvers"/>ἀμφότεροι σωθήσονται ἐν τῷ βίῳ.</l>
-          <p><milestone unit="manuscrits"/>Codd. Ch 18 Ca 24 Cc 15.</p>
+          <bibl>Codd. Ch 18 Ca 24 Cc 15.</bibl>
         </div>
         <div>
           <head>Chambry 142.3</head>
@@ -4015,7 +4014,7 @@
           <pb ed="perry" n="P181"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπος εἶχεν ὄνον τε καὶ ἵππον. Ὁδευόντων δέ, εἶπεν ὁ ὄνος τῷ ἵππῳ· Ἆρον ἐκ τοῦ βάρους τοῦ ἐμοῦ, εἰ θέλεις εἶναί με σῶον· εἰ δὲ μή, θνῄσκω. Ὁ δὲ οὐκ ἐπείσθη. Ὁ δὲ ὄνος ἐκ τοῦ κόπου πεσὼν ἀπέθανεν. Τοῦ δὲ δεσπότου τῷ ἵππῳ ἅπαντα ἐπιθέντος, ἀλλὰ καὶ αὐτὴν τὴν τοῦ ὄνου δοράν, ὁ ἵππος εἶπεν· Οἴμοι, μικρὸν οὐκ ἤθελον βάρος τοῦ ὄνου ἆραι, ἡ δὲ χρεία τὸ πᾶν μοι ἐπέθηκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς μικροῖς οἱ μεγάλοι κοινωνοῦντες καὶ συμπονοῦντες ἐν τῷ βίῳ ἀμφότεροι περισῴζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 12 Bb 7.</p>
+          <bibl>Codd. Ba 12 Bb 7.</bibl>
         </div>
         <div>
           <head>Chambry 142.4</head>
@@ -4023,14 +4022,14 @@
           <pb ed="perry" n="P181"/>
           <p><milestone unit="recitprose"/>Ἀνήρ τις ὄνου τε καὶ ἵππου κύριος ἦν. Μακρὰν οὖν στελλομένων πορείαν, ὁ ὄνος ἦν βιαίως ἀχθηφορῶν· διὸ ἔφησε πρὸς τὸν ἵππον· « Συγκάμφθητί μοι, καὶ ἆρον μικρόν τι ἐκ τοῦ φόρτου μου, εἰ μὴ θανεῖν με βούλει παρὰ καιρόν. » Τοῦ ἵππου δὲ μὴ πεισθέντος, ἡ προφήτεια τοῦ ὄνου εἰς ἔργον ἀπέϐη, καὶ ἐθανατώθη ὁ ὄνος κατάκοπος γεγονώς. Ἅπαν τοίνυν τὸ βάρος μετὰ καὶ τῆς τοῦ τεθνηκότος δορᾶς ὁ ἵππος ἦρε καὶ μὴ βουλόμενος· ὅθεν καὶ ἀπεκλαίετο λέγων· « Οἴμοι ὁ ἄθλιος, τί πέπονθα ; μικρᾶς γάρ τινος βοηθείας τὸν ὄνον μὴ ἀξιώσας, ἑαυτῷ μεγάλης ἀχθηφορίας παραίτιος γέγονα· πείσομαι δή ποτε καὶ αὐτὸς τὸ τοῦ ὄνου καὶ ἄωρος ἐξ ἀμετρίας στερηθησόμενος τῆς ζωῆς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ ἔνδοξοι τοῖς ταπεινοῖς κοινωνοῦντες ἐν βίῳ σῴζουσί τε καὶ σῴζονται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 10.</p>
+          <bibl>Cod. Bc 10.</bibl>
         </div>
         <div>
           <head>Chambry 142.5</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P181"/>
           <p><milestone unit="recitprose"/>Ἀνθρώπου τινὸς ὄνον καὶ ἵππον ἑλόντος, συνέϐη κατὰ τὴν ὁδὸν τὸν ὄνον ἐκ τοῦ βάρους τοῦ φορτίου ἀποκαμεῖν, καὶ τὸν ἵππον παρεκάλει ὀλίγον ἐκ τοῦ βάρους αὐτοῦ ἀφελεῖν. Ὁ δὲ οὐκ ἐπείθετο. Τοῦ δὲ ὄνον μηκέτι δυναμένου, ἀλλ’ ὑπὸ τοῦ κόπου ἀποθανόντος, ὁ τοῦ ἵππου δεσπότης οὐ μόνον ἅπερ ὁ ὄνος ἐϐάσταζεν, ἀλλὰ καὶ αὐτὴν &lt;τὴν&gt; τοῦ ὄνου δορὰν τῷ ἵππῳ ἐπέθετο. Στενάξας δὲ ὁ ἵππος ἔφη· « Οἴμοι, ὅτι μικρὸν βάρος μὴ θελήσας βαστάσαι, αὐτὰ τοῦ ὄνου πάντα καὶ αὐτὸν τὸν ὄνον ἀναγκάζομαι βαστάζειν. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 2.</p>
+          <bibl>Cod. Bd 2.</bibl>
         </div>
         <div>
           <head>Chambry 142.6</head>
@@ -4038,7 +4037,7 @@
           <pb ed="perry" n="P181"/>
           <p><milestone unit="recitprose"/>Ὀνηλάτης ἐπιθεὶς ὄνῳ καὶ ἡμιόνῳ γόμους ἤλαυνεν. Ὁ δὲ ὄνος, μέχρι μὲν πεδίον ἦν, ἀντεῖχε πρὸς τὸ βάρος. Ὡς δὲ ἐγένοντο κατά τι ὄρος, ὑποφέρειν μὴ δυνάμενος παρεκάλει τὴν ἡμίονον μέρος τι τοῦ γόμου αὐτοῦ προσδέξασθαι, ἵνα τὸ λοιπὸν αὐτὸς διακομίσαι δυνήσηται. Τῆς δὲ παρ’ οὐδὲν θεμένης αὐτοῦ τοὺς λόγους, ὁ μὲν κατακρημνισθεὶς διερράγη. Ὁ δὲ ὀνηλάτης ἀπορῶν ὅ τι ποιήσει, οὐ μόνον τοῦ ὄνου τὸν γόμον τῇ ἡμιόνῳ προσέθηκεν, ἀλλὰ καὶ αὐτὸν τὸν ὄνον ἐκδείρας ἐπεσώρευσε. Καὶ ἣ οὐ μετρίως καταπονηθεῖσα ἔφη πρὸς αὑτήν· « Δίκαια πέπονθα· εἰ γὰρ παρακαλοῦντι τῷ ὄνῳ μικρὰ κουφίσαι ἐπείσθην, οὐκ ἂν νῦν μετὰ τῶν φορτίων αὐτοῦ καὶ αὐτὸν ἔφερον. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν δανειστῶν ἔνιοι διὰ φιλαργυρίαν, ἵνα μικρὰ τοῖς χρεώσταις μὴ παράσχωσι, πολλάκις καὶ αὐτὸ τὸ κεφάλαιον ἀπολλῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 180 Pb 177 Mb 153 Ca 133.</p>
+          <bibl>Codd. Pa 180 Pb 177 Mb 153 Ca 133.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-143">
@@ -4049,7 +4048,7 @@
           <pb ed="perry" n="P320"/>
           <p><milestone unit="recitprose"/>Ἵππον τὸν ἑαυτοῦ στρατιώτης, ἕως μὲν καιρὸς τοῦ πολέμου ἦν, ἐκρίθιζεν, ἔχων συνεργὸν ἐν ταῖς ἀνάγκαις. Ὅτε δὲ ὁ πόλεμος κατέπαυσεν, εἰς δουλείας τινὰς καὶ φόρτους βαρεῖς ὁ ἵππος ὑπούργει, ἀχύρῳ μόνῳ τρεφόμενος. Ὡς δὲ πάλιν πόλεμος ἠκούσθη καὶ ἡ σάλπιγξ ἐφώνει, τὸν ἵππον χαλινώσας ὁ δεσπότης καὶ αὐτὸς καθοπλισθεὶς ἐπέϐη. Ὁ δὲ συνεχῶς κατέπιπτε μηδὲν ἰσχύων· ἔφη δὲ τῷ δεσπότῃ· « Ἄπελθε μετὰ τῶν πεζῶν [τῶν] ὁπλιτῶν ἄρτι· σὺ γὰρ ἀφ’ ἵππου εἰς ὄνον με μετεποίησας, καὶ πῶς πάλιν ἐξ ὄνου ἵππον θέλεις ἔχειν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐν καιρῷ ἀδείας καὶ ἀνέσεως τῶν συμφορῶν οὐ δεῖ ἐπιλανθάνεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 57.</p>
+          <bibl>Cod. Ba 57.</bibl>
           <p><milestone unit="traduction"/>Un soldat, pendant toute la durée de la guerre, avait nourri d’orge son cheval, compagnon de ses travaux et de ses dangers. Mais, la guerre finie, le cheval fut employé à des besognes serviles et au transport de lourds fardeaux, et il ne fut plus nourri que de paille. Cependant une autre guerre fut annoncée, et à l’appel de la trompette le maître brida son cheval, s’arma lui-même et l’enfourcha. Mais le cheval sans force tombait à chaque pas. Il dit à son maître : « Va maintenant te ranger parmi les fantassins ; car de cheval tu m’as changé en âne. Comment veux-tu d’un âne refaire un cheval ? »</p>
           <p><milestone unit="traduction"/>Dans les temps de sécurité et de relâche, il ne faut pas oublier les temps de malheur.</p>
         </div>
@@ -4058,7 +4057,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P320"/>
           <p><milestone unit="recitprose"/>Ἔτρεφε τὸν ἑαυτοῦ ἵππον στρατιώτης, ἕως καιρὸς πολέμου ἦν. Παυσαμένου δὲ τοῦ πολέμου, ἀχύροις καὶ μόνοις ἔτρεφε, φορτίοις μεγάλοις καταϐαρύνων. Ὡς δὲ πάλιν καιρὸς πολέμου ἐπέστη, ὁπλισάμενος τὸν ἵππον ἀναϐὰς ἔτρεχε. Τοῦ δὲ ἵππου συνεχῶς καταπίπτοντος, ἐδυσχέραινε. Ὁ δὲ ἵππος αὐτῷ ἔφη· « Ἄπελθε, ὦ δέσποτα, πεζὸς πολεμήσων· σὺ γὰρ ἀφ’ ἵππου ὄνον με πεποίηκας, χυδαίαις ἐργασίαις καταϐαρύνων, καὶ πῶς πάλιν ἐξ ὄνου ἵππον με θέλεις ἔχειν ; »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 29.</p>
+          <bibl>Cod. Bd 29.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-144">
@@ -4067,7 +4066,7 @@
         <pb ed="perry" n="P269"/>
         <p><milestone unit="recitprose"/>Οὔπω χαλινὸν ἵππος ᾔδει, οὐδὲ νῶτον ἀνθρώπῳ παρεῖχε πρὸς καθέδραν. Σῦς δὲ αὐτὸν ἄγριος ἔϐλαπτε, τὴν χλόην ἣν ἐνέμετο κόπτων καὶ κατορύσσων καὶ τὸ ὕδωρ ταράσσων ἔνθα ἔπινε. Διὰ τοῦτο ὁ μῶρος ἵππος πρὸς ἄμυναν τοῦ ἠδικηκότος συὸς διεγερθεὶς φιλίαν ἐσπείσατο μετὰ ἀνδρὸς ποικίλου, βοηθεῖν δὲ ἔλεγεν αὐτῷ καὶ ἐκδικεῖν κατὰ τοῦ βλάπτοντος ἐχθροῦ. Ὁ δὲ εἶπεν· « Ὅρκῳ πίστωσόν με ὅ λέγω σοι ποιήσειν. » Ὁ δὲ ἵππος ἐπείσθη. Ὁ δὲ εἶπεν· « Οὐ δυνατόν με πεζὸν ὄντα καταπολεμῆσαι τοῦτον· ἀλλ’ ἐὰν χαλινὸν δέξῃ καί &lt;με&gt; τοῖς νώτοις σου βαστάσῃς καὶ δῷς ὅπως σε κάμπτω καὶ τρέχοντα κωλύω, ἐλπίζω τότε τὸν σῦν εὐκόλως ἀναιρήσειν. » Ὁ δὲ ἵππος ὑπὸ ὀργῆς τὰς φρένας τυφλωθεὶς παρέδωκεν ἑαυτὸν καὶ ὑπὸ τοῦ δοκοῦντος ὠφελεῖν ἐχειρώθη.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι θυμὸς οἶδεν δουλῶσαι καὶ ταπεινῶσαι ἄνδρα γενναῖον καὶ πρὸς ἄμυναν [γενέσθαι] τοῦ ἀδικηκότος &lt;ὡρμημένον&gt;.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 117.</p>
+        <bibl>Cod. Ba 117.</bibl>
       </div>
       <div type="poem" xml:id="chambry-145">
         <head>Chambry 145</head>
@@ -4077,7 +4076,7 @@
           <pb ed="perry" n="P321"/>
           <p><milestone unit="recitprose"/>Διέϐαινε ποταμὸν κάμηλος ὀξὺ ῥέοντα. Ἀφοδεύσασα δὲ καὶ τὴν κόπρον εὐθὺς ἔμπροσθεν αὐτῆς ἰδοῦσα διὰ τὸ ὀξὺ τοῦ ῥεύματος εἶπεν· « Τί τοῦτο ; τὰ ὄπισθέν μου ἔμπροσθέν μου νῦν ὁρῶ διερχόμενα. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] ἐν πόλει &lt;ἐν&gt; ᾗ ἔσχατοι καὶ ἄφρονες κρατοῦσιν ἀντὶ τῶν πρώτων καὶ φρονίμων ἁρμόζει ὁ μῦθος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 25 Mb 76 Mg 49.</p>
+          <bibl>Codd. Ba 25 Mb 76 Mg 49.</bibl>
           <p><milestone unit="traduction"/>Un chameau traversait une rivière au cours rapide. Ayant fient’, il vit aussitôt sa crotte emportée devant lui par la rapidité du courant. « Qu’est-ce là ? s’écria-t-il ; ce qui était derrière moi, je le vois à présent passer devant moi. »</p>
           <p><milestone unit="traduction"/>Cette fable trouve son application dans un État où les derniers et les imbéciles dominent à la place des premiers et des gens sensés.</p>
         </div>
@@ -4087,7 +4086,7 @@
           <pb ed="perry" n="P321"/>
           <p><milestone unit="recitprose"/>Διέϐαινέ ποτε κάμηλος ποταμὸν ὀξὺ διαρρέοντα. Ἀφοδεύσασα δὲ καὶ τὴν κόπρον αὑτῆς ἔμπροσθεν κατιδοῦσα τῇ τοῦ ὕδατος ὀξυτάτῃ καταρροῇ· « Τί τοῦτο ; ἔφη, τὰ ἐξόπισθέν μου νῦν ἔμπροσθέν μου τεθέαμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις οἱ ἄτιμοι τῶν τιμίων προάγουσι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 20.</p>
+          <bibl>Cod. Bc 20.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-146">
@@ -4098,7 +4097,7 @@
           <pb ed="perry" n="P220"/>
           <p><milestone unit="recitprose"/>Τῶν ἀλόγων ζῴων βουλευομένων βασιλέα ἑλέσθαι, κάμηλος καὶ ἐλέφας καταστάντες ἐφιλονείκουν, καὶ διὰ τὸ μέγεθος τοῦ σώματος καὶ διὰ τὴν ἰσχὺν ἐλπίζοντες πάντων προκρίνεσθαι. Πίθηκος δὲ ἀμφοτέρους ἀνεπιτηδείους εἶναι ἔφη, τὴν μὲν κάμηλον, διότι χολὴν οὐκ ἔχει κατὰ τῶν ἀδικούντων, τὸν δὲ ἐλέφαντα, ὅτι δέος ἐστὶ μὴ χοιρίδιον, ὃ δέδοικεν, ἡμῖν ἐπιτιθῆται.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλοὶ καὶ τῶν μεγίστων πραγμάτων διὰ μικρὰν αἰτίαν κωλύονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 217 Pf 132 Pg 141 Mb 60 Me 169 Mf 140 Cf 124.</p>
+          <bibl>Codd. Pb 217 Pf 132 Pg 141 Mb 60 Me 169 Mf 140 Cf 124.</bibl>
           <p><milestone unit="traduction"/>Les bêtes délibéraient sur le choix d’un roi. Le chameau et l’éléphant se mirent sur les rangs et se disputèrent les suffrages, espérant être préférés aux autres, grâce à leur haute taille et à leur force. Mais le singe les déclara l’un et l’autre impropres à régner : « le chameau, dit-il, parce qu’il n’a point de colère contre les malfaiteurs, et l’éléphant, parce qu’il est à craindre qu’un goret, animal dont il a peur, ne vienne nous attaquer. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’une petite cause ferme parfois l’accès des grands emplois.</p>
         </div>
@@ -4108,7 +4107,7 @@
           <pb ed="perry" n="P220"/>
           <p><milestone unit="recitprose"/>Τῶν ἀλόγων ζῴων βουλομένων βασιλέα ἑλέσθαι τινὰ ἐξ αὐτῶν, κάμηλος καὶ ἐλέφας ἐψηφίζοντο, ὁ μὲν διὰ τὸ μέγεθος, ὁ δὲ διὰ τὴν ἰσχύν. Πίθηκος δὲ ἀνεπιτηδείους εἶναι ἔφη, τὴν μὲν κάμηλον, ὅτι χολὴν καὶ ἄμυναν &lt;οὐ&gt; τρέφει κατὰ τῶν ἐπταικότων, τὸν δὲ ἐλέφαντα, ὅτι δέος ἐστίν, αὐτοῦ βασιλεύοντος, μὴ χοιρίδια ἡμῖν ἐπιθῆται.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις τὰ μεγάλα τῶν πραγμάτων παρὰ μικρὸν κωλύονται καὶ οὐ τελοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ce 116.</p>
+          <bibl>Cod. Ce 116.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-147">
@@ -4119,7 +4118,7 @@
           <pb ed="perry" n="P117"/>
           <p><milestone unit="recitprose"/>Κάμηλος θεασαμένη ταῦρον ἐπὶ τοῖς κέρασιν ἀγαλλόμενον, φθονήσασα αὐτῷ, ἐϐουλήθη καὶ αὐτὴ τῶν ἴσων ἐφικέσθαι. Διόπερ παραγενομένη πρὸς τὸν Δία, τούτου ἐδέετο, ὅπως αὐτῇ κέρατα προσνείμῃ. Καὶ ὁ Ζεὺς ἀγανακτήσας κατ’ αὐτῆς, εἴγε μὴ ἀρκεῖται τῷ μεγέθει τοῦ σώματος καὶ τῇ ἰσχύι, ἀλλὰ καὶ περισσοτέρων ἐπιθυμεῖ, οὐ μόνον αὐτῇ κέρατα οὐ προσέθηκεν, ἀλλὰ καὶ μέρος τι τῶν ὤτων ἀφείλετο.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ διὰ πλεονεξίαν τοῖς ἄλλοις ἐποφθαλμιῶντες λανθάνουσι καὶ τῶν ἰδίων στερούμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 109 Pb 116 Pc 62 Pe 14 Pf 59 Pg 77 Ph 61 Ma 82 Me 81 Mf 71 Mj 76 Cd 65.</p>
+          <bibl>Codd. Pa 109 Pb 116 Pc 62 Pe 14 Pf 59 Pg 77 Ph 61 Ma 82 Me 81 Mf 71 Mj 76 Cd 65.</bibl>
           <p><milestone unit="traduction"/>Le chameau, voyant le taureau se prévaloir de ses cornes, l’envia et voulut lui aussi en obtenir autant. C’est pourquoi, étant allé trouver Zeus, il le pria de lui accorder des cornes. Mais Zeus, indigné qu’il ne se contentât point de sa grande taille et de sa force et qu’il désirât encore davantage, non seulement refusa de lui ajouter des cornes, mais encore lui retrancha une partie de ses oreilles.</p>
           <p><milestone unit="traduction"/>Ainsi beaucoup de gens qui, par cupidité, regardent les autres avec envie, ne s’aperçoivent pas qu’ils perdent leurs propres avantages.</p>
         </div>
@@ -4133,7 +4132,7 @@
           <l><milestone unit="recitvers"/>οὐκ ἐπέδωκεν, ἀλλά γε καὶ τῶν ὤτων</l>
           <l><milestone unit="recitvers"/>ἀπεστέρησε πολλὰ αὐτὸς χολήσας.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ ἔχων τι ἀρκείσθω ἐπ’ ἐκείνῳ καὶ πλείω μὴ ζητείτω, ἵνα μὴ καὶ ὃ ἔχει ἀπολέσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 152 Cg 25 Ch 100.</p>
+          <bibl>Codd. Ca 152 Cg 25 Ch 100.</bibl>
         </div>
         <div>
           <head>Chambry 147.3</head>
@@ -4141,7 +4140,7 @@
           <pb ed="perry" n="P117"/>
           <p><milestone unit="recitprose"/>Ὁ Ζεὺς τῇ καμήλῳ κέρατα αἰτούσῃ καὶ λεγούσῃ ὅτι ταῦτά μοι λείπει, οὐ μόνον &lt;οὐ&gt; δέδωκεν, ἀλλὰ καὶ τῶν ὤτων ἐστέρησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, ὃ ἔχει τις, εἰς ἐκεῖνο ἀρκείσθω καὶ μὴ πλεονεκτείτω.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 104.</p>
+          <bibl>Cod. Ba 104.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-148">
@@ -4152,7 +4151,7 @@
           <pb ed="perry" n="P249"/>
           <p><milestone unit="recitprose"/>Κάμηλος ἀναγκαζομένη ὑπὸ τοῦ ἰδίου δεσπότου ὀρχήσασθαι εἶπεν· « Ἀλλ’ οὐ μόνον ὀρχουμένη εἰμὶ ἄσχημος, ἀλλὰ καὶ περιπατοῦσα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος εἴρηται ἐν παντὶ ἔργῳ ἀπρέπειαν ἔχοντι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 132 Pg 90 Mb 77 Ch 72.</p>
+          <bibl>Codd. Pa 132 Pg 90 Mb 77 Ch 72.</bibl>
           <p><milestone unit="traduction"/>Un chameau que son propre maître contraignait à danser dit : « Ce n’est pas seulement quand je danse que je manque de grâce, j’en manque même lorsque je marche. »</p>
           <p><milestone unit="traduction"/>Cette fable peut se dire à propos de tout acte dépourvu de grâce.</p>
         </div>
@@ -4165,7 +4164,7 @@
           <l><milestone unit="recitvers"/>« Οὐ μόνον ἄσχημός εἰμι ὀρχουμένη,</l>
           <l><milestone unit="recitvers"/>ἀλλὰ καὶ περιπατοῦσ’ ἢ καθημένη. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ &lt;ὅτι ὁ&gt; ἐν ἑνὶ ἀδόκιμος καὶ ἐν παντὶ ἀδόκιμός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 63.</p>
+          <bibl>Cod. Cd 63.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-149">
@@ -4174,7 +4173,7 @@
         <pb ed="perry" n="P195"/>
         <p><milestone unit="recitprose"/>Ὅτε πρῶτον κάμηλος ὤφθη, οἱ ἄνθρωποι φοϐηθέντες καὶ τὸ μέγεθος καταπλαγέντες ἔφευγον. Ὡς δέ, χρόνου προϊόντος, συνεῖδον αὐτῆς τὸ πρᾷον, ἐθάρρησαν μέχρι τοῦ προσελθεῖν. Αἰσθόμενοι δὲ κατὰ μικρὸν ὡς χολὴν τὸ ζῷον οὐκ ἔχει, εἰς τοῦτο καταφρονήσεως ἦλθον ὥστε καὶ χαλινὸν αὐτῇ περιθέντες παισὶν ἐλαύνειν αὐτὴν ἔδωκαν.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὰ φοϐερὰ τῶν πραγμάτων ἡ συνήθεια καταπραΰνει.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 197 Pb 191 Pf 107 Ca 148 — La 122 Lb 108 Le 108 Lf 122 Lh 18 Me 140 Mf 116 Mg 131 Mj 129 Ml 131.</p>
+        <bibl>Codd. Pa 197 Pb 191 Pf 107 Ca 148 — La 122 Lb 108 Le 108 Lf 122 Lh 18 Me 140 Mf 116 Mg 131 Mj 129 Ml 131.</bibl>
         <p><milestone unit="traduction"/>Lorsqu’ils virent le chameau pour la première fois, les hommes eurent peur, et, frappés de sa grande taille, ils s’enfuirent. Mais quand avec le temps ils se furent rendu compte de sa douceur, ils s’enhardirent jusqu’à l’approcher. Puis s’apercevant peu à peu que la bête n’avait pas de colère, ils en vinrent à la mépriser au point de lui mettre une bride et de la donner à conduire à des enfants.</p>
         <p><milestone unit="traduction"/>Cette fable montre que l’habitude calme la peur qu’inspirent les choses effrayantes.</p>
       </div>
@@ -4186,7 +4185,7 @@
           <pb ed="perry" n="P84"/>
           <p><milestone unit="recitprose"/>Ἔν τινι νησιδίῳ ταῦρος ἐνέμετο· τῇ δὲ τούτου κόπρῳ κάνθαροι ἐτρέφοντο δύο. Καὶ δὴ τοῦ χειμῶνος ἐνισταμένου, ὁ ἕτερος ἔλεγε πρὸς τὸν ἕτερον ὡς ἄρα βούλοιτο εἰς τὴν ἤπειρον διαπτάσθαι, ἵνα ἐκείνῳ μόνῳ ὄντι ἡ τροφὴ ἱκανῶς ὑπάρχῃ, καὶ αὐτὸς ἐκεῖσε ἐλθὼν τὸν χειμῶνα διαγένηται. Ἔλεγε δὲ ὅτι, ἐὰν πολλὴν εὕρῃ τὴν νομήν, καὶ αὐτῷ οἴσει. Παραγενόμενος δὲ εἰς τὴν χέρσον καὶ καταλαϐὼν πολλὴν μὲν τὴν κόπρον, ὑγρὰν δέ, μένων ἐτρέφετο ἐνταῦθα. Τοῦ δὲ χειμῶνος διελθόντος, πάλιν εἰς τὴν νῆσον διέπτη. Ὁ δὲ ἕτερος θεασάμενος αὐτὸν λιπαρὸν καὶ εὐεκτοῦντα, ᾐτιάσατο αὐτὸν διότι προϋποσχόμενος αὐτῷ οὐδὲν ἐκόμισεν. Ὁ δὲ εἶπε· « Μὴ ἐμὲ μέμφου, τὴν δὲ φύσιν τοῦ τόπου· ἐκεῖθεν γὰρ τρέφεσθαι μὲν οἷόν τε, φέρεσθαι δὲ οὐδέν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόσειεν ἂν πρὸς ἐκείνους οἳ τὰς φιλίας μέχρις ἑστίασεως μόνον παρέχονται, περαιτέρω δὲ οὐδὲν τοὺς φίλους ὠφελοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 81 Pb 85 Pg 54 Ma 64.</p>
+          <bibl>Codd. Pa 81 Pb 85 Pg 54 Ma 64.</bibl>
           <p><milestone unit="traduction"/>Un taureau paissait dans une petite île, et deux escarbots se nourrissaient de sa bouse. À l’arrivée de l’hiver, l’un dit à l’autre qu’il voulait passer sur le continent, afin que, étant seul, son camarade eût de la nourriture en suffisance, tandis que lui s’en irait là-bas pour y passer l’hiver. Il ajouta que, s’il y trouvait de la pâture en abondance, il lui en apporterait. Or, arrivé sur le continent, il y rencontra des bouses nombreuses et fraîches ; il s’y établit et s’en nourrit. L’hiver passé, il revint dans l’île. Son camarade le voyant gras et en bon corps, lui rappela sa promesse et lui reprocha de ne lui avoir rien rapporté. « Ne t’en prends pas à moi, répondit-il, mais à la nature du lieu : il est possible d’y trouver à vivre, mais impossible d’en emporter quoi que ce soit. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à ceux qui poussent l’amitié jusqu’à régaler leurs amis, mais pas plus loin, et qui refusent de leur rendre aucun service.</p>
         </div>
@@ -4196,7 +4195,7 @@
           <pb ed="perry" n="P84"/>
           <p><milestone unit="recitprose"/>Ἔν τινι νησιδίῳ ταῦρος ἐνέμετο· τῇ δὲ τούτου κόπρῳ κάνθαροι ἐτρέφοντο δύο. Χειμῶνος δὲ ἐπιστάντος, ὁ εἷς ἔφη τῷ ἑτέρῳ· « Βούλομαι εἰς τὴν ἤπειρον διαπτάσθαι, ἵνα ἐκεῖ τὸν χειμῶνα μόνος ὢν διαγίνωμαι, καὶ, ἐὰν πολλὴν εὕρω τὴν νομὴν, καὶ σὲ προσλαμϐάνωμαι. » Παραγενόμενος δὲ ἐν τῇ χέρσῳ καὶ καταλαϐὼν πολλὴν κόπρον, ὑγρὰν δὲ, μένων ἐνταῦθα ἐτρέφετο. Τοῦ δὲ χειμῶνος παρελθόντος, πάλιν εἰς τὴν νῆσον διέπτη &lt;ἐν&gt; ᾗ ἦν ὁ ἕτερος. Θεασάμενος δὲ αὐτὸν λιπαρὸν ὁ ἕτερος ᾐτιᾶτο αὐτὸν διότι ὑποσχόμενος αὐτῷ οὐ διεκόμισεν. Ὁ δὲ ἔφη αὐτῷ· « Μὴ ἐμὲ μέμφου, ἀλλὰ τὴν φύσιν τοῦ τόπου· ἐκεῖθεν μὲν γὰρ τρέφεσθαι οἷόν τε, φέρεσθαι δὲ οὔ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόζει πρὸς ἐκείνους οἱ τὰς φιλίας μέχρι ἑστιάσεως παρέχονται, περαιτέρω δὲ οὐδὲν τοῖς φίλοις ὠφελοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 49.</p>
+          <bibl>Cod. Pe 49.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-151">
@@ -4207,7 +4206,7 @@
           <pb ed="perry" n="P116"/>
           <p><milestone unit="recitprose"/>Καρκῖνος ἀναϐὰς ἀπὸ τῆς θαλάσσης ἐπί τινος αἰγιαλοῦ μόνος ἐνέμετο. Ἀλώπηξ δὲ λιμώττουσα, ὡς ἐθεάσατο αὐτόν, ἀποροῦσα τροφῆς, προσδραμοῦσα συνέλαϐεν αὐτόν. Ὁ δὲ μέλλων καταϐιϐρώσκεσθαι ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα, ὅτι θαλάσσιος ὢν χερσαῖος ἠϐουλήθην γενέσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ τὰ οἰκεῖα καταλιπόντες ἐπιτηδεύματα καὶ τοῖς μηδὲν προσήκουσιν ἐπιχειροῦντες εἰκότως δυστυχοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 108 Pb 115 Pc 61 Pf 60 Pg 76 Ph 62 Ma 81 Mb 75 Me 82 Mf 72 Mj 77 Cd 64.</p>
+          <bibl>Codd. Pa 108 Pb 115 Pc 61 Pf 60 Pg 76 Ph 62 Ma 81 Mb 75 Me 82 Mf 72 Mj 77 Cd 64.</bibl>
           <p><milestone unit="traduction"/>Un crabe, étant monté de la mer sur le rivage, cherchait sa vie solitairement. Un renard affamé l’aperçut ; comme il n’avait rien à se mettre sous la dent, il courut sur lui et le prit. Alors le crabe, sur le point d’être dévoré, s’écria : « J’ai mérité ce qui m’arrive, moi qui, habitant de la mer, ai voulu devenir terrien. »</p>
           <p><milestone unit="traduction"/>Il en est ainsi des hommes : ceux qui abandonnent leurs propres occupations pour se mêler d’affaires qui ne les regardent pas, tombent naturellement dans le malheur.</p>
         </div>
@@ -4217,7 +4216,7 @@
           <pb ed="perry" n="P116"/>
           <p><milestone unit="recitprose"/>Καρκῖνος ἀπὸ τῆς θαλάσσης ἀναϐὰς ἐπί τινος ἐνέμετο τόπου. Ἀλώπηξ δὲ λιμώττουσα, ὡς ἐθεάσατο, προσελθοῦσα ἀνέλαϐεν αὐτὸν. Ὁ δὲ μέλλων καταϐιϐρώσκεσθαι ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα, ὃς θαλάττιος ὢν χερσαῖος ἠϐουλήθην γενέσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ τῶν ἀνθρώπων οἱ τὰ οἰκεῖα καταλιπόντες ἐπιτηδεύματα καὶ τοῖς μηδὲν προσήκουσιν ἐπιχειροῦντες εἰκότως δυστυχοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 99 Lb 66 Le 66 Lf 99 Lh 29 Mg 90 Ml 85.</p>
+          <bibl>Codd. La 99 Lb 66 Le 66 Lf 99 Lh 29 Mg 90 Ml 85.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-152">
@@ -4228,7 +4227,7 @@
           <pb ed="perry" n="P322"/>
           <p><milestone unit="recitprose"/>Μὴ λοξὰ περιπατεῖν καρκίνῳ μήτηρ &lt;ἔλεγε&gt; μηδὲ τῇ ὑγρᾷ πέτρᾳ τὰς πλευρὰς προστρίϐειν. Ὁ δὲ εἶπεν· « Μῆτερ, σύ, ἡ διδάσκουσα, ὀρθὰ βάδιζε καὶ βλέπων σε ζηλώσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς μεμψιμοίρους πρέπον ἐστὶν ὀρθὰ βιοῦν καὶ βαδίζειν, καὶ τότε ὅμοια διδάσκειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 91.</p>
+          <bibl>Cod. Ba 91.</bibl>
           <p><milestone unit="traduction"/>« Ne marche pas de travers, disait une écrevisse à sa fille, et ne frotte pas tes flancs contre le roc humide. — Mère, répliqua-t-elle, toi qui veux m’instruire, marche droit ; je te regarderai et t’imiterai. »</p>
           <p><milestone unit="traduction"/>Quand on reprend les autres, il convient qu’on vive et marche droit, avant d’en faire leçon.</p>
         </div>
@@ -4238,7 +4237,7 @@
           <pb ed="perry" n="P322"/>
           <p><milestone unit="recitprose"/>« Μὴ λοξὰ περιπάτει, καρκῖνος ἔλεγε τῷ τέκνῳ, μηδὲ ταῖς πτέρναις πρόστριϐε τὰς πλευράς σου. » Ἔφη δὲ τῇ μητρὶ ὁ καρκῖνος· « Ἐμὲ διδάσκουσα, μῆτερ, ἃ λέγεις, ὀρθὰ σὺ βάδιζε καὶ βλέπων σε ζηλώσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος τοὺς μεμψιμοίρους ἐλέγχει· πρῶτον γὰρ αὐτοὺς ὀρθὰ βιοῦν δεῖ καὶ τόθ’ ἑτέρους διδάσκειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mh 77.</p>
+          <bibl>Cod. Mh 77.</bibl>
         </div>
         <div>
           <head>Chambry 152.3</head>
@@ -4246,7 +4245,7 @@
           <pb ed="perry" n="P322"/>
           <p><milestone unit="recitprose"/>Καρκίνῳ ποτὲ ἡ μήτηρ παρῄνει· « Μὴ λοξά, τέκνον, ἐμπεριπάτει. » Ὁ δὲ πρὸς αὐτὴν λέγει· « Σύ μοι, ὦ μῆτερ, ὑπόδειξον βαδίζειν καὶ περιπατεῖν, ὄρθια βηματίζουσα, ὅπως ὁρῶν σε κἀγὼ παραζηλώσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι μεγίστην βλάϐην καὶ θάνατον οἶδε ποιεῖν τῶν κακῶν ἡ συνουσία.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 74.</p>
+          <bibl>Cod. Mb 74.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-153">
@@ -4257,7 +4256,7 @@
           <pb ed="perry" n="P250"/>
           <p><milestone unit="recitprose"/>Καρύα, παρά τινα ὁδὸν οὖσα καὶ ὑπὸ τῶν παριόντων λίθοις βαλλομένη, στενάξασα πρὸς ἑαυτὴν εἶπεν· « Ἀθλία εἰμὶ ἐγώ, ἥτις κατ’ ἐνιαυτὸν ἐμαυτῇ ὕϐρεις καὶ λύπας παρέχω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς τοὺς ἐπὶ τῶν ἰδίων ἀγαθῶν λυπουμένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 131 Pg 89 Cd 72.</p>
+          <bibl>Codd. Pa 131 Pg 89 Cd 72.</bibl>
           <p><milestone unit="traduction"/>Un noyer qui se trouvait au bord d’une route et que les passants frappaient à coups de pierres, se disait en soupirant : « Malheureux que je suis de m’attirer tous les ans des insultes et des douleurs ! »</p>
           <p><milestone unit="traduction"/>Cette fable vise les gens qui ne retirent que des désagréments de leurs propres biens.</p>
         </div>
@@ -4267,7 +4266,7 @@
           <pb ed="perry" n="P250"/>
           <p><milestone unit="recitprose"/>Καρύα τις ἐν ὁδῷ ἱσταμένη καρπὸν ἔφερε πολύν. Οἱ δὲ παροδῖται λίθοις αὐτὴν καὶ βάκλοις κατέκλων διὰ τὰ κάρυα. Ἡ δὲ οἰκτρὸν ἔφη· « Ὦ ἀθλία ἐγώ, ὅτι οὕς τῷ καρπῷ μου εὐφραίνω, ὑπὸ τούτων δεινὰς ἀντιλαμϐάνω χάριτας. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς ἀχαρίστους καὶ κακούργους, τοὺς ἀντὶ ἀγαθῶν κακὰ ἀντιδιδόντας, ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 60 Bb 36 Bd 30.</p>
+          <bibl>Codd. Ba 60 Bb 36 Bd 30.</bibl>
         </div>
         <div>
           <head>Chambry 153.3</head>
@@ -4282,7 +4281,7 @@
           <l><milestone unit="recitvers"/>τί μοι συνέϐη ; οὓς τοῖς καρποῖς εὐφραίνω,</l>
           <l><milestone unit="recitvers"/>μάστιγας δεινὰς ὑπ’ αὐτῶν νῦν λαμϐάνω. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἀχαρίστους ἀνθρώπους ἀντὶ ἀγαθῶν κακὰ ἀποδιδόντας.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 86.</p>
+          <bibl>Cod. Mb 86.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-154">
@@ -4293,7 +4292,7 @@
           <pb ed="perry" n="P118"/>
           <p><milestone unit="recitprose"/>Κάστωρ ἐστὶ ζῷον τετράπουν ἐν λίμνῃ νεμόμενον. Τούτου λέγεται τὰ αἰδοῖα εἴς τινας θεραπείας χρήσιμα εἶναι. Καὶ δή, εἴ ποτέ τις αὐτὸν θεασάμενος διώκει ἐκτέμνειν βουλόμενος, εἰδὼς οὗ χάριν διώκεται, μέχρι μέν τινος φεύγει τῇ τῶν ποδῶν ταχύτητι συγχρώμενος, πρὸς τὸ ὁλόκληρον ἑαυτὸν διαφυλάξαι· ἐπειδὰν δὲ περικατάληπτος γένηται, ἀποκόπτων τὰ ἑαυτοῦ αἰδοῖα ῥίπτει καὶ οὕτως τῆς σωτηρίας τυγχάνει.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων φρόνιμοί εἰσιν ὅσοι διὰ χρήματα ἐπιϐουλευόμενοι ἐκεῖνα ὑπερορῶσιν ὑπὲρ τοῦ τῇ σωτηρίᾳ μὴ κινδυνεύειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 110 Pb 117 Pf 61 Pg 78 Ph 63 Ma 83 Mb 239 Me 83 Mj 78 Cb 56 Ce 59 Cf 63 Ch 63.</p>
+          <bibl>Codd. Pa 110 Pb 117 Pf 61 Pg 78 Ph 63 Ma 83 Mb 239 Me 83 Mj 78 Cb 56 Ce 59 Cf 63 Ch 63.</bibl>
           <p><milestone unit="traduction"/>Le castor est un quadrupède qui vit dans les étangs. Ses parties honteuses servent, dit-on, à guérir certaines maladies. Aussi quand on le découvre et qu’on le poursuit pour les lui couper, comme il sait pourquoi on le poursuit, il fuit jusqu’à une certaine distance, et il use de la vitesse de ses pieds pour se conserver intact ; mais quand il se voit en prise, il se coupe les parties, les jette, et sauve ainsi sa vie.</p>
           <p><milestone unit="traduction"/>Parmi les hommes aussi, ceux-là sont sages qui, attaqués à cause de leurs richesses, les sacrifient pour ne pas risquer leur vie.</p>
         </div>
@@ -4303,7 +4302,7 @@
           <pb ed="perry" n="P118"/>
           <p><milestone unit="recitprose"/>Ὁ κάστωρ ζῷόν ἐστι τετράπουν ἐν λίμναις τὰ πολλὰ διαιτώμενον, οὗ τὰ αἰδοῖά φασιν ἰατροῖς χρήσιμα εἶναι. Οὗτος οὖν, ἐπειδὰν ὑπ’ ἀνθρώπων διωκόμενος καταλαμϐάνηται, γινώσκων οὗ χάριν διώκεται, ἀποτεμὼν τὰ ἑαυτοῦ αἰδοῖα ῥίπτει πρὸς τοὺς διώκοντας καὶ οὕτω σωτηρίας τυγχάνει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων οἱ φρόνιμοι ὑπὲρ τῆς ἑαυτῶν σωτηρίας οὐδένα λόγον τῶν χρημάτων ποιοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 33 Lb 90 Lc 16 Ld 23 Le 90 Lf 33 Lg 16 Mc 55 Md 60 Mg 84 Mk 58 Ml 117 Mm 76 Mn 23.</p>
+          <bibl>Codd. La 33 Lb 90 Lc 16 Ld 23 Le 90 Lf 33 Lg 16 Mc 55 Md 60 Mg 84 Mk 58 Ml 117 Mm 76 Mn 23.</bibl>
         </div>
         <div>
           <head>Chambry 154.3</head>
@@ -4311,7 +4310,7 @@
           <pb ed="perry" n="P118"/>
           <p><milestone unit="recitprose"/>Κάστωρ ἐστὶ τετράπουν ζῷον ἐν λίμναις νεμόμενον. Τούτου λέγεται τὰ αἰδοῖα εἴς τινας θεραπείας χρήσιμα εἶναι. Καὶ εἴ ποτέ τις αὐτὸ διώκει, φεύγει μὲν τῇ τῶν ποδῶν ταχύτητι, εἴ πῶς ὁλόκληρον αὑτὸν φυλάξῃ. Ἐπὰν δὲ ἤδη καταλαμϐάνηται, ἀποκόπτει αὑτοῦ τὰ αἰδοῖα καὶ ῥίπτει τῷ διώκοντι καὶ οὕτω τὴν σωτηρίαν αὑτοῦ πραγματεύεται.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ [τὰ] τῶν ἀνθρώπων οἱ φρόνιμοι ὑπὲρ τῆς ἑαυτῶν σωτηρίας οὐδένα λόγον περὶ χρημάτων ποιοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mh 55.</p>
+          <bibl>Cod. Mh 55.</bibl>
         </div>
         <div>
           <head>Chambry 154.4</head>
@@ -4324,7 +4323,7 @@
           <l><milestone unit="recitvers"/>τοὺς ὄρχεις ῥίψας, ὅλον τὸ σῶμα σῴζει.</l>
           <l><milestone unit="epimythiumenvers"/>Σωτηρίας χάριν οὐδένα δεῖ λόγον</l>
           <l><milestone unit="epimythiumenvers"/>παρὰ τὰ χρήματα τοὺς φρονίμους ἔχειν.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 54.</p>
+          <bibl>Cod. Cd 54.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-155">
@@ -4333,7 +4332,7 @@
         <pb ed="perry" n="P119"/>
         <p><milestone unit="recitprose"/>Κηπουρῷ τις ἐπιστὰς ἀρδεύοντι τὰ λάχανα ἐπυνθάνετο αὐτοῦ τὴν αἰτίαν δι’ ἣν τὰ μὲν ἄγρια τῶν λαχάνων εὐθαλῆ τέ ἐστι καὶ στερεά, τὰ δὲ ἥμερα λεπτὰ καὶ μεμαρασμένα. Κἀκεῖνος ἔφη· « Ἡ γῆ τῶν μὲν μήτηρ ἐστί, τῶν δὲ μητρυιά. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν παίδων οὐχ ὁμοίως τρέφονται οἱ ὑπὸ μητρυιᾶς τρεφόμενοι τοῖς μητέρας ἔχουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 111 Pb 118 Pc 63 Ma 84 Mb 78.</p>
+        <bibl>Codd. Pa 111 Pb 118 Pc 63 Ma 84 Mb 78.</bibl>
         <p><milestone unit="traduction"/>Un homme, s’étant arrêté près d’un jardinier qui arrosait ses légumes, lui demanda pourquoi les légumes sauvages étaient florissants et vigoureux, et les cultivés chétifs et malingres, « C’est que, répondit le jardinier, la terre est pour les uns une mère, pour les autres une marâtre. »</p>
         <p><milestone unit="traduction"/>Pareillement les enfants nourris par une marâtre ne sont pas nourris comme ceux qui ont leur mère.</p>
       </div>
@@ -4345,7 +4344,7 @@
           <pb ed="perry" n="P120"/>
           <p><milestone unit="recitprose"/>Κηπουροῦ κύων εἰς φρέαρ ἔπεσεν. Ὁ δὲ ἀνιμήσασθαι αὐτὸν βουλόμενος ἐκεῖ κατέϐη. Ὁ δὲ κύων ἠπορημένος, ὡς προσῆλθεν αὐτῷ, οἰόμενος ὑπ’ αὐτοῦ βαπτίζεσθαι, ἔδακεν αὐτόν. Καὶ ὃς κακῶς διατεθεὶς ἔφη· « Ἀλλ’ ἔγωγε ἄξια πέπονθα· τί γάρ, σοῦ σεαυτὸν κατακρημνίσαντος, τοῦ κινδύνου σε ἀπαλλάξαι ἐπειρώμην ; »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ἀχάριστον εἰς τοὺς εὐεργέτας καὶ πρὸς ἀδικοῦντα ὁ μῦθος ἁρμόζει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 112 Pb 119 Pc 64 Pf 42 Pg 79 Ph 64 Ma 85 Mb 237 Mj 79 Cd 66.</p>
+          <bibl>Codd. Pa 112 Pb 119 Pc 64 Pf 42 Pg 79 Ph 64 Ma 85 Mb 237 Mj 79 Cd 66.</bibl>
         </div>
         <div>
           <head>Chambry 156.2</head>
@@ -4353,7 +4352,7 @@
           <pb ed="perry" n="P120"/>
           <p><milestone unit="recitprose"/>Κηπωροῦ κύων εἰς φρέαρ κατέπεσεν. Ὁ δὲ κηπωρὸς βουλόμενος αὐτὸν ἐκεῖθεν ἀνενεγκεῖν, κατῆλθε καὶ αὐτὸς εἰς τὸ φρέαρ. Οἰηθεὶς δ’ ὁ κύων ὡς κατωτέρω μᾶλλον αὐτὸν παραγέγονε καταδῦσαι, τὸν κηπωρὸν στραφεὶς ἔδακεν. Ὁ δὲ μετ’ ὀδύνης ἐπανιών· « Δίκαια, φησί, πέπονθα· τί δήποτε γὰρ τὸν αὐτόχειρα σῶσαι ἐσπούδασα ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἀδίκους καὶ ἀχαρίστους.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 67 Lb 65 Lc 36 Le 65 Lf 67 Lg 36 Lh 28 Md 121 Me 80 Mg 89 Mi 95 Ml 83 Mm 85.</p>
+          <bibl>Codd. La 67 Lb 65 Lc 36 Le 65 Lf 67 Lg 36 Lh 28 Md 121 Me 80 Mg 89 Mi 95 Ml 83 Mm 85.</bibl>
           <p><milestone unit="traduction"/>Le chien d’un jardinier était tombé dans un puits. Le jardinier, voulant l’en retirer, descendit lui aussi dans le puits. S’imaginant qu’il venait pour l’enfoncer plus profondément, le chien se retourna et le mordit. Le jardinier, souffrant de sa blessure, remonta en disant : « C’est bien fait pour moi : qu’avais-je à m’empresser de sauver une bête qui voulait se suicider ? »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse aux hommes injustes et ingrats.</p>
         </div>
@@ -4366,7 +4365,7 @@
           <pb ed="perry" n="P121"/>
           <p><milestone unit="recitprose"/>Κιθαρῳδὸς ἀφυὴς ἐν κεκονιαμένῳ οἴκῳ συνεχῶς ᾄδων, ἀντηχούσης αὐτῷ τῆς φωνῆς, ἐνόμισεν αὑτὸν εὔφωνον σφόδρα εἶναι. Καὶ δὴ ἐπαρθεὶς ἐπὶ τούτῳ ἔγνω δεῖν καὶ εἰς θέατρον εἰσελθεῖν. Ἀφικόμενος δὲ ἐπὶ σκήνην καὶ πάνυ κακῶς ᾄδων λίθοις βαλλόμενος ἐξηλάθη.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ τῶν ῥητόρων ἔνιοι ἐν σχολαῖς εἶναί τινες δοκοῦντες, ὅταν ἐπὶ τὰς πολιτείας ἀφίκωνται, οὐδενὸς ἄξιοι εὑρίσκονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 113 Pb 120 Pf 63 Ph 65 Ma 86 Mb 238 Me 84 Mj 80.</p>
+          <bibl>Codd. Pa 113 Pb 120 Pf 63 Ph 65 Ma 86 Mb 238 Me 84 Mj 80.</bibl>
           <p><milestone unit="traduction"/>Un joueur de cithare dépourvu de talent chantait du matin au soir dans une maison aux murs bien plâtrés. Comme les murs lui renvoyaient les sons, il s’imagina qu’il avait une très belle voix, et il s’en fit si bien accroire là-dessus qu’il décida de se produire au théâtre ; mais arrivé sur la scène il chanta fort mal et se fit chasser à coups de pierres.</p>
           <p><milestone unit="traduction"/>Ainsi certains orateurs qui paraissaient à l’école avoir quelque talent, ne sont pas plus tôt entrés dans la carrière politique, qu’ils font éclater leur incapacité.</p>
         </div>
@@ -4376,7 +4375,7 @@
           <pb ed="perry" n="P121"/>
           <p><milestone unit="recitprose"/>Κιθαρῳδὸς ἀφυὴς ἐν οἴκῳ κεκονιαμένῳ συνήθως ᾄδων, καὶ ἀντηχούσης αὐτῷ τῆς φωνῆς, ᾠήθη σφόδρα εὔφωνος εἶναι. Καὶ δὴ ἐπαρθεὶς ἐπὶ τούτῳ ἔγνω δεῖν καὶ θεάτρῳ ἑαυτὸν ἐπιδοῦναι. Ἀφικόμενος δ’ ἐπιδείξασθαι καὶ κακῶς ᾄδων πάνυ, λίθοις αὐτὸν ἐξώσαντες ἀπήλασαν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ῥητόρων ἔνιοι ἐν ταῖς σχολαῖς δοκοῦντες εἶναί τινες, ὅταν ἐπὶ τὰς πολιτείας ἀφίκωνται, οὐδενὸς ἄξιοί εἰσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 100 Lb 67 Le 67 Lf 100 Lh 30 Mg 91 Ml 86.</p>
+          <bibl>Codd. La 100 Lb 67 Le 67 Lf 100 Lh 30 Mg 91 Ml 86.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-158">
@@ -4385,7 +4384,7 @@
         <pb ed="perry" n="P86"/>
         <p><milestone unit="recitprose"/>Ἔν τινι μυρσινῶνι κίχλα ἐνέμετο· διὰ δὲ τὴν γλυκύτητα τοῦ καρποῦ οὐκ ἀφίστατο. Ἰξευτὴς δὲ παρατηρησάμενος ἐμφιλοχωροῦσαν ἰξεύσας συνέλαϐε. Καὶ δὴ μέλλουσα ἀναιρεῖσθαι ἔφη· « Δειλαία εἰμί, ἥτις διὰ τροφῆς γλυκύτητα σωτηρίας στερίσκομαι. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρα ἄσωτον δι’ ἡδυπάθειαν ἀπολωλότα εὔκαιρός ἐστιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 83 Pb 87 Pc 45 Pe 51 Pf 42 Pg 55 Ph 44 Ma 66 Mb 51 Me 62 Mj 54 Ca 73.</p>
+        <bibl>Codd. Pa 83 Pb 87 Pc 45 Pe 51 Pf 42 Pg 55 Ph 44 Ma 66 Mb 51 Me 62 Mj 54 Ca 73.</bibl>
         <p><milestone unit="traduction"/>Une grive picorait dans un bosquet de myrtes, et, charmée par la douceur de leurs baies, elle ne pouvait le quitter. Un oiseleur, ayant remarqué qu’elle se plaisait en ce lieu, la prit à la glu. Alors, se voyant près d’être tuée, elle dit : « Malheureuse que je suis ! pour le plaisir de manger, je me prive de la vie. »</p>
         <p><milestone unit="traduction"/>La fable s’adresse au débauché qui se perd par le plaisir.</p>
       </div>
@@ -4397,7 +4396,7 @@
           <pb ed="perry" n="P122"/>
           <p><milestone unit="recitprose"/>Κλέπται εἴς τινα οἰκίαν εἰσελθόντες οὐδὲν μὲν ἄλλο εὗρον, μόνον δὲ ἀλεκτρυόνα, καὶ τοῦτον λαϐόντες ἀπηλλάγησαν. Ὁ δὲ μέλλων ὑπ’ αὐτῶν θύεσθαι ἐδέετο ὅπως αὐτὸν ἀπολύσωσι, λέγων χρήσιμον ἑαυτὸν τοῖς ἀνθρώποις εἶναι νύκτωρ αὐτοὺς ἐπὶ τὰ ἔργα ἐγείροντα. Οἱ δὲ ὑποτυχόντες ἔφασαν· « Ἀλλὰ καὶ διὰ τοῦτό σε μᾶλλον θύομεν· ἐκείνους γὰρ ἐγείρων ἡμᾶς οὐκ ἐᾷς κλέπτειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ταῦτα μάλιστα τοῖς πονηροῖς ἠναντίωται ἅτινα τῶν χρηστῶν ἐστιν εὐεργετήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 114 Pb 121 Pc 65 Pf 64 Pg 80 Ph 66 Ma 87 Mb 240 Me 85 Mj 81 Cd 67.</p>
+          <bibl>Codd. Pa 114 Pb 121 Pc 65 Pf 64 Pg 80 Ph 66 Ma 87 Mb 240 Me 85 Mj 81 Cd 67.</bibl>
           <p><milestone unit="traduction"/>Des voleurs, ayant pénétré dans une maison, n’y trouvèrent autre chose qu’un coq ; ils le prirent et se retirèrent. Et lui, sur le point d’être immolé par eux, les pria de le relâcher, alléguant qu’il était utile aux hommes, en les éveillant la nuit pour leurs travaux. « Raison de plus pour te tuer, s’écrièrent-ils ; car, en éveillant les hommes, tu nous empêches de voler. »</p>
           <p><milestone unit="traduction"/>Cette fable fait voir que ce qui contrarie le plus les méchants est ce qui rend service aux gens de bien.</p>
         </div>
@@ -4407,7 +4406,7 @@
           <pb ed="perry" n="P122"/>
           <p><milestone unit="recitprose"/>Κλέπται εἴς τινα εἰσελθόντες οἰκίαν οὐδὲν εὗρον ὅτι μὴ ἀλεκτρυόνα, καὶ τοῦτον λαϐόντες ἀπῄεσαν. Ὁ δὲ μέλλων ὑπ’ αὐτῶν θύεσθαι ἐδεῖτο ὡς ἂν αὐτὸν ἀπολύσωσι, λέγων χρήσιμος εἶναι τοῖς ἀνθρώποις νυκτὸς αὐτοὺς ἐπὶ τὰ ἔργα ἐγείρων. Οἱ δὲ ἔφασαν· « Αλλὰ διὰ τοῦτό σε μᾶλλον θύομεν· ἐκείνους γὰρ ἐγείρων κλέπτειν ἡμᾶς οὐκ ἐᾷς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ταῦτα μάλιστα τοῖς πονηροῖς ἐναντιοῦται ἃ τοῖς χρηστοῖς ἐστιν εὐεργετήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 101 Lb 68 Le 68 Lf 101 Mg 92 Ml 87.</p>
+          <bibl>Codd. La 101 Lb 68 Le 68 Lf 101 Mg 92 Ml 87.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-160">
@@ -4416,7 +4415,7 @@
         <pb ed="perry" n="P130"/>
         <p><milestone unit="recitprose"/>Κοιλία καὶ πόδες περὶ δυνάμεως ἤριζον. Παρ’ ἕκαστα δὲ τῶν ποδῶν λεγόντων ὅτι τοσοῦτον προέχουσι τῇ ἰσχύι ὡς καὶ αὐτὴν τὴν γαστέρα βαστάζειν, ἐκείνη ἀπεκρίνατο· « Ἀλλ’, ὦ οὗτοι, ἐὰν μὴ ἐγὼ τροφὴν ὑμῖν παράσχωμαι, οὐδὲ ὑμεῖς βαστάζειν δυνήσεσθε. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ ἐπὶ τῶν στρατευμάτων τὸ μηδὲν ἐπὶ τὸ πολὺ πλῆθος, ἐὰν μὴ οἱ στρατηγοὶ ἄριστα φρονῶσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 122 Pb 129 Pc 70 Pf 68 Mb 73 Me 93 Mf 78 Mj 85.</p>
+        <bibl>Codd. Pa 122 Pb 129 Pc 70 Pf 68 Mb 73 Me 93 Mf 78 Mj 85.</bibl>
         <p><milestone unit="traduction"/>L’estomac et les pieds disputaient de leur force. À tout propos les pieds alléguaient qu’ils étaient tellement supérieurs en force qu’ils portaient même l’estomac. À quoi celui-ci répondit : « Mais, mes amis, si je ne vous fournissais pas de nourriture, vous-mêmes ne pourriez pas me porter. »</p>
         <p><milestone unit="traduction"/>Il en va ainsi dans les armées : le nombre, le plus souvent, n’est rien, si les chefs n’excellent pas dans le conseil.</p>
       </div>
@@ -4426,7 +4425,7 @@
         <pb ed="perry" n="P126"/>
         <p><milestone unit="recitprose"/>Κολοιὸς λιμώττων ἐπί τινος συκῆς ἐκάθισεν· εὑρὼν δὲ τοὺς ὀλύνθους μηδέπω πεπείρους προσέμενεν ἕως σῦκα γένωνται. Ἀλώπηξ δὲ θεασαμένη αὐτον ἐγχρονίζοντα καὶ τὴν αἰτίαν παρ’ αὐτοῦ μαθοῦσα ἔφη · « Ἀλλὰ πεπλάνησαι, ὦ οὗτος, ἐλπίδι προσέχων, ἥτις βουκολεῖν μὲν οἶδε, τρέφειν δὲ οὐδαμῶς. »</p>
         <p><milestone unit="epimythiumprose"/>[Πρὸς ἄνδρα φιλόνεικον.]</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 118 Pb 125 Pf 66 Pg 83 Ph 68 Me 92 Mf 77 Mj 83.</p>
+        <bibl>Codd. Pa 118 Pb 125 Pf 66 Pg 83 Ph 68 Me 92 Mf 77 Mj 83.</bibl>
         <p><milestone unit="traduction"/>Un choucas affamé s’était perché sur un figuier ; mais voyant que les figues étaient encore vertes, il attendait qu’elles fussent mûres. Un renard, le voyant s’éterniser là, lui en demanda la raison. Quand il en fut instruit : « Tu as tort, l’ami, dit-il, de t’attacher à une espérance ; l’espérance s’entend à repaître d’illusion, mais de nourriture, non pas. »</p>
         <p><milestone unit="traduction"/>Cette fable s’applique au convoiteux.</p>
       </div>
@@ -4436,7 +4435,7 @@
         <pb ed="perry" n="P123"/>
         <p><milestone unit="recitprose"/>Κολοιὸς τῷ μεγέθει τῶν ἄλλων κολοιῶν διαφέρων, ὑπερφρονήσας τοὺς ὁμοφύλους, παρεγένετο πρὸς τοὺς κόρακας καὶ τούτοις ἠξίου συνδιαιτᾶσθαι. Οἱ δὲ ἀμφιγνοοῦντες αὐτοῦ τό τε εἶδος καὶ τὴν φωνὴν παίοντες αὐτὸν ἐξέϐαλον. Καὶ ὃς ἀπελαθεὶς ὑπ’ αὐτῶν ἧκε πάλιν πρὸς τοὺς κολοιούς. Οἱ δὲ ἀγανακτοῦντες ἐπὶ τῇ ὕϐρει οὐ προσεδέξαντο αὐτόν. Οὕτω τε συνέϐη αὐτῷ τῆς ἐξ ἀμφοτέρων διαίτης στερηθῆναι.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ τὰς πατρίδας ἀπολιπόντες καὶ τὰς ἀλλοδαπὰς προκρίνοντες οὔτε ἐν ἐκείναις εὐδοκιμοῦσι διὰ τὸ ξένοι εἶναι καὶ ὑπὸ τῶν πολιτῶν δυσχεραίνονται διὰ τὸ ὐπερπεφρονηκέναι αὐτούς.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 115 Pb 122 Pc 66 Pf 65 Pg 81 Ph 67 Ma 88 Me 91 Mf 76 Mj 82 Cd 68.</p>
+        <bibl>Codd. Pa 115 Pb 122 Pc 66 Pf 65 Pg 81 Ph 67 Ma 88 Me 91 Mf 76 Mj 82 Cd 68.</bibl>
         <p><milestone unit="traduction"/>Un choucas, qui dépassait en grosseur les autres choucas, prit en mépris ceux de sa tribu, se rendit chez les corbeaux et demanda à partager leur vie. Mais les corbeaux, à qui sa forme et sa voix étaient inconnues, le battirent et le chassèrent. Et lui, repoussé par eux, s’en revint chez les choucas ; mais les choucas, sensibles à l’outrage, refusèrent de le recevoir. Il arriva ainsi qu’il fut exclu de la société et des uns et des autres.</p>
         <p><milestone unit="traduction"/>Il en est ainsi chez les hommes. Ceux qui abandonnent leur patrie et lui préfèrent un autre pays sont mal vus dans ce pays, parce qu’ils sont étrangers, et ils sont odieux à leurs propres concitoyens, parce qu’ils les ont méprisés.</p>
       </div>
@@ -4448,7 +4447,7 @@
           <pb ed="perry" n="P101"/>
           <p><milestone unit="recitprose"/>Ζεὺς βουλόμενος βασιλέα ὀρνέων καταστῆσαι, προθεσμίαν αὐτοῖς ἔταξεν ἐν ᾗ παραγενήσονται πάντα, ὅπως τὸν ὡραιότατον πάντων καταστήσῃ ἐπ’ αὐτοῖς βασιλέα. Τὰ δὲ παραγενόμενα ἐπί τινα ποταμὸν ἀπενίζοντο. Κολοιὸς δέ, συνιδὼν ἑαυτὸν δυσμορφίᾳ περικείμενον, ἀπελθὼν καὶ τὰ ἀποπίπτοντα τῶν ὀρνέων πτερὰ συλλεξάμενος, ἑαυτῷ περιέθηκε καὶ προσεκόλλησε. Συνέϐη οὖν ἐκ τούτου εὐειδέστερον πάντων γεγονέναι. Ἐπέστη οὖν ἡ ἡμέρα τῆς προθεσμίας καὶ ἦλθον πάντα τὰ ὄρνεα πρὸς τὸν Δία. Ὁ δὲ κολοιὸς ποικίλος γενόμενος ἧκε καὶ αὐτός. Τοῦ δὲ Διὸς μέλλοντος χειροτονῆσαι αὐτοῖς τὸν κολοιὸν βασιλέα διὰ τὴν εὐπρέπειαν, ἀγανακτήσαντα τὰ ὄρνεα, ἕκαστον τὸ ἴδιον αὐτοῦ πτερὸν ἀφείλετο. Οὕτω τε συνέϐη αὐτῷ ἀπογυμνωθέντι κολοιὸν πάλιν γενέσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ χρεωφειλέται, μέχρι μὲν τὰ ἀλλότρια ἔχουσι χρήματα, δοκοῦσί τινες εἶναι, ἐπειδὰν δὲ αὐτὰ ἀποδώσωσιν, ὁποῖοι ἐξ ἀρχῆς ἦσαν εὑρίσκονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 94 Pb 101 Pc 51 Pf 50 Pg 65 Ph 52 Ma 73 Me 65 Mf 57 Mj 65.</p>
+          <bibl>Codd. Pa 94 Pb 101 Pc 51 Pf 50 Pg 65 Ph 52 Ma 73 Me 65 Mf 57 Mj 65.</bibl>
           <p><milestone unit="traduction"/>Zeus, voulant instituer un roi des oiseaux, leur fixa un jour pour comparaître tous devant lui : il choisirait le plus beau de tous pour régner sur eux. Les oiseaux se rendirent au bord d’une rivière pour s’y laver. Or le choucas, qui se rendait compte de sa laideur, s’en vint ramasser les plumes que les oiseaux laissaient tomber, puis il se les ajusta et se les attacha. Il arriva ainsi qu’il fut le plus beau de tous. Or le jour fixé arriva et tous les oiseaux se rendirent chez Zeus. Le choucas, avec sa parure bigarrée, se présenta lui aussi. Et Zeus allait lui donner son suffrage pour la royauté, à cause de sa beauté ; mais les oiseaux indignés lui arrachèrent chacun la plume qui venait d’eux. Il en résulta que le choucas dépouillé se retrouva choucas.</p>
           <p><milestone unit="traduction"/>Il en est ainsi des hommes qui ont des dettes : tant qu’ils sont en possession du bien d’autrui, ils paraissent être des personnages ; mais quand ils ont rendu ce qu’ils doivent, on les retrouve tels qu’ils étaient auparavant.</p>
         </div>
@@ -4458,7 +4457,7 @@
           <pb ed="perry" n="P101"/>
           <p><milestone unit="recitprose"/>Ζεὺς βουλόμενος βασιλέα ὀρνέων καταστῆσαι, προθεσμίαν αὐτοῖς ἔταξεν ἐν ᾗ παραγενήσονται πάντα, ὅπως τὸν ὡραιότατον πάντων καταστήσῃ ἐπ’ αὐτοῖς βασιλέα. Τὰ δὲ παραγενόμενα ἐπί τινα ποταμὸν ἀπενίζοντο. Κολοιὸς δέ, συνιδὼν ἑαυτὸν δυσμορφίᾳ περικείμενον, ἀπελθὼν καὶ τὰ ἀποπίπτοντα τῶν ὀρνέων πτερὰ συλλεξάμενος, ἑαυτῷ περιέθηκε καὶ προσεκόλλησε. Συνέϐη οὖν ἐκ τούτου εὐειδέστερον πάντων γεγονέναι. Ἐπέστη οὖν ἡ ἡμέρα τῆς προθεσμίας καὶ ἦλθον πάντα τὰ ὄρνεα πρὸς τὸν Δία. Ὁ δὲ κολοιὸς ποικίλος γενόμενος ἧκε καὶ αὐτός. Τοῦ δὲ Διὸς μέλλοντος χειροτονῆσαι αὐτοῖς τὸν κολοιὸν βασιλέα διὰ τὴν εὐπρέπειαν, ἀγανακτήσαντα τὰ ὄρνεα, ἕκαστον τὸ ἴδιον αὐτοῦ πτερὸν ἀφείλετο. Οὕτω τε συνέϐη αὐτῷ ἀπογυμνωθέντι κολοιὸν πάλιν γενέσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ χρεωφειλέται, μέχρι μὲν τὰ ἀλλότρια ἔχουσι χρήματα, δοκοῦσί τινες εἶναι, ἐπειδὰν δὲ αὐτὰ ἀποδώσωσιν, ὁποῖοι ἐξ ἀρχῆς ἦσαν εὑρίσκονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 78 Cb 49 Cd 46 Ce 51 Cf 55 Ch 56 Mc 48 Md 53 Mh 48 Mi 88 Ml 75 Mm 69.</p>
+          <bibl>Codd. Ca 78 Cb 49 Cd 46 Ce 51 Cf 55 Ch 56 Mc 48 Md 53 Mh 48 Mi 88 Ml 75 Mm 69.</bibl>
         </div>
         <div>
           <head>Chambry 163.3</head>
@@ -4466,7 +4465,7 @@
           <pb ed="perry" n="P101"/>
           <p><milestone unit="recitprose"/>Ζεύς, βουλόμενος καταστῆσαι βασιλέα ὀρνέων, προθεσμίαν αὐτοῖς ἔταξεν ἐν ᾗ παραγενήσονται πάντα, ὅπως τὸν ὡραιότατον πάντων καταστήσῃ βασιλέα αὐτοῖς. Ὁ δὲ κολοιὸς συνιδὼν ἑαυτὸν δυσμορφίᾳ περικείμενον, ἀπελθὼν ὅπου τὰ λοιπὰ ὄρνεα ἐλούετο, τὰ πίπτοντα ἐκείνοις πτερὰ συλλέξας, ἑαυτῷ περιέθηκε καὶ συνήρμοσεν αὐτά. Συνέϐη οὖν ἐκ τούτου ὡραιότερον πάντων φανῆναι τῷ Διὶ ἐν τῇ ἡμέρᾳ τῆς προθεσμίας. Μέλλοντος οὖν τοῦ Διὸς χειροτονεῖν βασιλέα τούτοις τὸν κολοιὸν διὰ τὴν εὐπρέπειαν, ἀγανακτήσαντα τὰ ὄρνεα ἕκαστον αὐτῶν τὸ ἴδιον πτερὸν ἔλαϐε, καὶ ὁ κολοιὸς πάλιν ἦν κολοιός.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτως πολλοὶ τῶν ἀνθρώπων χρεωφειλέται, μέχρις ἂν κατέχωσι τὰ ἀλλότρια χρήματα, δοκοῦσιν εἶναί τινες· ἐπειδὰν δὲ αὐτὰ ἀποδώσωσιν, ὁποῖοι ὑπῆρχον πρότερον φαίνονται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 52.</p>
+          <bibl>Cod. Mk 52.</bibl>
         </div>
         <div>
           <head>Chambry 163.4</head>
@@ -4474,7 +4473,7 @@
           <pb ed="perry" n="P101"/>
           <p><milestone unit="recitprose"/>Ἶρις, ἡ τῶν θεῶν ἄγγελος, πᾶσι πετεινοῖς ἐκήρυξεν· « Εἴ τις ὑμῶν κρείττων εἰς κάλλος φανῇ, οὗτος πτηνὼν πάντων βασιλεύσει ὑπὸ τοῦ Διός. » Ἐπισυνηγμένων δὲ πάντων ὀρνέων εἰς τὴν τῆς Στυγὸς κρήνην καὶ ἀπολουομένων, κολοιός, υἱὸς κορώνης γέρων, πάντων ὀρνέων τὰ πτερὰ πρὸς ἑαυτὸν ἁρμοσάμενος, ἦλθεν ἀετοῦ κρείσσων. Ὁ Ζεὺς δὲ τὸ κάλλος θαμϐηθεὶς τὴν νίκην τούτῳ παρέχειν ἔμελλεν, εἰ μὴ χελιδὼν Ἀθηναία τοῦτον ἤλεγξε, τὸ πτερὸν αὑτῆς ἐκσπάσασα. Ταὐτὸ δὲ καὶ τῶν λοιπῶν ὀρνέων ποιησάντων, διεγνώσθη κολοιὸς ὤν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὄνειδός ἐστιν ἀνθρώπῳ ἐξ ἀλλοτρίου πλούτου κοσμεῖσθαι ἑαυτόν, ὅτι κατάδηλος πᾶσι καὶ φανερὸς γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 59.</p>
+          <bibl>Cod. Ba 59.</bibl>
         </div>
         <div>
           <head>Chambry 163.5</head>
@@ -4482,7 +4481,7 @@
           <pb ed="perry" n="P101"/>
           <p><milestone unit="recitprose"/>Πρόσταγμα παρὰ τοῦ Διὸς ἐξῆλθεν ἐν τῷ ποταμῷ διέλθωσι καὶ λουθῶσι καὶ θεάσῃ αὐτῶν τὴν καλλονήν. Ὁ δὲ Ζεὺς τοῦτο τὸ δόγμα ἐπιθείς, ἦλθον πάντα τὰ ὄρνεα λουθῆναι ἐν τῷ ποταμῷ καὶ λουόμενα ἔπιπτον τὰ πτερὰ τῶν ὀρνέων. Ὁ δὲ κολοιὸς καὶ αὐτὸς ἀπελθὼν λουθῆναι ἤθελεν ὁμοιωθῆναι καὶ τοῖς λοιποῖς καὶ εὐειδέσιν ὀρνέοις· ἐκ τῶν πιπτόντων ὀρνέων τὰ πτερὰ περισωρεύσας περιεϐάλλετο ἑαυτόν, ἵνα φαίνῃ καὶ αὐτὸς τῷ Διὶ ὡς τὰ λοιπὰ ὄρνεα. Ἄνεμος δὲ φυσήσας ἔρριψε τὰ πτερὰ τοῦ κολοιοῦ καὶ πάλιν κολοιὸς τοῖς πᾶσιν ὤφθη καὶ ᾐσχύνθη κολοιὸς ἔκτοτε φανείς· ἐκ τούτου οὐδεὶς ὅτι τῶν πλουσίων ἐμυήθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι δεῖ τὸν καθένα οἷος καὶ ὑπάρχει οὕτως καὶ φαίνεσθαι καὶ μὴ, πένης ὤν, φαίνεσθαι πλούσιος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mo 152.</p>
+          <bibl>Cod. Mo 152.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-164">
@@ -4493,7 +4492,7 @@
           <pb ed="perry" n="P129"/>
           <p><milestone unit="recitprose"/>Κολοιὸς ἰδὼν περιστερὰς ἔν τινι περιστεροτροφείῳ καλῶς τρεφομένας, λευκάνας ἑαυτὸν ἧκεν ὡς καὶ ἀπὸ τῆς αὐτῆς διαίτης μεταληψόμενος. Αἱ δέ, μέχρι μὲν ἡσύχαζεν, οἰόμεναι περιστερὰν αὐτὸν εἶναι, προσίεντο· ἐπειδὴ δέ ποτε ἐκλαθόμενος ἐφθέγξατο, τηνικαῦτα ἀμφιγνοήσασαι αὐτοῦ τὴν φωνὴν ἐξήλασαν αὐτόν. Καὶ ὃς ἀποτυχὼν τῆς ἐνταῦθα τροφῆς ἐπανῆλθε πάλιν πρὸς τοὺς κολοιούς· κἀκεῖνοι οὐ γνωρίζοντες αὐτὸν διὰ τὸ χρῶμα τῆς μετ’ αὐτῶν διαίτης ἀπεῖρξαν αὐτόν. Οὕτω τε δυοῖν ἐπιθυμήσας οὐδὲ μιᾶς ἔτυχεν.</p>
           <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς δεῖ τοῖς ἑαυτῶν ἀρκεῖσθαι, λογιζομένους ὅτι ἡ πλεονεξία πρὸς τῷ μηδὲν ὠφελεῖν πολλάκις καὶ τὰ προσόντα ἀφαιρεῖται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 121 Pb 128 Ph 69.</p>
+          <bibl>Codd. Pa 121 Pb 128 Ph 69.</bibl>
           <p><milestone unit="traduction"/>Un choucas, ayant aperçu dans un pigeonnier des pigeons bien nourris, blanchit son plumage et se présenta pour avoir part à leur provende. Tant qu’il resta silencieux, les pigeons, le prenant pour un des leurs, l’admirent parmi eux ; mais à un moment il s’oublia et poussa un cri. Alors, ne connaissant pas sa voix, ils le chassèrent. Et lui, voyant la bonne chère des pigeons lui échapper, revint chez les choucas. Mais les choucas ne le reconnaissant plus à cause de sa couleur, le rejetèrent de leur société, de sorte que pour avoir voulu les deux provendes, il n’eut ni l’une ni l’autre.</p>
           <p><milestone unit="traduction"/>Cette fable montre que nous devons nous contenter de nos propres biens, et nous dire que la convoitise non seulement ne sert à rien, mais encore nous fait perdre souvent ce que nous possédons.</p>
         </div>
@@ -4503,7 +4502,7 @@
           <pb ed="perry" n="P129"/>
           <p><milestone unit="recitprose"/>Κολοιὸς ἔν τινι περιστερεῶνι περιστερὰς ἰδὼν καλῶς τρεφομένας, λευκάνας ἑαυτὸν ἦλθεν ὡς καὶ αὐτὸς τῆς αὐτῆς διαίτης μεταληψόμενος. Αἱ δέ, μέχρι μὲν ἡσύχαζεν, οἰόμεναι περιστερὰν αὐτὸν εἶναι, προσίεντο· ἐπεὶ δέ ποτε ἐκλαθόμενος ἐφθέγξατο, τηνικαῦτα τὴν αὐτοῦ γνοῦσαι φύσιν, ἐξήλασαν παίουσαι. Καὶ ὃς ἀποτυχὼν τῆς ἐνταῦθα τροφῆς ἐπανῆκε πρὸς τοὺς κολοιοὺς πάλιν. Κἀκεῖνοι διὰ τὸ χρῶμα αὐτὸν οὐκ ἐπιγνόντες, τῆς μεθ’ αὑτῶν διαίτης ἀπεῖρξαν, ὥστε δυοῖν ἐπιθυμήσαντα μηδετέρας τυχεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ καὶ ἡμᾶς τοῖς ἑαυτῶν ἀρκεῖσθαι, λογιζομένους ὅτι ἡ πλεονεξία πρὸς τῷ μηδὲν ὠφελεῖν, ἀφαιρεῖται καὶ τὰ προσόντα πολλάκις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 105 Lb 72 Le 72 Lf 105 Me 89 Mf 75 Mg 96 Ml 90.</p>
+          <bibl>Codd. La 105 Lb 72 Le 72 Lf 105 Me 89 Mf 75 Mg 96 Ml 90.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-165">
@@ -4512,7 +4511,7 @@
         <pb ed="perry" n="P131"/>
         <p><milestone unit="recitprose"/>Κολοιόν τις συλλαϐὼν καὶ δήσας αὐτοῦ τὸν πόδα λινῷ κάλῳ τῷ ἑαυτοῦ παιδὶ ἔδωκεν. Ὁ δὲ οὐχ ὑπομείνας τὴν μετ’ ἀνθρώπων δίαιταν, ὡς πρὸς ὀλίγον ἀδείας ἔτυχε, φυγὼν ἧκεν εἰς τὴν ἑαυτοῦ καλιάν. Περιειληθέντος δὲ τοῦ δέσμου τοῖς κλάδοις, ἀναπτῆναι μὴ δυνάμενος ἐπειδὴ ἀποθνῄσκειν ἔμελλεν, ἔφη πρὸς ἑαυτόν· « Ἀλλ’ ἔγωγε δείλαιος, ὅστις τὴν παρὰ ἀνθρώπων δουλείαν μὴ ὑπομείνας ἔλαθον ἐμαυτὸν καὶ σωτηρίας στερήσας. »</p>
         <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόσειεν ἂν ἐπ’ ἐκείνων τῶν ἀνθρώπων οἳ μετρίων ἑαυτοὺς κινδύνων ῥύσασθαι βουλόμενοι ἔλαθον εἰς μείζονα δεινὰ περιπεσόντες.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 123 Pb 130 Pf 67 Ph 70 Mj 84 — La 106 Lb 73 Lc 26 Le 73 Lf 106 Lg 26 Me 90 Mg 97 Ml 91.</p>
+        <bibl>Codd. Pa 123 Pb 130 Pf 67 Ph 70 Mj 84 — La 106 Lb 73 Lc 26 Le 73 Lf 106 Lg 26 Me 90 Mg 97 Ml 91.</bibl>
         <p><milestone unit="traduction"/>Un homme ayant attrapé un choucas et lui ayant lié la patte avec un fil de lin, le donna à son enfant. Mais le choucas, ne pouvant se résigner à vivre avec les hommes, profita d’un instant de liberté pour s’enfuir et revint à son nid. Mais le fil s’étant enroulé aux branches, l’oiseau ne put s’envoler et, se voyant sur le point de mourir, il dit : « Je suis bien malheureux : pour n’avoir pas supporté l’esclavage chez les hommes, je me suis sans m’en douter privé de la vie. »</p>
         <p><milestone unit="traduction"/>Cette fable pourrait se dire des hommes qui, en voulant se défendre de médiocres dangers, se sont jetés à leur insu dans des périls plus redoutables.</p>
       </div>
@@ -4524,7 +4523,7 @@
           <pb ed="perry" n="P124"/>
           <p><milestone unit="recitprose"/>Κόραξ κρέας ἁρπάσας ἐπί τινος δένδρου ἐκάθισεν. Ἀλώπηξ δὲ θεασαμένη αὐτὸν καὶ βουλομένη τοῦ κρέατος περιγενέσθαι στᾶσα ἐπῄνει αὐτὸν ὡς εὐμεγέθη τε καὶ καλόν, λέγουσα καὶ ὡς πρέπει αὐτῷ μάλιστα τῶν ὀρνέων βασιλεύειν, καὶ τοῦτο πάντως ἂν ἐγένετο, εἰ φωνὴν εἶχεν. Ὁ δὲ παραστῆσαι αὐτῇ θέλων ὅτι καὶ φωνὴν ἔχει, ἀποϐαλὼν τὸ κρέας μεγάλα ἐκεκράγει. Ἐκείνη δὲ προσδραμοῦσα καὶ τὸ κρέας ἁρπάσασα ἔφη· « Ὦ κόραξ, καὶ φρένας εἰ εἶχες, οὐδὲν ἂν ἐδέησας εἰς τὸ πάντων σε βασιλεῦσαι. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ἀνόητον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 116 Pb 123 Pc 67 Pg 82 Ma 89.</p>
+          <bibl>Codd. Pa 116 Pb 123 Pc 67 Pg 82 Ma 89.</bibl>
           <p><milestone unit="traduction"/>Un corbeau, ayant volé un morceau de viande, s’était perché sur un arbre. Un renard l’aperçut, et, voulant se rendre maître de la viande, se posta devant lui et loua ses proportions élégantes et sa beauté, ajoutant que nul n’était mieux fait que lui pour être le roi des oiseaux, et qu’il le serait devenu sûrement, s’il avait de la voix. Le corbeau, voulant lui montrer que la voix non plus ne lui manquait pas, lâcha la viande et poussa de grands cris. Le renard se précipita et, saisissant le morceau, dit : « Ô corbeau, si tu avais aussi du jugement, il ne te manquerait rien pour devenir le roi des oiseaux. »</p>
           <p><milestone unit="traduction"/>Cette fable est une leçon pour les sots.</p>
         </div>
@@ -4534,7 +4533,7 @@
           <pb ed="perry" n="P124"/>
           <p><milestone unit="recitprose"/>Κόραξ κρέας ἁρπάσας ἐπί τινος δένδρου ἐκάθισεν. Ἀλώπηξ δὲ τοῦτον θεασαμένη καὶ βουληθεῖσα τοῦ κρέατος περιγενέσθαι, στᾶσα κάτωθεν, ἐπῄνει αὐτὸν ὡς εὐμεγέθες καὶ καλὸν ὄρνεον λέγουσα καὶ θηρευτικὸν καὶ εὔμορφον καὶ ὅτι « ἁρμόζει σοι βασιλέα εἶναι ὀρνέων, καὶ τοῦτο ἐκ παντὸς ἐγένετο ἄν, εἰ φωνὴν εἶχες· ἀλλ’ ὢ ποῖον ὄρνεον καὶ ἄλαλον ὑπάρχεις. » Ὁ δὲ κόραξ ταῦτα ἀκούσας καὶ χαυνωθεὶς τοῖς ἐπαίνοις εὐθέως ῥίψας τὸ κρέας μεγάλα ἐκεκράγει. Ἡ δὲ ἀλώπηξ δραμοῦσα ἔλαϐε τὸ κρέας καὶ στραφεῖσα ἔφη αὐτῷ· « Ἔχεις, κόραξ, ἅπαντα· νοῦς δέ σε λείπει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τινα ὑπὸ τῶν κολάκων ἐπαίρεσθαι· πολλάκις γὰρ βλάϐος αὐτῷ ἐκ τούτων γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 66 Cb 58 Ce 60 Cf 64 Mc 58 Md 63 Mh 59 Mk 60 Ml 92 Mm 77.</p>
+          <bibl>Codd. Ch 66 Cb 58 Ce 60 Cf 64 Mc 58 Md 63 Mh 59 Mk 60 Ml 92 Mm 77.</bibl>
         </div>
         <div>
           <head>Chambry 166.3</head>
@@ -4542,7 +4541,7 @@
           <pb ed="perry" n="P124"/>
           <p><milestone unit="recitprose"/>Κόραξ τυρὸν ἔδακνεν· ἡ δὲ πανοῦργος ἀλώπηξ τὸν τυρὸν ἐξέλθουσα φαγεῖν ἐπαίνῳ τὸν κόρακα ἐξηπάτα φάσκουσα ὡς « πάντων ὀρνέων εὐπρεπείᾳ διαφέρεις ἔν τε πτεροῖς καὶ αὐχένι, καὶ στῆθος ἔχεις ἀετοῦ καὶ ὄνυχας· ἀλλ’ ὁ τοιοῦτος ὄρνις ἄφωνος εἶ καὶ κωφός. » Κόραξ δὲ τοῖς ἐπαίνοις χαυνωθεὶς τὸν τυρόν τε τοῦ στόματος ἐκϐαλὼν ἐκεκράγει μεγάλα. Τοῦτον δὲ ἡ ἀλώπηξ ἁρπάσασα ἔφη· « Ἔχεις, κόραξ, ἅπαντα· νοῦς δέ σοι λείπει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα τοῖς κολάκων ἐπαίνοις τυφοῦσθαι καὶ ἐπαίρεσθαι· βλάϐη γὰρ αὐτοῖς ἀντὶ τῆς τοιαύτης τιμῆς ἕπεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 61 Bb 37.</p>
+          <bibl>Codd. Ba 61 Bb 37.</bibl>
         </div>
         <div>
           <head>Chambry 166.4</head>
@@ -4565,7 +4564,7 @@
           <l><milestone unit="recitvers"/>« ἅπαντα, κόραξ, νοῦς δὲ μόνον σοι λείπει. »</l>
           <l><milestone unit="recitvers"/>Κόραξ τοὺς ὀφθαλμοὺς σώματος ὀρύττει·</l>
           <l><milestone unit="recitvers"/>ψυχῆς δὲ κόρας ὀρύττει κολακία.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 57.</p>
+          <bibl>Cod. Cd 57.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-167">
@@ -4576,7 +4575,7 @@
           <pb ed="perry" n="P323"/>
           <p><milestone unit="recitprose"/>Κόραξ ὑπὸ παγίδος κρατηθεὶς ηὔξατο τῷ Ἀπόλλωνι λιϐανωτὸν ἐπιθύσειν. Σωθεὶς δὲ τοῦ κινδύνου τῆς ὑποσχέσεως ἐπελάθετο. Πάλιν δὲ ὑφ’ ἑτέρας κρατηθεὶς παγίδος, ἀφεὶς τὸν Ἀπόλλωνα, τῷ Ἑρμῇ ὑπέσχετο θῦσαι. Ὁ δὲ πρὸς αὐτὸν ἔφη· « Ὦ κάκιστε, πῶς σοι πιστεύσω, ὃς τὸν πρότερόν σου δεσπότην ἠρνήσω καὶ ἠδίκησας ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ πρὸς τοὺς εὐεργέτας ἀγνώμονες γενόμενοι ἐν περιστάσει ἐμπεσόντες οὐχ ἕξουσι βοηθούς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 62 Bb 38 Mb 79.</p>
+          <bibl>Codd. Ba 62 Bb 38 Mb 79.</bibl>
           <p><milestone unit="traduction"/>Un corbeau pris au piège promit à Apollon de lui brûler de l’encens ; mais sauvé du danger, il oublia sa promesse. Pris de nouveau, à un autre piège, il laissa Apollon pour s’adresser à Hermès, à qui il promit un sacrifice. Mais ce dieu lui répondit : « Misérable, comment me fierais-je à toi, qui as renié et frustré ton premier maître ? »</p>
           <p><milestone unit="traduction"/>Quand on s’est montré ingrat envers un bienfaiteur, on n’a plus, si l’on tombe dans l’embarras, à compter sur aucun secours.</p>
         </div>
@@ -4585,7 +4584,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P323"/>
           <p><milestone unit="recitprose"/>Κόραξ ἐν παγίδι κρατηθεὶς ηὔξατο τῷ Ἀπόλλωνι λιϐανωτὸν ἐπιθύσειν, εἰ τῆς παγίδος αὐτὸν ῥύσειε. Σωθεὶς δὲ τῆς ὑποσχέσεως ἐπελάθετο. Αὖθις δὲ ἐν ἑτέρᾳ παγίδι ληφθείς, ἀφεὶς τὸν Ἀπόλλωνα, τῷ Ἑρμῇ ηὔξατο θῦσαι. Ὁ δὲ πρὸς αὐτὸν εἶπεν· « Ὦ κάκιστον ζῷον, πῶς σοι πιστεύσω, ὅτι πρότερόν σου δεσπότην ἠδίκησας ; »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 31.</p>
+          <bibl>Cod. Bd 31.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-168">
@@ -4594,7 +4593,7 @@
         <pb ed="perry" n="P128"/>
         <p><milestone unit="recitprose"/>Κόραξ τροφῆς ἀπορῶν, ὡς ἐθέασατο ὄφιν ἔν τινι εὐηλίῳ τόπῳ κοιμώμενον, τοῦτον καταπτὰς ἥρπασε. Τοῦ δὲ ἐπιστραφέντος καὶ δακόντος αὐτόν, ἀποθνῄσκειν μέλλων, ἔφη· « Ἀλλ’ ἔγωγε δείλαιος, ὅστις τοιοῦτον ἕρμαιον εὕρηκα ἐξ οὗ καὶ ἀπόλλυμαι. »</p>
         <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος λεχθείη ἂν ἐπ’ ἄνδρα ὃς διὰ θησαυροῦ εὕρεσιν καὶ περὶ σωτηρίας ἐκινδύνευσεν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 120 Pb 127 Pc 69 Pg 84 Ma 90 Mh 58 Cd 69 — La 104 Lb 71 Le 71 Lf 104 Me 88 Mf 74 Mg 95 Ml 84.</p>
+        <bibl>Codd. Pa 120 Pb 127 Pc 69 Pg 84 Ma 90 Mh 58 Cd 69 — La 104 Lb 71 Le 71 Lf 104 Me 88 Mf 74 Mg 95 Ml 84.</bibl>
         <p><milestone unit="traduction"/>Un corbeau à court de nourriture aperçut un serpent qui dormait au soleil ; il fondit sur lui et l’enleva. Mais le serpent se retourna et le mordit, et le corbeau, sur le point de mourir, dit : « Je suis bien malheureux d’avoir trouvé une aubaine telle que j’en meurs. »</p>
         <p><milestone unit="traduction"/>On pourrait dire cette fable à propos d’un homme que la découverte d’un trésor met en péril de mort.</p>
       </div>
@@ -4606,7 +4605,7 @@
           <pb ed="perry" n="P324"/>
           <p><milestone unit="recitprose"/>Κόραξ νοσῶν ἔφη τῇ μητρί· « Μῆτερ, εὔχου τῷ θεῷ καὶ μὴ θρήνει. » Ἡ δ’ ὑπολαϐοῦσα ἔφη· « Τίς σε, ὦ τέκνον, τῶν θεῶν ἐλεήσει ; τίνος γὰρ κρέας ὑπὸ σοῦ γε οὐκ ἐκλάπη ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πολλοὺς ἐχθροὺς ἐν βίῳ ἔχοντες οὐδένα φίλον ἐν ἀνάγκῃ εὑρήσουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 136 Mg 98.</p>
+          <bibl>Codd. La 136 Mg 98.</bibl>
           <p><milestone unit="traduction"/>Un corbeau malade dit à sa mère : « Prie les dieux, mère, et ne pleure pas. » La mère lui répondit : « Lequel des dieux, mon enfant, aura pitié de toi ? en est-il un à qui tu n’aies pas dérobé de viande ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui se sont fait beaucoup d’ennemis dans leur vie ne trouveront pas d’amis, dans le besoin.</p>
         </div>
@@ -4620,7 +4619,7 @@
           <l><milestone unit="recitvers"/>« Καὶ τίς σε, τέκνον, τῶν θεῶν ἐλεήσει ;</l>
           <l><milestone unit="recitvers"/>Τίνος γὰρ κρέα ὑπὸ σοῦ οὐκ ἐκλάπη ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πολλοὺς ἐχθροὺς ἐν βίῳ ἔχοντες οὐδένα φίλον ἐν ἀνάγκῃ εὑρήσουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 69 Ca 87 Cb 60 Cd 60 Ce 66 Cf 70 Ma 174 Mb 80 Mc 60 Md 66 Mh 62 Mm 80 Lf 136.</p>
+          <bibl>Codd. Ch 69 Ca 87 Cb 60 Cd 60 Ce 66 Cf 70 Ma 174 Mb 80 Mc 60 Md 66 Mh 62 Mm 80 Lf 136.</bibl>
         </div>
         <div>
           <head>Chambry 169.3</head>
@@ -4628,14 +4627,14 @@
           <pb ed="perry" n="P324"/>
           <p><milestone unit="recitprose"/>Κόραξ νοσήσας τῇ μητρὶ κλαιούσῃ εἶπεν· « Εὔχου τοῖς θεοῖς, μῆτερ, καὶ μὴ κλαῖε. » Ἡ δὲ εἶπεν· « Τίς σε τῶν θεῶν, τέκνον, ἐλεήσει ; τίνος γὰρ αὐτῶν βωμὸς ὑπὸ σοῦ οὐκ ἐσυλήθη ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὁ πάντας ἐν τῷ βίῳ ἐχθροὺς κεκτημένος οὐδένα φίλον ἐν ἀνάγκαις εὑρήσει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 63 Bb 39.</p>
+          <bibl>Codd. Ba 63 Bb 39.</bibl>
         </div>
         <div>
           <head>Chambry 169.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P324"/>
           <p><milestone unit="recitprose"/>Κόραξ νοσήσας τῇ μητρὶ κλαιούσῃ εἶπεν· « Εὖξαι τοῖς θεοῖς, ὦ μῆτερ, καὶ τῶν δακρύων ἀπόσχου. » Ἡ δὲ εἶπε· « Καὶ τίς σε τῶν θεῶν, ὦ τέκνον, ἐλεήσει ; τίνος γὰρ ὑπὸ σοῦ βωμὸς οὐκ ἐσυλήθη ; »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 32.</p>
+          <bibl>Cod. Bd 32.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-170">
@@ -4646,7 +4645,7 @@
           <pb ed="perry" n="P251"/>
           <p><milestone unit="recitprose"/>Κορυδαλὸς εἰς πάγην ἁλοὺς θρηνῶν ἔλεγεν· « Οἴμοι τῷ ταλαιπώρῳ καὶ δυστήνῳ πτηνῷ· οὐ χρυσὸν ἐνοσφισάμην τινός, οὐκ ἄργυρον, οὐκ ἄλλο τι τῶν τιμίων· κόκκος δὲ σίτου μικρὸς τὸν θάνατόν μοι προὐξένησεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς διὰ κέρδος εὐτελὲς μέγαν ὑφισταμένους κίνδυνον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 55 Lb 64 Le 64 Lf 55 Lh 27 Me 79 Mf 70 Ml 82 Cf 69.</p>
+          <bibl>Codd. La 55 Lb 64 Le 64 Lf 55 Lh 27 Me 79 Mf 70 Ml 82 Cf 69.</bibl>
           <p><milestone unit="traduction"/>Une alouette huppée, prise au lacs, disait en gémissant : « Hélas ! pauvre oiseau infortuné que je suis ! Je n’ai dérobé à personne ni or, ni argent, ni quoi que ce soit de précieux : c’est un petit grain de blé qui a causé ma mort. »</p>
           <p><milestone unit="traduction"/>Cette fable s’applique à ceux qui, pour un profit mesquin, s’exposent a un grand danger.</p>
         </div>
@@ -4656,7 +4655,7 @@
           <pb ed="perry" n="P251"/>
           <p><milestone unit="recitprose"/>Κορυδαλὸς εἰς πάγην πεσὼν ἐθρήνει λέγων· « Οἴμοι τῷ ταλαιπώρῳ καὶ δυστηνῷ πτηνῷ· οὐ διὰ χρυσόν, οὐ διὰ ἄργυρον, οὐ διὰ ἄλλο τι τῶν τιμίων, διὰ &lt;δὲ&gt; κόκκον σίτου μικρὸν τὸν θάνατον ἐμαυτῷ προεξένησα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ [ὅτι] τοὺς διὰ κέρδος εὐτελὲς ὑφισταμένους θάνατον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ce 65.</p>
+          <bibl>Cod. Ce 65.</bibl>
         </div>
         <div>
           <head>Chambry 170.3</head>
@@ -4670,7 +4669,7 @@
           <l><milestone unit="recitvers"/>καὶ παγὶς ἐν γῇ μικρὰ ἐγκεκρυμμένη</l>
           <l><milestone unit="recitvers"/>† περιεῖλέ μου τὴν κουκουλίθραν. † »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς πένητας οἵτινες ἐξερχόμενοὶ συνάξαι διατροφὰς συλλαμϐάνονται παρὰ δυναστῶν καὶ κινδυνεύουσι μὴ ἐλεούμενοι ὑπ’ αὐτῶν τετυφλωμένων ὄντων καὶ ἀσυνέτων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ma 176 Md 68 Mh 64 Mm 82.</p>
+          <bibl>Codd. Ma 176 Md 68 Mh 64 Mm 82.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-171">
@@ -4681,7 +4680,7 @@
           <pb ed="perry" n="P125"/>
           <p><milestone unit="recitprose"/>Κορώνη φθονήσασα κόρακι ἐπὶ τῷ διὰ οἰωνῶν μαντεύεσθαι ἀνθρώποις καὶ τὸ μέλλον προφαίνειν καὶ διὰ τοῦτο ὑπ’ αὐτῶν μαρτυρεῖσθαι, ἐϐουλήθη τῶν αὐτῶν ἐφικέσθαι· καὶ δὴ θεασαμένη τινὰς ὁδοιπόρους παριόντας ἧκεν ἐπί τινος δένδρου, καὶ στᾶσα μεγάλα ἐκεκράγει. Τῶν δὲ πρὸς τὴν φωνὴν ἐπιστραφέντων καὶ καταπλαγέντων, εἷς τις ὑποτυχὼν ἔφη· « Ἀλλ’ ἀπίωμεν, ὦ φίλοι· κορώνη γάρ ἐστιν, ἥτις κεκραγυῖα οἰωνὸν οὐκ ἔχει. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ τοῖς κρείττοσιν ἀνθαμιλλώμενοι πρὸς τῷ τῶν ἴσων μὴ ἐφικέσθαι, καὶ γέλωτα ὀφλισκάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 117 Pb 124 Ma 91.</p>
+          <bibl>Codd. Pa 117 Pb 124 Ma 91.</bibl>
           <p><milestone unit="traduction"/>La corneille conçut de la jalousie contre le corbeau, parce qu’il donne des présages aux hommes, qu’il leur annonce l’avenir et que pour cette raison il est pris à témoin par eux ; aussi voulut-elle s’arroger les mêmes privilèges. Donc ayant vu passer des voyageurs, elle alla se percher sur un arbre et là poussa de grands cris. À sa voix, les voyageurs se retournèrent, effrayés ; mais l’un d’eux prenant la parole dit : « Allons, amis, continuons notre chemin : ce n’est qu’une corneille, ses cris ne donnent pas de présage. »</p>
           <p><milestone unit="traduction"/>Il en est ainsi chez les hommes : ceux qui rivalisent avec de plus forts qu’eux, non seulement ne peuvent les égaler, mais encore ils prêtent à rire.</p>
         </div>
@@ -4691,7 +4690,7 @@
           <pb ed="perry" n="P125"/>
           <p><milestone unit="recitprose"/>Κορώνη φθονήσασα κόρακι ἐπὶ τῷ δι’ οἰωνῶν τοῖς ἀνθρώποις μαντεύεσθαι, καὶ διὰ τοῦτο μαρτυρουμένῳ ὡς προλέγοντι τὸ μέλλον, θεασαμένη τινὰς ὁδοιπόρους παριόντας, ἧκεν ἐπί τι δένδρον καὶ στᾶσα μεγάλως ἔκραξεν. Τῶν δὲ πρὸς τὴν φωνὴν ἐπιστραφέντων καὶ καταπλαγέντων, ὑποτυχών τις ἔφη· « Ἀπίωμεν, ὦ οὗτοι· κορώνη γάρ ἐστιν, ἥτις κέκραγε καὶ οἰωνισμὸν οὐκ ἔχει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων οἱ τοῖς κρείττοσιν ἁμιλλώμενοι, πρὸς τῷ τῶν ἴσων μὴ ἐφικέσθαι καὶ γέλωτα ὀφλισκάνουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 102 Lb 69 Le 69 Lf 102 Me 86 Mf 73 Mg 93 Ml 88.</p>
+          <bibl>Codd. La 102 Lb 69 Le 69 Lf 102 Me 86 Mf 73 Mg 93 Ml 88.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-172">
@@ -4702,7 +4701,7 @@
           <pb ed="perry" n="P127"/>
           <p><milestone unit="recitprose"/>Κορώνη Ἀθηνᾷ θύουσα κύνα ἐφ’ ἑστίασιν ἐκάλεσεν. Ὁ δὲ ἔφη πρὸς αὐτήν· « Τί μάτην τὰς θυσίας ἀναλίσκεις ; ἡ γὰρ δαίμων οὕτως σε μισεῖ ὡς καὶ τῶν σῶν οἰωνῶν τὴν πίστιν περιελέσθαι. » Καὶ ἡ κορώνη ἀπεκρίνατο· « Ἀλλὰ καὶ διὰ τοῦτο αὐτῇ θύω, διότι οἶδα αὐτὴν ἀπεχθῶς διακειμένην, ἵνα διαλλαγῇ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ διὰ φόϐον τοὺς ἐχθροὺς εὐεργετεῖν οὐκ ὀκνοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 119 Pb 126 Pc 68 Pf 69 Mb 85 Mj 86.</p>
+          <bibl>Codd. Pa 119 Pb 126 Pc 68 Pf 69 Mb 85 Mj 86.</bibl>
           <p><milestone unit="traduction"/>Une corneille offrant une victime à Athéna invita un chien au banquet du sacrifice. Le chien lui dit : « Pourquoi dépenses-tu ton bien à des sacrifices inutiles ? La déesse, en effet, te hait au point d’ôter toute créance à tes présages. » À quoi la corneille répliqua : « Mais c’est précisément pour cela que je lui sacrifie : je la sais mal disposée à mon égard et je veux qu’elle se réconcilie avec moi. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que beaucoup de gens n’hésitent pas à faire du bien à leurs ennemis, parce qu’ils en ont peur.</p>
         </div>
@@ -4712,7 +4711,7 @@
           <pb ed="perry" n="P127"/>
           <p><milestone unit="recitprose"/>Κορώνη Ἀθηνᾷ θύουσα κύνα ἐπὶ ἑστίασιν ἐκάλει. Ὁ δὲ πρὸς αὐτὴν ἔφη· « Τί μάτην τὰς θυσίας ἀναλίσκεις ; ἡ γὰρ θεὸς οὕτω σε μισεῖ ὡς κἀκ τῶν συντρόφων σοι οἰωνῶν τὴν πίστιν περιελεῖν. » Καὶ ἡ κορώνη πρὸς αὐτόν· « Διὰ τοῦτο μᾶλλον αὐτῇ θύω, ἵνα διαλλαγῇ μοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ διὰ κέρδος τοὺς ἐχθροὺς εὐεργετεῖν οὐκ ὀκνοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 103 Lb 70 Le 70 Lf 103 Me 87 Mg 94 Ml 89.</p>
+          <bibl>Codd. La 103 Lb 70 Le 70 Lf 103 Me 87 Mg 94 Ml 89.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-173">
@@ -4721,7 +4720,7 @@
         <pb ed="perry" n="P54"/>
         <p><milestone unit="recitprose"/>Γεωργοῦ παῖς κοχλίας ὤπτα· ἀκούσας δὲ αὐτῶν τριζόντων ἔφη· « Ὦ κάκιστα ζῷα, τῶν οἰκιῶν ὑμῶν ἐμπιπραμένων, αὐτοὶ ᾄδετε. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πᾶν τὸ παρὰ καιρὸν δρώμενον ἐπονείδιστον.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 54 Pb 54 Pc 25 — La 82 Lb 31 Lc 42 Le 31 Lf 82 Lg 42 Md 135 Me 38 Mg 40 Mi 109 Mj 36 Mm 49.</p>
+        <bibl>Codd. Pa 54 Pb 54 Pc 25 — La 82 Lb 31 Lc 42 Le 31 Lf 82 Lg 42 Md 135 Me 38 Mg 40 Mi 109 Mj 36 Mm 49.</bibl>
         <p><milestone unit="traduction"/>L’enfant d’un laboureur grillait des escargots. En les entendant crépiter, il dit : « Misérables bêtes, vos maisons brûlent, et vous chantez ! »</p>
         <p><milestone unit="traduction"/>Cette fable montre que tout ce qu’on fait à contre-temps est repréhensible.</p>
       </div>
@@ -4731,7 +4730,7 @@
         <pb ed="perry" n="P399"/>
         <p><milestone unit="recitprose"/>Ἀνὴρ εὐπορῶν χῆνά τε ἅμα καὶ κύκνον ἔτρεφεν, οὐκ ἐπὶ τοῖς αὐτοῖς μέντοι· τὸν μὲν γὰρ ᾠδῆς, τὸν δὲ τραπέζης ἕνεκεν. Ἐπεὶ δὲ ἔδει τὸν χῆνα παθεῖν ἐφ’ οἷς ἐτρέφετο, νὺξ μὲν ἦν, καὶ διαγινώσκειν ὁ καιρὸς οὐκ ἀφῆκεν ἑκάτερον. Ὁ δὲ κύκνος, ἀντὶ τοῦ χηνὸς ἀπαχθείς, ᾄδει τι μέλος θανάτου προοίμιον, καὶ τῇ μὲν ᾠδῇ μηνύει τὴν φύσιν, τὴν δὲ τελευτὴν διαφεύγει τῷ μέλει.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἡ μουσικὴ τελευτῆς ἀναϐολὴν ἀπεργάζεται.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 78 Lb 19 Le 19 Lf 78 Md 132 Mg 11 Mi 106 Mj 22 Ml 16 Mm 32.</p>
+        <bibl>Codd. La 78 Lb 19 Le 19 Lf 78 Md 132 Mg 11 Mi 106 Mj 22 Ml 16 Mm 32.</bibl>
         <p><milestone unit="traduction"/>Un homme opulent nourrissait ensemble une oie et un cygne, non point pour le même objet, mais l’un pour son chant, l’autre en vue de sa table. Or lorsque l’oie dut subir le destin pour lequel on l’élevait, il faisait nuit, et le temps ne permettait pas de distinguer les deux volatiles. Mais le cygne, emporté à la place de l’oie, entonne un chant, prélude de son trépas. Sa voix le fit reconnaître et son chant le sauva de la mort.</p>
         <p><milestone unit="traduction"/>Cette fable montre que souvent la musique fait ajourner la mort.</p>
       </div>
@@ -4741,7 +4740,7 @@
         <pb ed="perry" n="P233"/>
         <p><milestone unit="recitprose"/>Τοὺς κύκνους φασὶ παρὰ τὸν θάνατον ᾄδειν. Καὶ δή τις περιτυχὼν κύκνῳ πωλουμένῳ καὶ ἀκούσας ὅτι εὐμελέστατόν ἐστι ζῷον, ἠγόρασε. Καὶ ἔχων ποτὲ συνδείπνους προσελθὼν παρεκάλει αὐτὸν ᾆσαι ἐν τῷ πότῳ. Τοῦ δὲ τότε μὲν ἡσυχάζοντος, ὕστερον δέ ποτε, ὡς ἐνόησεν ὅτι ἀποθνῄσκειν ἔμελλεν, ἑαυτὸν θρηνοῦντος, ὁ δεσπότης αὐτοῦ ἀκούσας ἔφη· « Ἀλλ’ εἰ σὺ οὐκ ἄλλως ᾄδεις, ἐὰν μὴ ἀποθνῄσκῃς, ἐγὼ μάταιος ἦν, ὃς τότε σε παρεκάλουν, ἀλλ’ οὐκ ἔθυον. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων, ἃ μὴ ἑκόντες χαρίσασθαι βούλονται, ταῦτα ἄκοντες ἐπιτελοῦσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 225 Pf 130 Me 167 Mf 138.</p>
+        <bibl>Codd. Pa 225 Pf 130 Me 167 Mf 138.</bibl>
         <p><milestone unit="traduction"/>Les cygnes chantent, dit-on, au moment de mourir. Or un homme étant tombé sur un cygne mis en vente, et sachant par ouï-dire que c’était un animal très mélodieux, en fit l’acquisition. Un jour qu’il donnait à dîner, il alla chercher le cygne et le pria de chanter pendant le festin. Le cygne alors garda le silence, mais un jour, dans la suite, pensant qu’il allait mourir, il se pleura dans un thrène. Son maître, l’entendant, lui dit : « Si tu ne chantes que quand tu vas mourir, j’ai été bien sot de te prier de chanter jadis au lieu de t’immoler. »</p>
         <p><milestone unit="traduction"/>Il arrive ainsi quelquefois que, ce qu’on ne veut pas faire de bonne grâce, on le fait par contrainte.</p>
       </div>
@@ -4753,7 +4752,7 @@
           <pb ed="perry" n="P92"/>
           <p><milestone unit="recitprose"/>Ἔχων τις δύο κύνας, τὸν μὲν θηρεύειν ἐδίδασκε, τὸν δὲ οἰκουρὸν ἐποίησε. Καὶ δή, εἴ ποτε ὁ θηρευτὴς ἐξιὼν ἐπ’ ἄγραν συνελάμϐανέ τι, ἐκ τούτου μέρος καὶ τῷ ἑτέρῳ παρέϐαλλεν. Ἀγανακτοῦντος δὲ τοῦ θηρευτικοῦ καὶ τὸν ἕτερον ὀνειδίζοντος, εἴ γε αὐτὸς μὲν ἐξιὼν παρ’ ἕκαστα μοχθεῖ, ὁ δὲ οὐδὲν ποιῶν τοῖς αὐτοῦ πόνοις ἐντρυφᾷ, ἐκεῖνος ἔφη πρὸς αὐτόν· « Ἀλλὰ μὴ ἐμὲ μέμφου, ἀλλὰ τὸν δεσπότην, ὃς οὐ πονεῖν με ἐδίδαξεν, ἀλλοτρίους δὲ πόνους κατεσθίειν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν παίδων οἱ ῥᾴθυμοι οὐ μεμπτέοι εἰσίν, ὅταν αὐτοὺς οἱ γονεῖς οὕτως ἄγωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 88 Pb 93 Pe 55 Pf 47 Pg 60 Ph 49 Me 58 Mf 52.</p>
+          <bibl>Codd. Pa 88 Pb 93 Pe 55 Pf 47 Pg 60 Ph 49 Me 58 Mf 52.</bibl>
           <p><milestone unit="traduction"/>Un homme avait deux chiens. Il dressa l’un à chasser et fit de l’autre un gardien du foyer. Or quand le chien de chasse sortait pour chasser et prenait quelque gibier, le maître en jetait une partie à l’autre chien aussi. Le chien de chasse mécontent fit des reproches à son camarade : c’était lui qui sortait et avait le mal en toute occasion, tandis que son camarade, sans rien faire, jouissait du fruit de ses travaux ! Le chien de garde répondit : « Eh mais ! ce n’est pas moi qu’il faut blâmer, mais notre maître qui m’a appris, non à travailler, mais à vivre du travail d’autrui. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que les enfants paresseux ne sont pas à blâmer, quand leurs parents les élèvent dans la paresse.</p>
         </div>
@@ -4763,7 +4762,7 @@
           <pb ed="perry" n="P92"/>
           <p><milestone unit="recitprose"/>Ἔχων τις δύο κύνας, τὸν μὲν ἕτερον θηρεύειν ἐδίδαξε, τὸν δὲ λοιπὸν οἰκοφυλακεῖν. Καὶ δή, εἴ ποτε ὁ θηρευτικὸς ἤγρευέ τι, καὶ ὁ οἰκουρὸς συμμετεῖχεν αὐτῷ τῆς θοίνης. Ἀγανακτοῦντος δὲ τοῦ θηρευτικοῦ κἀκεῖνον ὀνειδίζοντος, εἴ γε αὐτὸς μὲν καθ’ ἑκάστην μοχθεῖ, ἐκεῖνος δὲ μηδὲν πονῶν τοῖς αὐτοῦ τρέφεται πόνοις, ὑπολαϐὼν αὐτὸς εἶπε· « Μὴ ἐμέ, ἀλλὰ τὸν δεσπότην μέμφου, ὃς οὐ πονεῖν με ἐδίδαξεν, ἀλλὰ πόνους ἀλλοτρίους ἐσθίειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ τῶν νέων οἱ μηδὲν ἐπιστάμενοι οὐ μεμπτοί εἰσιν, ὅταν αὐτοὺς οἱ γονεῖς οὕτως ἀγάγωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 96 Lb 51 Le 51 Lf 96 Lh 17 Mg 74 Mj 61 Ml 62.</p>
+          <bibl>Codd. La 96 Lb 51 Le 51 Lf 96 Lh 17 Mg 74 Mj 61 Ml 62.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-177">
@@ -4772,7 +4771,7 @@
         <pb ed="perry" n="P135"/>
         <p><milestone unit="recitprose"/>Κύνες λιμώττουσαι, ὡς ἐθεάσαντο ἔν τινι ποταμῷ βύρσας βρεχομένας, μὴ δυνάμεναι αὐτῶν ἐφικέσθαι, συνέθεντο ἀλλήλαις ὅπως πρῶτον τὸ ὕδωρ ἐκπίωσι, εἶθ’ οὕτως ἐπὶ τὰς βύρσας παραγένωνται. Συνέϐη δὲ αὐταῖς πινούσαις διαρραγῆναι πρὶν ἤ τῶν βυρσῶν ἐφικέσθαι.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων δι’ ἐλπίδα κέρδους ἐπισφαλεῖς μόχθους ὑφιστάμενοι φθάνουσι πρότερον καταναλισκόμενοι ἢ ὧν βούλονται περιγενόμενοι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 128 Pb 134 Pc 74 Pf 72 Mb 243 Me 95 Mf 80 Mj 89 Cd 70.</p>
+        <bibl>Codd. Pa 128 Pb 134 Pc 74 Pf 72 Mb 243 Me 95 Mf 80 Mj 89 Cd 70.</bibl>
         <p><milestone unit="traduction"/>Des chiens affamés virent des peaux qui trempaient dans une rivière. Ne pouvant les atteindre, ils convinrent entre eux de boire toute l’eau, pour arriver ensuite aux peaux. Mais il advint qu’à force de boire ils crevèrent avant d’atteindre les peaux.</p>
         <p><milestone unit="traduction"/>Ainsi certains hommes se soumettent, dans l’espérance d’un profit, à des travaux dangereux, et se perdent avant d’atteindre l’objet de leurs désirs.</p>
       </div>
@@ -4784,7 +4783,7 @@
           <pb ed="perry" n="P64"/>
           <p><milestone unit="recitprose"/>Δηχθείς τις ὑπὸ κυνὸς περιῄει ζητῶν τὸν ἰασόμενον. Εἰπόντος δέ τινος οὕτως ὡς ἄρα δέοι αὐτὸν ἄρτῳ τὸ αἷμα ἐκμάξαντα τῷ δακόντι κυνὶ βαλεῖν, ὑποτυχὼν ἔφη· « Ἀλλ’ ἐὰν τοῦτο πράξω, δεήσει με ὑπὸ πάντων τῶν ἐν τῇ πόλει κυνῶν δάκνεσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ ἡ τῶν ἀνθρώπων πονηρία δελεαζομένη ἔτι μᾶλλον ἀδικεῖν παροξύνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 62 Pb 64 Pc 31 Pe 31 Pg 41 Ph 31 Ma 45.</p>
+          <bibl>Codd. Pa 62 Pb 64 Pc 31 Pe 31 Pg 41 Ph 31 Ma 45.</bibl>
           <p><milestone unit="traduction"/>Un homme mordu par un chien courait de tous côtés, cherchant quelqu’un pour le guérir. Un quidam lui dit qu’il n’avait qu’à essuyer le sang de sa blessure avec du pain et à le jeter au chien qui l’avait mordu. À quoi le blessé répondit : « Mais, si je fais cela, je serai fatalement mordu par tous les chiens de la ville. »</p>
           <p><milestone unit="traduction"/>Pareillement, si vous flattez la méchanceté des hommes, vous les excitez à faire plus de mal encore.</p>
         </div>
@@ -4794,7 +4793,7 @@
           <pb ed="perry" n="P64"/>
           <p><milestone unit="recitprose"/>Δηχθείς τις ὑπὸ κυνὸς περιῄει ζητῶν τὸν τοῦτον ἰάσασθαι δυνάμενον. Καί τις τῶν παρατυχόντων ἀκούσας ἔφη αὐτῷ· « Ὦ οὗτος, εἰ θέλεις σῴζεσθαι, λαϐὼν ἄρτον, τὸ αἷμα ἐκμάξας τῆς πληγῆς τῷ δακόντι κυνὶ ἐπίδος. » Ὁ δὲ γελάσας ἔφη· « Ἀλλ’ ἐὰν τοῦτο πράξω, δέον ἐστὶν ἵνα ὑπὸ πάντων τῶν ἐν τῇ πόλει κυνῶν δηχθήσωμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων οἱ πονηρίᾳ δελεαζόμενοι ἔτι μᾶλλον ἀδικεῖν παροξύνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 55 Cb 37 Cd 34 Ce 38 Cf 43 Ch 44 Mh 37.</p>
+          <bibl>Codd. Ca 55 Cb 37 Cd 34 Ce 38 Cf 43 Ch 44 Mh 37.</bibl>
         </div>
         <div>
           <head>Chambry 178.3</head>
@@ -4802,7 +4801,7 @@
           <pb ed="perry" n="P64"/>
           <p><milestone unit="recitprose"/>Δηχθείς τις ὑπὸ κυνὸς τὸν ἰασόμενον περιῄει ζητῶν. Ἐντυχὼν δέ τις αὐτῷ καὶ γνοὺς ὃ ζητεῖ· « Ὦ οὗτος, εἶπεν, εἰ σῴζεσθαι βούλει, λαϐὼν ἄρτον καὶ τούτῳ τὸ αἷμα τῆς πληγῆς ἐκμάξας, τῷ δακόντι κυνὶ φαγεῖν ἐπίδος. » Κἀκεῖνος γελάσας ἔφη· « Ἀλλ’ εἰ τοῦτο ποιήσω, δεῖ με ὑπὸ πάντων τῶν ἐν τῇ πόλει κυκῶν δηχθῆναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ τῶν ἀνθρώπων οἱ πονηροὶ εὐεργετούμενοι μᾶλλον ἀδικεῖν παροξύνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 25 Lb 36 Lc 13 Ld 16 Le 36 Lf 25 Lg 13 Md 42 Me 43 Mf 38 Mg 45 Mi 77 Mj 42 Mk 40 Ml 47 Mm 54 Mn 16.</p>
+          <bibl>Codd. La 25 Lb 36 Lc 13 Ld 16 Le 36 Lf 25 Lg 13 Md 42 Me 43 Mf 38 Mg 45 Mi 77 Mj 42 Mk 40 Ml 47 Mm 54 Mn 16.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-179">
@@ -4813,7 +4812,7 @@
           <pb ed="perry" n="P328"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις ἡτοίμαζε δεῖπνον, ἑστιάσων τινὰ τῶν φίλων αὐτῷ καὶ οἰκείων. Ὁ δὲ κύων αὐτοῦ ἄλλον κύνα ἐκάλει, λέγων· « Ὦ φίλε, δεῦρο συνδείπνησόν μοι. » Ὁ δὲ προσελθὼν χαίρων ἵστατο, βλέπων τὸ μέγα δεῖπνον, βοῶν ἐν τῇ καρδίᾳ· « Βαϐαί, πόση μοι χαρὰ ἄρτι ἐξαπιναίως ἐφάνη· τραφήσομαί τε γὰρ καὶ εἰς κόρον δειπνήσω, ὥστε με αὔριον μηδαμῆ γε πεινᾶσαι. » Ταῦτα καθ’ ἑαυτὸν λέγοντος τοῦ κυνὸς καὶ ἅμα σείοντος τὴν κέρκον, ὡς δὴ εἰς τὸν φίλον θαρροῦντος, ὁ μάγειρος, ὡς εἶδε τοῦτον ὧδε κἀκεῖσε τὴν κέρκον περιστρέφοντα, κατασχὼν τὰ σκέλη αὐτοῦ ἔρριψε παραχρῆμα ἔξωθεν τῶν θυρίδων. Ὁ δὲ κατιὼν ἀπῄει μεγάλως κράζων. Τῶν τις δὲ κυνῶν, τῶν καθ’ ὁδὸν αὐτῷ σαναντώντων, ἐπηρώτα· « Πῶς ἐδείπνησας, φίλος ; » Ὁ δὲ πρὸς αὐτὸν ὑπολαϐὼν ἔφη· « Ἐκ τῆς πολλῆς πόσεως μεθυσθεὶς ὑπὲρ κόρον οὐδὲ τὴν ὁδὸν αὐτὴν ὅθεν ἐξῆλθον οἶδα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ θαρρεῖν τοῖς ἐξ ἀλλοτρίων εὖ ποιεῖν ἐπαγγελλομένοις.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 133 Mg 20.</p>
+          <bibl>Codd. La 133 Mg 20.</bibl>
           <p><milestone unit="traduction"/>Un homme préparait un dîner pour traiter un de ses amis et familiers. Son chien invita un autre chien. « Ami, lui dit-il, viens céans dîner avec moi. » L’invité arriva plein de joie, et s’arrêta à regarder le grand dîner, murmurant dans son cœur : « Oh ! quelle aubaine inattendue pour moi ! Je vais bâfrer et m’en donner tout mon soûl, de manière à n’avoir pas faim de tout demain. » Tandis qu’il parlait ainsi à part lui, tout en remuant la queue, comme un ami qui a confiance en son ami, le cuisinier le voyant tourner la queue de-ci, de-là, le prit par les pattes et le lança soudain par la fenêtre. Et le chien s’en retourna en poussant de grands cris. Il trouva sur sa route d’autres chiens ; l’un d’eux lui demanda : « Comment as-tu dîné, l’ami ? » Il lui répondit : « À force de boire je me suis enivré outre mesure, et je ne sais même pas par où je suis sorti. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas se fier à ceux qui font les généreux avec le bien d’autrui.</p>
         </div>
@@ -4845,7 +4844,7 @@
           <l><milestone unit="recitvers"/>« Ἐξ ὧν ἔπιον μεθυσθεὶς ὑπὲρ κόρον</l>
           <l><milestone unit="recitvers"/>οὐδὲ τὴν ὁδὸν ὅθεν ἐξῆλθον εἶδον. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ θαρρεῖν τοῖς μηδὲν ἀνύουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 16 Ca 22 Cb 16 Cc 13 Cd 16 Mb 81 Mc 21 Mk 22 Lf 133.</p>
+          <bibl>Codd. Ch 16 Ca 22 Cb 16 Cc 13 Cd 16 Mb 81 Mc 21 Mk 22 Lf 133.</bibl>
         </div>
         <div>
           <head>Chambry 179.3</head>
@@ -4853,7 +4852,7 @@
           <pb ed="perry" n="P328"/>
           <p><milestone unit="recitprose"/>Ἄνθρωπός τις δεῖπνον ἡτοίμαζεν εἰς τὸ καλέσαι φίλον αὐτοῦ οἰκεῖον. Ὁ δὲ κύων αὐτοῦ ἄλλον κύνα ἐκάλει λέγων· « Ὦ φίλε, δεῦρο δείπνησον ὧδε. » Ὁ δὲ προσελθὼν καὶ ἰδὼν τὸ μέγα ἐκεῖνο δεῖπνον ἵστατο καὶ διελογίζετο· « Βαϐαί, πόση μοι χαρὰ ἄρτι ἐφάνη· ἐξαπίνης γάρ με αὕτη κατέσχε, καὶ εἰς κόρον μέλλω τρυφῆσαι. » Ταῦτα καθ’ ἑαυτὸν στρέφων ὁ κύων καὶ σείων τὴν κέρκον, ἑώρα πρὸς τὸν φίλον τὸν κεκληκότα ἐπὶ τὸ δεῖπνον. Ὁ οὖν μάγειρος ἰδὼν αὐτὸν τὴν κέρκον ὧδε κἀκεῖσε περιστρέφοντα, κατασχὼν ἐκ τοῦ σκέλους, ἔρριψεν αὐτὸν διὰ τῆς θυρίδος. Ὁ δὲ κατιὼν ἀπῄει κράζων. Τῶν δὲ κυνῶν προσυπαντώντων καὶ ἐπερωτώντων αὐτόν· « Πῶς ἐδείπνησας ; » ὑπολαϐὼν ἔφη πρὸς αὐτούς· « Ἐξ ὧν ἔπιον μεθυσθεὶς ὑπὲρ κόρον οὐδὲ τὴν ὁδὸν εἶδον ὅθεν ἐξῆλθον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ θαρρεῖν τοῖς μηδὲν ἀνύουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ma 151 Md 21 Mh 14 Mi 56 Mm 21.</p>
+          <bibl>Codd. Ma 151 Md 21 Mh 14 Mi 56 Mm 21.</bibl>
         </div>
         <div>
           <head>Chambry 179.4</head>
@@ -4861,7 +4860,7 @@
           <pb ed="perry" n="P328"/>
           <p><milestone unit="recitprose"/>Δεῖπνόν τις εἶχεν. Ὁ δὲ τούτου κύων ἕτερον κύνα φίλον αὐτοῦ ἐκάλει. Ὁ δὲ ἦλθεν. Ὁ μάγειρος δὲ ἄρας αὐτὸν τοῦ σκέλους ἔρριψεν ἔξω. Τῶν κυνῶν δὲ ἐρωτώντων αὐτὸν πῶς ἐδείπνησε· « Τοιαῦτα ἔφη ὅτι οὐδὲ τὴν ὁδὸν οἶδα ὅθεν ἐξῆλθον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις οἱ ἐκϐληθέντες ὡς ἀνάξιοι δόξης αἰσχυνόμενοι πειρῶνται κενοδοξεῖν διὰ λόγων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 27.</p>
+          <bibl>Cod. Ba 27.</bibl>
         </div>
         <div>
           <head>Chambry 179.5</head>
@@ -4869,14 +4868,14 @@
           <pb ed="perry" n="P328"/>
           <p><milestone unit="recitprose"/>Δεῖπνόν τις ἐτέλει λαμπρόν. Ὁ δὲ τούτου κύων ἕτερον κύνα διὰ φιλίας εἰς τὸ δεῖπνον μετεκαλεῖτο. Τοῦ δὲ κεκλημένου καταλαϐόντος καὶ ἐν τῷ ὀπτανείῳ περιπολοῦντος, ὁ ὀψοποιὸς τοῦτον ἐκ τοῦ σκέλους λαϐὼν τῆς πύλης ἔξωθεν ἐσφενδόνησεν. Ὁ δὲ ἀναστὰς πρὸς φυγὴν ἐτράπετο. Τῶν δὲ ὑπαντώντων κυνῶν ἐπερομένων αὐτὸν πῶς τῷ δείπνῳ ἐπανεπαύσατο, εἶπε· « Τῇ τρυφῇ καρωθεὶς οὐδὲ τὴν ὁδὸν εἶδον ὅθεν ἐξῆλθον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις διὰ λόγου τινὲς τὴν ἀτιμίαν αὑτῶν πειρῶνται διασκεδάζειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 21.</p>
+          <bibl>Cod. Bc 21.</bibl>
         </div>
         <div>
           <head>Chambry 179.6</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P328"/>
           <p><milestone unit="recitprose"/>Δεῖπνόν τις ἄνθρωπος εἶχεν. Ὁ δὲ τούτου κύων ἕτερον κύνα ἑαυτοῦ φίλον ἐπὶ τὸ δεῖπνον ἐκάλει. Ἐλθόντα οὖν ὁ μάγειρος αὐτὸν ἐκ τῶν ποδῶν ἄρας τοῦ μαγειρίου ἔρριψεν ἔξω. Τῶν δὲ λοιπῶν κυνῶν ἐν τῇ ὁδῷ ἐρωτώντων ὅπως ἐδείπνησεν· « Οὕτως, ἔφη, ὥστε οὐδὲ τὴν ὁδὸν εἶδον ὅθεν ἐξῆλθον. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 10.</p>
+          <bibl>Cod. Bd 10.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-180">
@@ -4887,7 +4886,7 @@
           <pb ed="perry" n="P329"/>
           <p><milestone unit="recitprose"/>Κύων τρεφόμενος ἐν οἴκῳ, θηρσὶν εἰδὼς μάχεσθαι, ἰδὼν πολλοὺς ἐν τάξει ἱσταμένους, ῥήξας τὸν κλοιὸν τοῦ τραχήλου, ἔφευγε διὰ τῶν ἀμφόδων. Κύνες δὲ ἄλλοι τοῦτον ἰδόντες εὐτραφῆ οἷα ταῦρον εἶπον· « Τί φεύγεις ; » Ὁ δὲ εἶπεν· « Ὅτι μὲν τροφῇ συζῶ περισσῇ οἶδα καὶ σῶμα τὸ ἐμὸν εὐφραίνω· ἀεὶ δὲ πλησίον εἰμὶ θανάτου, ἄρκοις καὶ λέουσι μαχόμενος. » Οἱ δὲ πρὸς ἀλλήλους εἶπον· « Καλὸν βίον ἡμεῖς, εἰ καὶ πενιχρόν, ζῶμεν, οἵτινες οὔτε λέουσι οὔτε ἄρκοις μαχόμεθα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ κινδύνους ἑαυτῷ ἐπιφέρειν διὰ τρυφὴν καὶ ματαίαν δόξαν, ἀλλὰ τούτους ἐκφεύγειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 69 Mb 244.</p>
+          <bibl>Codd. Ba 69 Mb 244.</bibl>
           <p><milestone unit="traduction"/>Un chien, nourri dans une maison, était dressé à combattre les bêtes fauves. Un jour qu’il en vit beaucoup rangées en ligne, il brisa le collier de son cou et s’enfuit par les rues. D’autres chiens l’ayant vu, puissant comme un taureau, lui dirent : « Pourquoi te sauves-tu ? — Je sais bien, répondit-il, que je vis dans l’abondance et que j’ai toutes les satisfactions de l’estomac, mais je suis toujours près de la mort, en combattant les ours et les lions. » Alors les chiens se dirent entre eux : « Nous avons une belle vie, quoique pauvre, nous qui ne combattons ni les lions, ni les ours. »</p>
           <p><milestone unit="traduction"/>Il ne faut pas, pour la bonne chère et la vaine gloire, attirer sur soi le danger, mais l’éviter au contraire.</p>
         </div>
@@ -4896,7 +4895,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P329"/>
           <p><milestone unit="recitprose"/>Κύων θηρευτικὸς ῥήξας τοὺς δεσμοὺς τοῦ τραχήλου ἔφευγε διὰ τῶν ἀμφόδων. Κύνες δὲ ἕτεροι οἷάπερ ταῦρον ἰδόντες εὐπαθῆ, τὴς αἰτίαν τῆς φυγῆς ἐπηρώτων. Ὁ δὲ εἶπεν· « Ὅτι τροφῇ συζῶ περισσῇ καὶ τὸ σῶμα τὸ ἐμὸν εὐφραίνω οὐκ ἀπαρνοῦμαι· ἀεὶ μέντοι πλησίον εἰμὶ  θανάτου ἄρκοις καὶ λέουσι μαχόμενος. » Οἱ δὲ πρὸς ἀλλήλους εἶπον· « Καλῶς ἡμῖν τὸ πενιχρῶς ζῆν οὔτε λέουσιν οὔτε ἄρκοις μαχομένοις. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 34.</p>
+          <bibl>Cod. Bd 34.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-181">
@@ -4907,7 +4906,7 @@
           <pb ed="perry" n="P252"/>
           <p><milestone unit="recitprose"/>Κύων καὶ ἀλέκτωρ φιλίαν πρὸς ἀλλήλους ποιησάμενοι ἐν τῷ ἅμα ὥδευον. Τῆς δὲ νυκτὸς καταλαϐούσης, ἐν τόπῳ ἀλσώδει ἐλθόντες, ὁ μὲν ἀλεκτρυὼν ἐπί τι δένδρον ἀναϐὰς ἐν τοῖς κλάδοις ἐκάθισεν· ὁ δὲ κύων κάτωθεν τῆς ῥαγάδος τοῦ δένδρου ἀφύπνωσε, καὶ τῆς νυκτὸς παρελθούσης καὶ αὐγῆς καταλαϐούσης, ὁ ἀλέκτωρ κατὰ τὸ σύνηθες μεγάλα ἐκεκράγει. Ἀλώπηξ δὲ τούτου ἀκούσασα καὶ βουλομένη αὐτὸν καταθοινήσασθαι, ἐλθοῦσα καὶ στᾶσα κάτωθεν τοῦ δένδρου ἐϐόα πρὸς αὐτόν· « Ἀγαθὸν ὄρνεον εἶ καὶ χρηστὸν τοῖς ἀνθρώποις· κατάϐηθι δὲ ὅπως ᾄσωμεν τὰς νυκτερινὰς ᾠδὰς καὶ συνευφρανθῶμεν ἀμφότεροι. » Ὁ δὲ ἀλέκτωρ ὑπολαϐὼν ἔφη αὐτῇ· « Ἄπελθε, φίλε, κάτωθεν πρὸς τὴν ῥίζαν τοῦ δένδρου καὶ φώνησον τὸν παραμονάριον, ὅπως κρούσῃ τὸ ξύλον. » Τῆς δὲ ἀλώπεκος ἀπελθούσης τοῦ φωνῆσαι αὐτόν, ὁ κύων ἄφνω πηδήσας καὶ τὴν ἀλώπεκα δραξάμενος, διεσπάραξεν αὐτήν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω καὶ τῶν ἀνθρώπων οἱ φρόνιμοι, ὁπόταν τι κακὸν αὐτοῖς ἐπέλθῃ, ῥᾴδίως πρὸς αὐτὸ ἀντιπαρατάσσονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 88 Ce 64 Cf 68 Mh 65.</p>
+          <bibl>Codd. Ca 88 Ce 64 Cf 68 Mh 65.</bibl>
         </div>
         <div>
           <head>Chambry 181.2</head>
@@ -4915,7 +4914,7 @@
           <pb ed="perry" n="P252"/>
           <p><milestone unit="recitprose"/>Κύων καὶ ἀλεκτρυὼν ἑταιρείαν ποιησάμενοι ὥδευον. Ἑσπέρας δὲ καταλαϐούσης, ὁ μὲν ἀλεκτρυὼν ἐπὶ δένδρου ἐκάθευδεν ἀναϐάς, ὁ δὲ κύων πρὸς τῇ ῥίζῃ τοῦ δένδρου κοίλωμα ἔχοντος. Τοῦ δὲ ἀλεκτρυόνος κατὰ τὸ εἰωθὸς νύκτωρ φωνήσαντος, ἀλώπηξ ἀκούσασα πρὸς αὐτὸν ἔδραμε καὶ στᾶσα κάτωθεν πρὸς ἑαυτὴν κατελθεῖν ἠξίου· ἐπιθυμεῖν γὰρ ἀγαθὴν οὕτω φωνὴν ζῷον ἔχον ἀσπάσασθαι. Τοῦ δὲ εἰπόντος τὸν θυρωρὸν πρότερον διυπνίσαι ὑπὸ τὴν ῥίζαν καθεύδοντα, ὡς, ἐκείνου ἀνοίξαντος, κατελθεῖν, κἀκείνης ζητούσης αὐτὸν φωνῆσαι, ὁ κύων αἴφνης πηδήσας αὐτὴν διεσπάραξεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ἀνθρώπων τοὺς ἐχθροὺς ἐπελθόντας πρὸς ἰσχυροτέρους πέμπουσι παραλογιζόμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 36 Lb 63 Le 63 Lf 36 Lh 26 Ma 177 Md 70 Me 78 Mf 69 Mg 87 Ml 81 Mm 84.</p>
+          <bibl>Codd. La 36 Lb 63 Le 63 Lf 36 Lh 26 Ma 177 Md 70 Me 78 Mf 69 Mg 87 Ml 81 Mm 84.</bibl>
           <p><milestone unit="traduction"/>Un chien et un coq ayant fait société allaient par chemins. Le soir venu, le coq monta sur un arbre pour y dormir, et le chien se coucha au pied de l’arbre qui était creux. Or le coq ayant, suivant son habitude, chanté avant le jour, un renard l’entendit, accourut et, s’arrêtant en bas de l’arbre, le pria de descendre vers lui ; car il désirait embrasser une bête qui avait une si belle voix. Le coq lui dit d’éveiller d’abord le portier qui dormait au pied de l’arbre : il descendrait, quand celui-ci aurait ouvert. Alors, comme le renard cherchait à parler au portier, le chien bondit brusquement et le mit en pièces.</p>
           <p><milestone unit="traduction"/>Cette fable montre que les gens sensés, quand leurs ennemis les attaquent, leur donnent le change en les adressant à de plus forts.</p>
         </div>
@@ -4926,7 +4925,7 @@
         <pb ed="perry" n="P253"/>
         <p><milestone unit="recitprose"/>Ὠά τις κύων καταπίνειν εἰθισμένος, ἰδών τινα κόχλον, χάνας τὸ στόμα αὐτοῦ, μεγίστῃ συνολκῇ καταπέπωκε τοῦτον, οἰηθεὶς ὠὸν εἶναι. Βαρούμενος δὲ τὰ σπλάγχνα καὶ ὀδυνώμενος ἔλεγε· « Δίκαια ἔγωγε πέπονθα, εἴγε πάντα περιφερῆ ὠὰ πεπίστευκα. »</p>
         <p><milestone unit="epimythiumprose"/>Διδάσκει ἡμᾶς ὁ λόγος ὅτι οἱ ἀδικάστως πρᾶγμα προσιόντες λανθάνουσιν ἑαυτοὺς περιπείροντες ἀτόποις.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ma 145.</p>
+        <bibl>Cod. Ma 145.</bibl>
         <p><milestone unit="traduction"/>Un chien habitué à avaler des œufs, voyant un coquillage, ouvrit la gueule et, refermant violemment ses mâchoires, l’avala, le prenant pour un œuf. Mais ses entrailles s’alourdissant, il eut mal et dit : « Je n’ai que ce que je mérite, moi qui ai pris tous les objets ronds pour des œufs. »</p>
         <p><milestone unit="traduction"/>Cette fable nous enseigne que ceux qui entreprennent une affaire sans discernement s’empêtrent à leur insu dans d’étranges embarras.</p>
       </div>
@@ -4938,7 +4937,7 @@
           <pb ed="perry" n="P136"/>
           <p><milestone unit="recitprose"/>Κύων θηρευτικὸς λαγωὸν συλλαϐών, τοῦτον ποτὲ μὲν ἔδακνε, ποτὲ δὲ αὐτοῦ τὰ χείλη περιέλειχεν. Ὁ δὲ ἀπαυδήσας ἔφη πρὸς αὐτόν· « Ἀλλ’, ὦ οὗτος, παῦσαί με καταδάκνων ἢ καταφιλῶν, ἵνα γνῶ πότερον ἐχθρὸς ἢ φίλος μου καθέστηκας. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ἀμφίϐολον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 129 Pb 135 Pg 88 Cd 71.</p>
+          <bibl>Codd. Pa 129 Pb 135 Pg 88 Cd 71.</bibl>
           <p><milestone unit="traduction"/>Un chien de chasse, ayant attrapé un lièvre, tantôt le mordait, tantôt lui léchait les babines. Le lièvre excédé lui dit : « Hé ! toi, cesse ou de me mordre ou de me baiser, afin que je sache si tu es mon ennemi ou mon ami. »</p>
           <p><milestone unit="traduction"/>Cette fable s’applique à l’homme équivoque.</p>
         </div>
@@ -4948,7 +4947,7 @@
           <pb ed="perry" n="P136"/>
           <p><milestone unit="recitprose"/>Κύων λαγωὸν διώξας ἐκράτησεν καὶ ποτὲ μὲν ἔδακνε, ποτὲ δὲ σαίνων προσέχαιρε καὶ ἐφίλει. Καὶ ὁ λαγωὸς εἶπεν· « Εἰ μὲν φίλος εἶ, τί δάκνεις ; εἰ δὲ ἐχθρός, τί σαίνεις οὐρήν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς τὸ ἦθος ἀνθρώποις παλίμϐουλον κεκτημένοις οὔτε ἀπιστεῖν ἔνεστι οὔτε πιστεύειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 68.</p>
+          <bibl>Cod. Ba 68.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-184">
@@ -4959,7 +4958,7 @@
           <pb ed="perry" n="P254"/>
           <p><milestone unit="recitprose"/>Κύων εἴς τι μαγειρεῖον εἰσελθών, τοῦ μαγείρου ἀσχοληθέντος, καρδίαν ἁρπάσας ἔφυγεν. Ὁ δὲ ἐπιστραφείς, ὡς ἐθεάσατο αὐτόν, εἶπεν· « Ἀλλ’, ὦ οὗτος, ὅπου ἂν ᾖς, φυλάξομαι σε· οὐ γὰρ ἀπ’ ἐμοῦ καρδίαν εἴληφας, ἀλλ’ ἐμοὶ καρδίαν δέδωκας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλάκις τὰ παθήματα τοῖς ἀνθρώποις μαθήματα γίνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 124 Pg 85 Mb 241 — Ce 61 Cf 65 Ch 67 Mh 60.</p>
+          <bibl>Codd. Pa 124 Pg 85 Mb 241 — Ce 61 Cf 65 Ch 67 Mh 60.</bibl>
         </div>
         <div>
           <head>Chambry 184.2</head>
@@ -4967,7 +4966,7 @@
           <pb ed="perry" n="P254"/>
           <p><milestone unit="recitprose"/>Κύων εἰσπηδήσας εἰς μαγειρεῖον καὶ, τοῦ μαγείρου ἀσχολουμένου, καρδίαν ἁρπάσας, ἔφυγεν. Ὁ δὲ μάγειρος ἐπιστραφείς, ὡς εἶδεν αὐτὸν φεύγοντα, εἶπεν· « Ὦ οὗτος, ἴσθι ὡς, ὅπουπερ ἂν ᾖς, φυλάξομαί σε· οὐ γὰρ ἀπ’ ἐμοῦ καρδίαν εἴληφας, ἀλλ’ ἐμοὶ καρδίαν ἔδωκας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις τὰ παθήματα τοῖς ἀνθρώποις μαθήματα γίνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 34 Lb 61 Lc 17 Ld 24 Le 61 Lf 34 Lg 17 Ma 172 Mc 56 Md 64 Me 76 Mf 67 Mg 85 Ml 79 Mm 78 Mn 24.</p>
+          <bibl>Codd. La 34 Lb 61 Lc 17 Ld 24 Le 61 Lf 34 Lg 17 Ma 172 Mc 56 Md 64 Me 76 Mf 67 Mg 85 Ml 79 Mm 78 Mn 24.</bibl>
           <p><milestone unit="traduction"/>Un chien, s’étant élancé dans une boucherie, y saisit un cœur, tandis que le boucher était occupé, et prit la fuite. Le boucher s’étant retourné et le voyant fuir, s’écria : « Toi, sache bien que, partout où tu seras, je te tiendrai à l’œil : car ce n’est pas à moi que tu as pris le cœur, bien au contraire tu m’en as donné. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent les accidents sont des enseignements pour les hommes.</p>
         </div>
@@ -4983,7 +4982,7 @@
           <l><milestone unit="recitvers"/>ἢν γὰρ ἐμοῦ καρδίαν δοκεῖς λαμϐάνειν,</l>
           <l><milestone unit="recitvers"/>ταύτην ἐγὼ ἔλαϐον διπλῆν ἐκ σοῦ γε. »</l>
           <p><milestone unit="epimythiumprose"/>Ἐκεῖνα μανθάνει τις ἅπερ μαθεῖν φέρει ἡ τύχη.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 58.</p>
+          <bibl>Cod. Cd 58.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-185">
@@ -4994,7 +4993,7 @@
           <pb ed="perry" n="P134"/>
           <p><milestone unit="recitprose"/>Κύων πρὸ ἐπαύλεώς τινος ἐκοιμᾶτο. Λύκος δὲ θεασάμενος καὶ συλλαϐὼν οἷός τε ἦν καταφαγεῖν. Ὁ δὲ αὐτοῦ ἐδεήθη πρὸς τὸ παρὸν μεθεῖναι αὐτόν, λέγων· « Νῦν μὲν λεπτός εἰμι καὶ ἰσχνός· μέλλουσι δέ μου οἱ δεσπόται γάμους ἄγειν· ἐὰν οὖν ἀφῇς με νῦν, ὕστερον λιπαρώτερον καταθοινήσῃ με. » Ὁ δὲ πεισθεὶς τότε μὲν ἀπέλυσε· μεθ’ ἡμέρας δὲ ὀλίγας ἐλθών, ὡς ἐθεάσατο αὐτὸν ἐπὶ τοῦ δώματος κοιμώμενον, ἐκάλει πρὸς αὑτὸν, ὑπομιμνῄσκων τῶν ὁμολογιῶν. Ὁ δὲ ὑποτυχὼν ἔφη· « Ἀλλ’, ὦ λύκε, ἐὰν αὖθίς με πρὸ τῆς ἐπαύλεως κοιμώμενον ἴδῃς, μηκέτι γάμους ἀναμείνῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ φρόνιμοι τῶν ἀνθρώπων, ὅταν περί τι κινδυνεύσαντες ἐκφύγωσι, ταῦτα εἰς ὕστερον φυλάσσονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 127 Pb 133 Pc 73 Pf 71 Pg 87 Mb 83 Mj 88.</p>
+          <bibl>Codd. Pa 127 Pb 133 Pc 73 Pf 71 Pg 87 Mb 83 Mj 88.</bibl>
         </div>
         <div>
           <head>Chambry 185.2</head>
@@ -5002,7 +5001,7 @@
           <pb ed="perry" n="P134"/>
           <p><milestone unit="recitprose"/>Κύων πρό τινος ἐπαύλεως ἐκοιμᾶτο. Λύκος δὲ τοῦτον θεασάμενος ἔδραμεν ἐπ’ αὐτόν, μέλλων αὐτὸν καταφαγεῖν. Ὁ δὲ κύων ἐδέετο αὐτοῦ ὅπως μὴ θύσῃ αὐτόν, λέγων· « Νῦν, ὦ κύριέ μου, μὴ φάγῃς με, ὅτι λεπτός εἰμι καὶ ἰσχνὸς καὶ πτωχός· μικρὸν δὲ ἀνάμεινόν με· μέλλουσι γὰρ οἱ ἐμοὶ δεσπόται γάμους ποιῆσαι, καὶ ἐὰν ἄρτι ἐάσῃς με, φαγὼν περισσότερον, λιπαρώτερος γενήσομαι καὶ τότε κρείττων τίς σοι φανήσομαι. » Ὁ δὲ πεισθεὶς τοῖς λόγοις αὐτοῦ τότε μὲν κατέλιπεν αὐτόν· μεθ’ ἡμέρας δὲ ὀλίγας ἐλθὼν ἐζήτει αὐτὸν καὶ εὑρίσκει αὐτὸν ἐπὶ τοῦ δώματος κοιμώμενον. Ὁ δὲ σταθεὶς κάτω ἐπεκαλεῖτο αὐτόν, ὑπομιμνῄσκων αὐτὸν τῶν συνθηκῶν. Ὑπολαϐὼν δὲ ὁ κύων ἔφη αὐτῷ· « Ὦ λύκε, ἐὰν ἀπὸ τοῦ νῦν πρὸ τῆς ἐπαύλεως ἴδῃς με, μηκέτι γάμους ἀναμείνῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω οἱ φρόνιμοι τῶν ἀνθρώπων, ὅταν περί τι κινδυνεύσαντες ἐκφύγωσιν, ὕστερον ταῦτα φυλάττονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 86 Cb 59 Ce 62 Cf 66 Ch 68 Mc 59 Mh 61 Mk 61.</p>
+          <bibl>Codd. Ca 86 Cb 59 Ce 62 Cf 66 Ch 68 Mc 59 Mh 61 Mk 61.</bibl>
         </div>
         <div>
           <head>Chambry 185.3</head>
@@ -5010,7 +5009,7 @@
           <pb ed="perry" n="P134"/>
           <p><milestone unit="recitprose"/>Κύων πρὸ ἐπαύλεώς τινος ἐκάθευδε. Λύκου δ’ ἐπιδραμόντος καὶ βρῶμα μέλλοντος θήσειν αὐτὸν, ἐδεῖτο μὴ νῦν αὐτὸν καταθῦσαι. « Νῦν μὲν γάρ, φησί, λεπτός εἰμι καὶ ἰσχνός· ἂν δὲ μικρὸν ἀναμείνῃς, μέλλουσιν οἱ ἐμοὶ δεσπόται ποιήσειν γάμους, κἀγὼ τηνικαῦτα πολλὰ φαγὼν πιμελέστερος ἔσομαι, καὶ σοὶ ἡδύτερον βρῶμα γενήσομαι. » Ὁ μὲν οὖν λύκος πεισθεὶς ἀπῆλθε· μεθ’ ἡμέρας δ’ ἐπανελθὼν εὗρεν ἄνω ἐπὶ τοῦ δώματος τὸν κύνα καθεύδοντα, καὶ στὰς κάτωθεν πρὸς ἑαυτὸν ἐκάλει, ὑπομιμνῄσκων αὐτὸν τῶν συνθηκῶν. Καὶ ὁ κύων· « Ἀλλ’, ὦ λύκε, εἰ τὸ ἀπὸ τοῦδε πρὸ τῆς ἐπαύλεώς με ἴδοις καθεύδοντα, μηκέτι γάμους ἀναμείνῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ἀνθρώπων, ὅταν περί τι κινδυνεύσαντες σωθῶσι, διὰ βίου τοῦτο φυλάττονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 35 Lb 62 Lc 44 Le 62 Lf 35 Lg 44 Lh 25 Ma 173 Md 65 Me 77 Mf 68 Mg 86 Ml 80 Mm 79.</p>
+          <bibl>Codd. La 35 Lb 62 Lc 44 Le 62 Lf 35 Lg 44 Lh 25 Ma 173 Md 65 Me 77 Mf 68 Mg 86 Ml 80 Mm 79.</bibl>
           <p><milestone unit="traduction"/>Un chien dormait devant une ferme. Un loup fondit sur lui, et il allait faire de lui son repas, quand le chien le pria de ne pas l’immoler tout de suite : « À présent, dit-il, je suis mince et maigre ; mais attends quelque temps : mes maîtres vont célébrer des noces ; moi aussi j’y prendrai de bonnes lippées, j’engraisserai et je serai pour toi un manger plus agréable. » Le loup le crut et s’en alla. À quelque temps de là il revint, et trouva le chien endormi dans une pièce haute de la maison ; il s’arrêta en bas et l’appela, lui rappelant leurs conventions. Alors le chien : « Ô loup, dit-il, si à partir d’aujourd’hui tu me vois dormir devant la ferme, n’attends plus de noces »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes sensés, quand ils se sont tirés d’un danger, s’en gardent toute leur vie.</p>
         </div>
@@ -5039,7 +5038,7 @@
           <l><milestone unit="recitvers"/>πρὸς ἔπαυλιν εὕδοντα ἐφεύρῃς, φίλε,</l>
           <l><milestone unit="recitvers"/>μηδαμῶς ἀναμείνῃς δεσπότου γάμους. »</l>
           <l><milestone unit="epimythiumenvers"/>Ὁ αὔριον ὄρνις τοῦ σήμερον κρεῖττον.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 59.</p>
+          <bibl>Cod. Cd 59.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-186">
@@ -5050,7 +5049,7 @@
           <pb ed="perry" n="P133"/>
           <p><milestone unit="recitprose"/>Κύων κρέας ἔχουσα ποταμὸν διέϐαινε· θεασαμένη δὲ τὴν ἑαυτῆς σκιὰν κατὰ τοῦ ὕδατος, ὑπέλαϐεν ἑτέραν κύνα εἶναι μεῖζον κρέας ἔχουσαν. Διόπερ ἀφεῖσα τὸ ἴδιον ὥρμησεν ὡς τὸ ἐκείνης ἀφαιρησομένη. Συνέϐη δὲ αὐτῇ ἀμφοτέρων στερηθῆναι, τοῦ μὲν μὴ ἐφικομένῃ, διότι οὐδὲ ἦν, τοῦ δὲ, ὅτι ὑπὸ τοῦ ποταμοῦ παρεσύρη.</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα πλεονέκτην ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 132 Pa 126 Pc 72 Ma 92.</p>
+          <bibl>Codd. Pb 132 Pa 126 Pc 72 Ma 92.</bibl>
           <p><milestone unit="traduction"/>Un chien tenant un morceau de viande traversait une rivière. Ayant aperçu son ombre dans l’eau, il crut que c’était un autre chien qui tenait un morceau de viande plus gros. Aussi, lâchant le sien, il s’élança pour enlever celui de son compère. Mais le résultat fut qu’il n’eut ni l’un ni l’autre, l’un se trouvant hors de ses prises, puisqu’il n’existait même pas, et l’autre ayant été entraîné par le courant.</p>
           <p><milestone unit="traduction"/>Cette fable s’applique au convoiteux.</p>
         </div>
@@ -5060,7 +5059,7 @@
           <pb ed="perry" n="P133"/>
           <p><milestone unit="recitprose"/>Κύων κρέας φέρων ποταμὸν διέϐαινε· θεασάμενος δὲ τὴν ἑαυτοῦ σκιὰν κατὰ τοῦ ὕδατος ὑπέλαϐεν ἕτερον κύνα εἶναι μεῖζον κρέας κατέχοντα, καὶ ἀφεὶς τὸ ἴδιον ὥρμησεν τὸ ἐκείνου λαϐεῖν. Συνέϐη δὲ αὐτὸν ἀπολέσαι ἀμφότερα, τὸ μὲν, διότι οὐδὲ ἦν, ὅτι ὃ κατεῖχεν ὑπὸ τοῦ ῥεύματος κατεσύρη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ πλειόνων ἐπιθυμοῦντες καὶ ἃ ἔχουσιν ἀπόλλουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 71 Cb 61 Ce 63 Cf 67 Mc 61 Md 69 Ml 93 Mm 83.</p>
+          <bibl>Codd. Ch 71 Cb 61 Ce 63 Cf 67 Mc 61 Md 69 Ml 93 Mm 83.</bibl>
         </div>
         <div>
           <head>Chambry 186.3</head>
@@ -5068,7 +5067,7 @@
           <pb ed="perry" n="P133"/>
           <p><milestone unit="recitprose"/>Κύων κρέας ἔφερεν εἰς τὸ ποιῆσαι δεῖπνον· σκιὰν δὲ τὴν αὐτοῦ ἰδὼν εἰς ποταμὸν ἑστῶσαν, κρέας φέρουσαν κἀκείνην ὡς καὶ αὐτός, ῥίψας τὸ οἰκεῖον ἐγύρευε τὸ ξένον· καὶ ῥεῦμα τούτου προσέσυρε τὸ κρέας· τὸ δ’ ἄλλο ἠφάνισται, καὶ γὰρ οὐκ ἦν γε· ἀμφότερα γὰρ παρέσυρε τὸ ῥεῦμα.</p>
           <p><milestone unit="epimythiumprose"/>Τοῦτο παρίστησι σαφῶς ὡς ὁ λιχνεύων τὸ μέγιστον χαίνει καὶ τὸ ἧττον, καὶ ὁ θέλων πλεῖστα ἐσθίειν χαίνει καὶ τὰ μικρὰ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 62.</p>
+          <bibl>Cod. Cd 62.</bibl>
         </div>
         <div>
           <head>Chambry 186.4</head>
@@ -5076,7 +5075,7 @@
           <pb ed="perry" n="P133"/>
           <p><milestone unit="recitprose"/>Κύων ἐκ μαγειρείου κρέας κλέψας ποταμὸν διεπέρα· τὴν δὲ σκιὰν τοῦ κρέατος μείζω ἰδών, εἰς τὸ ὕδωρ ἐφῆκε τὸ κρέας καὶ τῇ σκιᾷ ἐπέδραμεν· κἀκείνης μὲν ἠστόχησε, προσαπώλεσε δὲ καὶ τὸ κρέας ὃ εἶχεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὁ τοῦ ἀπλήστου ἀνδρὸς βίος ταῖς ματαίαις ἐλπίσι καὶ ἀϐεϐαίοις ἀναλοῦται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 66 Bb 42.</p>
+          <bibl>Codd. Ba 66 Bb 42.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-187">
@@ -5087,7 +5086,7 @@
           <pb ed="perry" n="P332"/>
           <p><milestone unit="recitprose"/>Λάθρᾳ κύων ἔδακνε. Τούτῳ δὲ ὁ δεσπότης κώδωνα ἐκρέμασεν, ὥστε πρόδηλον εἶναι τοῖς πᾶσι. Οὗτος δὲ τὸν κώδωνα σείων ἐν τῇ ἀγορᾷ ἠλαζονεύετο. Γραῦς δὲ κύων εἶπεν αὐτῷ· « Τί φαντάζῃ ; οὐ δι’ ἀρετὴν τοῦτον φορεῖς, ἀλλὰ δι’ ἔλεγχον τῆς κεκρυμμένης σου κακίας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ τῶν ἀλαζόνων κενόδοξοι τρόποι πρόδηλοί εἰσι δηλοῦντες τὴν ἀφανῆ κακίαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 71 Bb 45 Mb 84.</p>
+          <bibl>Codd. Ba 71 Bb 45 Mb 84.</bibl>
           <p><milestone unit="traduction"/>Un chien mordait à la sourdine. Son maître lui pendit une sonnette, pour le signaler à tout le monde. Or lui, secouant sa sonnette, faisait le glorieux sur la place publique. Une vieille chienne lui dit : « Qu’as-tu à te pavaner ? Ce n’est point à cause de ta vertu que tu portes cette sonnette, mais bien pour dénoncer ta méchanceté cachée. »</p>
           <p><milestone unit="traduction"/>Les manières glorieuses des fanfarons laissent voir visiblement leur méchanceté secrète.</p>
         </div>
@@ -5096,7 +5095,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P332"/>
           <p><milestone unit="recitprose"/>Λάθρᾳ κύων ἔδακνε τοὺς ἐντυγχάνοντας. Ὥστε δὲ εἶναι τοῦτον διάδηλον, &lt;ὁ δεσπότης&gt; κώδωνα ἐπὶ τοῦ τραχήλου ἐκρέμασε. Αὐτὸς δὲ ἐπὶ τούτῳ ἠλαζονεύετο. Γέρων δὲ κύων αὐτὸν ἰδὼν ἔφη· « Ὦ μάταιε, τί ἐπὶ τούτῳ μέγα κομπάζεις ; οὐ γὰρ δι’ ἀρετὴν τοῦτον φέρεις, ἀλλὰ δι’ ἔλεγχον τῆς κεκρυμμένης σου κακίας. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 36.</p>
+          <bibl>Cod. Bd 36.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-188">
@@ -5107,7 +5106,7 @@
           <pb ed="perry" n="P132"/>
           <p><milestone unit="recitprose"/>Κύων θηρευτικὸς λέοντα ἰδών, τοῦτον ἐδίωκεν. Ὡς δὲ ἐπιστραφεὶς ὁ λέων ἐϐρυχήσατο, φοϐηθεὶς εἰς τοὐπίσω ἔφυγεν. Ἀλώπηξ δὲ θεασαμένη αὐτὸν ἔφη· « Ὦ κακὴ κεφαλή, σὺ λέοντα ἐδίωκες, οὗ οὐδὲ τὸν βρυχηθμὸν ὑπέμεινας ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος λεχθείη ἂν ἐπ’ ἀνδρῶν αὐθάδων οἳ κατὰ πολὺ δυνατωτέρων συκοφαντεῖν ἐπιχειροῦντες, ὅταν ἐκεῖνοι ἀντιστῶσιν, εὐθέως ἀναχαιτίζουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 125 Pb 131 Pc 71 Pf 70 Pg 86 Ma 175 Mb 82 Md 67 Me 94 Mf 79 Mh 63 Mj 87 Mm 81 Ch 70.</p>
+          <bibl>Codd. Pa 125 Pb 131 Pc 71 Pf 70 Pg 86 Ma 175 Mb 82 Md 67 Me 94 Mf 79 Mh 63 Mj 87 Mm 81 Ch 70.</bibl>
           <p><milestone unit="traduction"/>Un chien de chasse, ayant aperçu un lion, s’était mis à sa poursuite. Mais le lion se retourna et se mit à rugir. Alors le chien eut peur et rebroussa chemin. Un renard le vit et lui dit : « Pauvre sire, tu poursuivais le lion, et tu n’as même pas pu supporter son rugissement. »</p>
           <p><milestone unit="traduction"/>On pourrait conter cette fable à propos des présomptueux qui se mêlent de dénigrer des gens plus puissants qu’eux, et qui se rejettent brusquement en arrière, quand ceux-ci leur font tête.</p>
         </div>
@@ -5121,7 +5120,7 @@
           <l><milestone unit="recitvers"/>Τοῦτον δ’ ἀλώπηξ προσιδοῦσ’ ἐπεφώνει·</l>
           <l><milestone unit="recitvers"/>« Πῶς σὺ διώκεις οὗ τὴν φωνὴν οὐ φέρεις ; »</l>
           <p><milestone unit="epimythiumprose"/>Ἄφρων δ’ ὃς ἐθέλει πρὸς κρείττονας ἀντιφερίζειν· νίκης τε στέρεται &lt;καὶ&gt; πρὸς τούτοις γελοῖα πάσχει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 61.</p>
+          <bibl>Cod. Cd 61.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-189">
@@ -5129,7 +5128,7 @@
         <head type="sub">Κώνωψ καὶ λέων — Le cousin et le lion.</head>
         <pb ed="perry" n="P255"/>
         <p><milestone unit="recitprose"/>Κώνωψ πρὸς λέοντα ἐλθὼν εἶπεν· « Οὔτε φοϐοῦμαί σε, οὔτε δυνατώτερός μου εἶ· εἰ δὲ μή, τί σοί ἐστιν ἡ δύναμις ; ὅτι ξύεις τοῖς ὄνυξι καὶ δάκνεις τοῖς ὀδοῦσι ; τοῦτο καὶ γυνὴ τῷ ἀνδρὶ μαχομένη ποιεῖ. Ἐγὼ δὲ λίαν ὑπάρχω σου ἰσχυρότερος. Εἰ δὲ θέλεις, ἔλθωμεν καὶ εἰς πόλεμον. » Καὶ σαλπίσας ὁ κώνωψ ἐνεπήγετο, δάκνων τὰ περὶ τὰς ῥίνας αὐτοῦ ἄτριχα πρόσωπα. Καὶ ὁ λέων τοῖς ἰδίοις ὄνυξι κατέλυεν ἑαυτόν, ἕως ἀπηύδησεν. Ὁ δὲ κώνωψ νικήσας τὸν λέοντα, σαλπίσας καὶ ἐπινίκιον ᾄσας, ἔπτατο· καὶ ἀράχνης δεσμῷ ἐμπλακεὶς ἐσθιόμενος ἀπωδύρετο πῶς μεγίστοις πολεμῶν ὑπό εὐτελοῦς ζῴου, τῆς ἀράχνης, ἀπώλετο.</p>
-        <p><milestone unit="manuscrits"/>Cod. T 6.</p>
+        <bibl>Cod. T 6.</bibl>
         <p><milestone unit="traduction"/>Un cousin s’approcha d’un lion et lui dit : « Je n’ai pas peur de toi, et tu n’es pas plus puissant que moi. Si tu prétends le contraire, montre de quoi tu es capable. Est-ce d’égratigner avec tes griffes et de mordre avec tes dents ? Une femme même qui se bat avec son mari en fait autant. Moi, je suis beaucoup plus fort que toi ; si tu veux, je te provoque même au combat. » Et, sonnant de la trompe, le cousin fondit sur lui, mordant le museau dépourvu de poil autour des narines. Quant au lion, il se déchirait de ses propres griffes, jusqu’à ce qu’il renonça au combat. Le cousin, ayant vaincu le lion, sonna de la trompe, entonna un chant de victoire, et prit son essor. Mais il s’empêtra dans une toile d’araignée, et, se sentant dévorer, il gémissait, lui qui faisait la guerre aux plus puissants, de périr par le fait d’un vil animal, une araignée.</p>
       </div>
       <div type="poem" xml:id="chambry-190">
@@ -5140,7 +5139,7 @@
           <pb ed="perry" n="P137"/>
           <p><milestone unit="recitprose"/>Κώνωψ ἐπιστὰς κέρατι ταύρου καὶ πολὺν χρόνον ἐπικαθίσας, ἐπειδὴ ἀπαλλάττεσθαι ἔμελλεν, ἐπυνθάνετο τοῦ ταύρου εἰ ἤδη βούλεται αὐτὸν ἀπελθεῖν. Ὁ δὲ ὑποτυχὼν εἶπεν· « Ἀλλ’ οὔτε, ὅτε ἦλθες, ἔγνων, οὔτε, ἐὰν ἀπέλθῃς, γνώσομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα ἀδύνατον, ὃς οὔτε παρὼν οὔτε ἀπὼν ἐπιϐλαϐὴς ἢ ὠφέλιμός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 130 Pb 136 Pc 75.</p>
+          <bibl>Codd. Pa 130 Pb 136 Pc 75.</bibl>
           <p><milestone unit="traduction"/>Un cousin s’était posé sur la corne d’un taureau. Après y être resté longtemps, comme il allait partir, il demanda au taureau s’il désirait qu’enfin il s’en allât. Le taureau répondit : « Quand tu es venu, je ne t’ai pas senti, et quand tu t’en iras, je ne te sentirai pas non plus. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à l’homme impuissant dont ni la présence ni l’absence ne peuvent nuire ou servir.</p>
         </div>
@@ -5150,7 +5149,7 @@
           <pb ed="perry" n="P137"/>
           <p><milestone unit="recitprose"/>Κώνωψ ἐπὶ κέρατος βοὸς ἐκαθέσθη καὶ ηὔλει. Εἶπε δὲ πρὸς τὸν βοῦν· « Εἰ βαρῶ σου τὸν τένοντα, ἀναχωρήσω. » Ὁ δὲ ἔφη· « Οὔτε, ὅτε ἦλθες, ἔγνων, οὔτε, ἐὰν μένῃς, μελήσει μοι. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς εὐτελεῖς καὶ ἀδόξους [καὶ] μαχομένους τυράννοις ἔλέγχει ὁ μῦθος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 70 Bb 44 Bd 35.</p>
+          <bibl>Codd. Ba 70 Bb 44 Bd 35.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-191">
@@ -5161,7 +5160,7 @@
           <pb ed="perry" n="P256"/>
           <p><milestone unit="recitprose"/>Λαγωοί ποτε πολεμοῦντες ἀετοῖς παρεκάλουν εἰς συμμαχίαν ἀλώπεκας. Αἱ δὲ ἔφησαν· « Ἐϐοηθήσαμεν ἂν ὑμῖν, εἰ μὴ ᾔδειμεν τίνες ἐστὲ καὶ τίσι πολεμεῖτε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φιλονεικοῦντες τοῖς κρείττοσι τῆς ἑαυτῶν σωτηρίας καταφρονοῦσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 157 Pb 160 Ca 108 — La 111 Lb 79 Le 79 Lf 111 Lh 36 Mg 104 Ml 99.</p>
+          <bibl>Codd. Pa 157 Pb 160 Ca 108 — La 111 Lb 79 Le 79 Lf 111 Lh 36 Mg 104 Ml 99.</bibl>
           <p><milestone unit="traduction"/>Les lièvres un jour, étant en guerre avec les aigles, appelèrent à leur secours les renards. Ceux-ci répondirent : « Nous serions venus à votre aide, si nous ne savions qui vous êtes, et qui vous combattez. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui se mettent en lutte avec de plus puissants font fi de leur salut.</p>
         </div>
@@ -5171,7 +5170,7 @@
           <pb ed="perry" n="P256"/>
           <p><milestone unit="recitprose"/>Λαγωοί ποτε παρατασσόμενοι ἀετοὺς πολεμῆσαι παρεκάλουν ἐλθεῖν εἰς συμμαχίαν αὐτῶν ἀλώπεκας. Αἱ δὲ εἶπον· « Ἐϐοηθήσαμεν ἂν ὑμῖν, εἰ μὴ ᾔδειμεν τίνες ἦτε καὶ τίσιν ἐπολεμεῖτε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ μαχόμενοι τοῖς κρείττοσι τῆς ἑαυτῶν σωτηρίας καταφρονοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 73 Me 96 Mf 81 Mj 90.</p>
+          <bibl>Codd. Pf 73 Me 96 Mf 81 Mj 90.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-192">
@@ -5182,7 +5181,7 @@
           <pb ed="perry" n="P138"/>
           <p><milestone unit="recitprose"/>Λαγωοὶ καταγνόντες τῆς ἑαυτῶν δειλίας ἔγνωσαν δεῖν ἑαυτοὺς κατακρημνίσαι. Παραγενομένων δὲ αὐτῶν ἐπί τινα κρημνόν, ᾧ λίμνη ὑπέκειτο, ἐνταῦθα βάτραχοι ἀκούσαντες τῆς ποδοψοφίας αὑτοὺς εἰς τὰ βαθῆ τῆς λίμνης ἐδίδοσαν. Εἷς δέ τις τῶν λαγωῶν θεασάμενος αὐτοὺς ἔφη πρὸς αὐτούς· « Ἀλλὰ μηκέτι ἑαυτοὺς κατακρημνίσωμεν· ἰδοῦ γὰρ εὕρηνται καὶ ἡμῶν δειλότερα ζῷα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τοῖς ἀνθρώποις αἱ τῶν ἄλλων συμφοραὶ τῶν ἰδίων δυστυχημάτων παραμυθίαι γίνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 133 Pb 137 Pc 76 Pg 91 Ma 93 Ca 89.</p>
+          <bibl>Codd. Pa 133 Pb 137 Pc 76 Pg 91 Ma 93 Ca 89.</bibl>
         </div>
         <div>
           <head>Chambry 192.2</head>
@@ -5205,7 +5204,7 @@
           <l><milestone unit="recitvers"/>ὡς γὰρ ὁρᾶτε, δειλότερα τυγχάνει</l>
           <l><milestone unit="recitvers"/>ταῦτα τὰ ζῷα πλέον ἡμῶν ἁπάντων. »</l>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ μῦθος δηλοῖ ὅτι τοῖς δυστυχοῦσιν οὐ τὴν τυχοῦσαν παρηγορίαν φέρει τὸ καὶ ἑτέρους ὁρᾶν κακοπαθοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 23 Ch 98 Ca 150 Cb 80 Ce 89 Cf 94 Mc 78.</p>
+          <bibl>Codd. Cg 23 Ch 98 Ca 150 Cb 80 Ce 89 Cf 94 Mc 78.</bibl>
         </div>
         <div>
           <head>Chambry 192.3</head>
@@ -5225,7 +5224,7 @@
           <l><milestone unit="recitvers"/>« Στῆτε, ἀδελφοί, μηδὲν κακὸν ποιοῦντες·</l>
           <l><milestone unit="recitvers"/>ἰδοῦ καὶ γένος ἄλλον ἡμᾶς δειμαίνει. »</l>
           <p><milestone unit="epimythiumprose"/>Τοῦτο οὕτως λέγει· οἱ πτωχοὶ καὶ ἀδύνατοι ἀνθρώποι αἱροῦνται μᾶλλον θανεῖν ἢ καταφρονεῖσθαι· ἐπὰν δέ τινας ἴδωσιν αὐτῶν ἐπιδεομένους, οὐκέτι μέμνηνται τοῦ θανάτου.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 97.</p>
+          <bibl>Cod. Cd 97.</bibl>
         </div>
         <div>
           <head>Chambry 192.4</head>
@@ -5233,7 +5232,7 @@
           <pb ed="perry" n="P138"/>
           <p><milestone unit="recitprose"/>Οἱ λαγωοί ποτε συνελθόντες τὸν ἑαυτῶν πρὸς ἀλλήλους ἀπεκλαίοντο βίον ὡς ἐπισφαλὴς εἴη καὶ δειλίας πλέως· καὶ γὰρ καὶ ὑπ’ ἀνθρώπων καὶ κυνῶν καὶ ἀετῶν καὶ ἄλλων πολλῶν ἀναλίσκονται· βέλτιον οὖν εἶναι θανεῖν ἅπαξ ἢ διὰ βίου τρέμειν. Τοῦτο τοίνυν κυρώσαντες, ὥρμησαν κατὰ ταὐτὸν εἰς τὴν λίμνην, ὡς εἰς αὐτὴν ἐμπεσούμενοι καὶ ἀποπνιγησόμενοι. Τῶν δὲ καθημένων κύκλῳ τῆς λίμνης βατράχων, ὡς τὸν τοῦ δρόμου κτύπον ᾔσθοντο, εὐθὺς εἰς ταύτην εἰσπηδησάντων, τῶν λαγωῶν τις ἀγχινούστερος εἶναι δοκῶν τῶν ἄλλων ἔφη· « Στῆτε, ἑταῖροι, μηδὲν δεινὸν ὑμᾶς αὐτοὺς διαπράξησθε· ἤδη γάρ, ὡς ὁρᾶτε, καὶ ἡμῶν ἕτερ’ ἐστὶ ζῷα δειλότερα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ δυστυχοῦντες ἐξ ἑτέρων χείρονα πασχόντων παραμυθοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 57 Lb 95 Le 95 Lf 57 Lh 47 Me 144 Mf 119 Mg 119 Mj 118 Ml 123.</p>
+          <bibl>Codd. La 57 Lb 95 Le 95 Lf 57 Lh 47 Me 144 Mf 119 Mg 119 Mj 118 Ml 123.</bibl>
           <p><milestone unit="traduction"/>Les lièvres s’étant un jour assemblés se désolaient entre eux d’avoir une vie si précaire et pleine de crainte : n’étaient-ils pas en effet la proie des hommes, des chiens, des aigles et de bien d’autres animaux ? Il valait donc mieux périr une bonne fois que de vivre dans la terreur. Cette résolution prise, ils s’élancent en même temps vers l’étang, pour s’y jeter et s’y noyer. Mais les grenouilles, accroupies autour de l’étang, n’eurent pas plus tôt perçu le bruit de leur course qu’elles sautèrent dans l’eau. Alors un des lièvres, qui paraissait être plus fin que les autres, dit : « Arrêtez, camarades ; ne vous faites pas de mal ; car, vous venez de le voir, il y a des animaux plus peureux encore que nous. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les malheureux se consolent en voyant des gens plus malheureux qu’eux.</p>
         </div>
@@ -5243,7 +5242,7 @@
           <pb ed="perry" n="P138"/>
           <p><milestone unit="recitprose"/>Οἱ λαγωοὶ πάντες εἰς ἓν συνελθόντες εἶπον· « Ἀϐίωτός ἐστιν ἡμῶν ὁ βίος· καὶ γὰρ ἀετοὶ καὶ κύνες καὶ ἄνδρες ἡμᾶς καταπονοῦσιν· βέλτιον οὖν ἐστιν ἡμᾶς ῥῖψαι ἑαυτοὺς ἐν τῇ πλησίον λίμνῃ καὶ διαφθαρῆναι. » Ταῦτα εἰπόντες ἀπῄεσαν. Οἱ δὲ ἐπὶ τῆς ὄχθης καὶ τοῦ χείλους τῆς λίμνης βάτραχοι τούτους ἰδόντες ἔρριψαν ἑαυτοὺς ἐν τῇ λίμνῃ ἐκ τοῦ φόϐου. Εἷς δέ τις γερὼν λαγωὸς ἔφη· « Στῆτε, καὶ μὴ ἀπογνῶμεν ἑαυτῶν· εἰσὶ γάρ, ὡς ὁρᾶτε, καὶ ὑπὲρ ἡμᾶς ἄλλοι δειλότεροι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁτι τοῖς δυστυχοῦσιν οὐ τὴν τυχοῦσαν παραμυθίαν φέρει τὸ καὶ ἑτέρους χείρονα παθόντας ὁρᾶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 101 Bb 62.</p>
+          <bibl>Codd. Ba 101 Bb 62.</bibl>
         </div>
         <div>
           <head>Chambry 192.6</head>
@@ -5251,7 +5250,7 @@
           <pb ed="perry" n="P138"/>
           <p><milestone unit="recitprose"/>Οἱ λαγωοὶ συναχθέντες ἑαυτοῖς εἶπον· « Ἀϐίωτός ἐστιν ἡμῶν ὁ βίος· καὶ γὰρ ἀετοὶ καὶ κύνες τε καὶ ἄνδρες ὡς οὐδὲν πάντες καταπονοῦσιν ἡμᾶς. Βέλτιόν ἐστιν ἡμᾶς ῥῖψαι ἐν τῇ λίμνῃ καὶ πνιγῆναι. » Ταῦτ’ οὖν εἰπόντες ἀπῄεσαν ἐν λίμνῃ. Οἱ δὲ ἐπὶ ταῖς ὄχθαις τῆς λίμνης βάτραχοι τούτους ἰδόντες ἔρριψαν αὑτοὺς ἐν λίμνῃ ἐκ τοῦ φόϐου. Εἷς δέ τις γέρων λαγωὸς ἔφη πρὸς τοὺς ἑτέρους· « Στῆτε, φίλοι, καὶ μὴ ἑαυτοὺς ἀποπνίξωμεν· εἰσὶ γὰρ καὶ ἄλλα ζῷα, ὡς ὁρᾶτε, δειλότερα ἡμῶν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ ἑαυτὸν ἀπογινώσκειν δι’ εὐτέλειαν σώματος ἢ πλούτου, ἀλλὰ πανηγορεῖν ἑαυτόν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Md 88 Mh 80 Mi 4 Mm 106.</p>
+          <bibl>Codd. Md 88 Mh 80 Mi 4 Mm 106.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-193">
@@ -5260,7 +5259,7 @@
         <pb ed="perry" n="P333"/>
         <p><milestone unit="recitprose"/>Ὁ λαγωὸς τῇ ἀλώπεκι· « Ὄντως πολλὰ κερδαίνεις ἢ ἔχεις ὅτι ὄνομά σοι κερδώ ἐστιν ; » Ἡ δὲ ἀλώπηξ· « Εἰ ἀπιστεῖς, ἔφη, δεῦρο· ἐγὼ ἑστιῶ σε. » Ὁ δὲ ἠκολούθει καὶ ἦν ἔνδον οὐδὲν ἢ ὁ λαγωὸς δεῖπνος τῇ ἀλώπεκι. Ὁ δὲ λαγωὸς ἔφη· « Σὺν κακῷ μέν, ἀλλ’ ἔμαθόν σου τὸ ὄνομα πόθεν ἐστί, οὐκ ἀπὸ τοῦ κερδαίνειν, ἀλλ’ ἀπὸ τοῦ δολοῦν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς περιέργοις πολλάκις μέγιστον κακὸν συνέϐη κακῶς τῇ περιεργείᾳ χρωμένοις.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 100.</p>
+        <bibl>Cod. Ba 100.</bibl>
         <p><milestone unit="traduction"/>Le lièvre dit au renard : « Fais-tu réellement beaucoup de profits, et peux-tu dire pourquoi on t’appelle le « profiteur ? » — Si tu en doutes, répondit le renard, viens chez moi, je t’offre à dîner. » Le lièvre le suivit. Or à l’intérieur le renard n’avait rien à dîner que le lièvre. Le lièvre lui dit : « J’apprends pour mon malheur, mais enfin j’apprends d’où te vient ton nom : ce n’est pas de tes gains, mais de tes ruses. »</p>
         <p><milestone unit="traduction"/>Il arrive souvent de grands malheurs aux curieux qui s’abandonnent à leur maladroite indiscrétion.</p>
       </div>
@@ -5270,7 +5269,7 @@
         <pb ed="perry" n="P139"/>
         <p><milestone unit="recitprose"/>Λάρος ἰχθὺν καταπιών, διαρραγέντος αὐτῷ τοῦ φάρυγγος, ἐπὶ τῆς ἠϊόνος νεκρὸς ἔκειτο. Ἰκτῖνος δὲ αὐτὸν θεασάμενος ἔφη· « Ἄξια σύ γε πέπονθας, ὅτι πτηνὸν γεννηθεὶς ἐπὶ θαλάσσης τὴν δίαιταν ἐποιοῦ. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τὰ οἰκεῖα ἐπιτηδεύματα καταλιπόντες καὶ τοῖς μηδὲν προσήκουσιν ἐπιϐαλλόμεμοι εἰκότως δυστυχοῦσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 134 Pf 74 Ca 112 Me 97 Mj 91.</p>
+        <bibl>Codd. Pa 134 Pf 74 Ca 112 Me 97 Mj 91.</bibl>
         <p><milestone unit="traduction"/>Une mouette ayant avalé un poisson, son gosier éclata et elle resta étendue morte sur le rivage. Un milan, l’ayant aperçue, dit : « Tu n’as que ce que tu mérites, puisque, née oiseau, tu cherchais ta vie sur la mer. »</p>
         <p><milestone unit="traduction"/>Ainsi les gens qui abandonnent leur propre métier pour en prendre un qui n’est pas le leur sont justement malheureux.</p>
       </div>
@@ -5282,7 +5281,7 @@
           <pb ed="perry" n="P257"/>
           <p><milestone unit="recitprose"/>Λέαινα ὀνειδιζομένη ὑπὸ ἀλώπεκος ἐπὶ τῷ διὰ παντὸς ἕνα τίκτειν· « Ἕνα, ἔφη, ἀλλὰ λέοντα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τὸ καλὸν οὐκ ἐν πλήθει δεῖ μετρεῖν, ἀλλὰ πρὸς ἀρετὴν ἀφορᾶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 158 Ma 106 Mb 103 Ml 103 — Ca 106 Cb 67 Ce 76 Cf 80 Cg 5 Ch 80.</p>
+          <bibl>Codd. Pb 158 Ma 106 Mb 103 Ml 103 — Ca 106 Cb 67 Ce 76 Cf 80 Cg 5 Ch 80.</bibl>
           <p><milestone unit="traduction"/>Un renard reprochait à une lionne de ne jamais mettre au monde qu’un seul petit. « Un seul, dit-elle, mais un lion. »</p>
           <p><milestone unit="traduction"/>Il ne faut pas mesurer le mérite sur la quantité, mais avoir égard à la vertu.</p>
         </div>
@@ -5297,7 +5296,7 @@
           <l><milestone unit="recitvers"/>« Ἕνα μὲν σκύμνον ἡ &lt;ἐμὴ&gt; μήτηρ τίκτει,</l>
           <l><milestone unit="recitvers"/>ἀλλὰ λέοντά &lt;γε&gt;, ὡς νῦν ἐμὲ βλέπεις. »</l>
           <l><milestone unit="epimythiumenvers"/>Πρὸς τοὺς ὀλίγα πράττοντας, συνετῶς δέ.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 80.</p>
+          <bibl>Cod. Cd 80.</bibl>
         </div>
         <div>
           <head>Chambry 195.3</head>
@@ -5310,7 +5309,7 @@
           <l><milestone unit="recitvers"/>Ἡ δὲ γελῶσα πρὸς αὐτοὺς ταῦτα λέγει·</l>
           <l><milestone unit="recitvers"/>« Σκύμνον μὲν ἕνα, ἀλλὰ γενναῖον πάνυ. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι κρείσσων εἷς ῥώμῃ σώματος καὶ ἀνδρείᾳ καὶ φρονήσει ἢ πολλοὶ δειλοὶ καὶ ἄφρονες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 189 Mb 216.</p>
+          <bibl>Codd. Ca 189 Mb 216.</bibl>
         </div>
         <div>
           <head>Chambry 195.4</head>
@@ -5318,7 +5317,7 @@
           <pb ed="perry" n="P257"/>
           <p><milestone unit="recitprose"/>Λέαινα, πάντων τῶν τετραπόδων καυχωμένων εἰς παίδων πλῆθος, ἐπεὶ καὶ τῇ λεαίνῃ ἔφασκον βοῶντες· « Εἰπὲ καὶ σὺ τὸ πόσους τίκτεις παῖδας, » ἡ δὲ γελῶσα πρὸς αὐτοὺς ταῦτα λέγει· « Σκύμνον μὲν ἕνα, ἀλλὰ γενναῖον πάντως. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρείσσων εἷς ῥώμῃ σώματος καὶ ἀνδρείᾳ καὶ φρονήσει διαπρέπων ἢ πολλοὶ δειλοὶ καὶ ἄφρονες.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 102.</p>
+          <bibl>Cod. Mb 102.</bibl>
         </div>
         <div>
           <head>Chambry 195.5</head>
@@ -5326,7 +5325,7 @@
           <pb ed="perry" n="P257"/>
           <p><milestone unit="recitprose"/>Φασὶν ὗν καυχωμένην ἀγέλην παίδων ἔχουσαν εἰπεῖν τῇ λεαίνῃ· « Πόσους παῖδας σὺ γεννᾷς ; » Ἡ δὲ εἶπεν· « Ἕνα μέν, ἀλλὰ γενναῖον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρείσσων εἷς ῥώμῃ σώματος καὶ ἀνδρείᾳ ἢ καὶ φρονήσει διαφέρων ἢ πολλοὶ δειλοὶ καὶ ἄνανδροι ἢ καὶ ἄφρονες.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 142.</p>
+          <bibl>Cod. Ba 142.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-196">
@@ -5335,7 +5334,7 @@
         <pb ed="perry" n="P334"/>
         <p><milestone unit="recitprose"/>Λέων τις ἐϐασίλευσεν οὐχὶ θυμώδης, οὐδὲ ὠμός, οὐδὲ βίαιος, ἀλλὰ πρᾷος καὶ δίκαιος, ὥσπερ ἄνθρωπος. Ἐπὶ δὲ τῆς αὐτοῦ βασιλείας συναθροισμὸς ἐγένετο πάντων τῶν ζῴων δοῦναι δίκας καὶ λαϐεῖν πρὸς ἄλληλα, ὁ λύκος μὲν προϐάτῳ, πάρδαλις δὲ αἰγάγρῳ, ἐλάφῳ δὲ τίγρις, κύων δὲ λαγωῷ. Ὁ πτὼξ δὲ ἔφη· « Πολλὰ ηὐχόμην ἰδεῖν τὴν ἡμέραν ταύτην, ἵνα τοῖς βιαίοις φοϐερὰ τὰ εὐτελῆ φανῶσιν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι δικαιοσύνης ἐν πόλει οὔσης καὶ δικαίως πάντων δικαζόντων, καὶ οἱ εὐτελεῖς ἀταράχως βιοῦσιν.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 78.</p>
+        <bibl>Cod. Ba 78.</bibl>
         <p><milestone unit="traduction"/>Un lion devint roi, qui n’était ni colère, ni cruel, ni violent, mais doux et juste, comme un homme. Il se fit sous son règne une assemblée générale des animaux, en vue de recevoir et de se donner mutuellement satisfaction, le loup au mouton, la panthère au chamois, le tigre au cerf, le chien au lièvre. Le lièvre peureux dit alors : « J’ai vivement souhaité de voir ce jour, afin que les faibles paraissent redoutables aux violents. »</p>
         <p><milestone unit="traduction"/>Quand la justice règne dans l’État, et que tous les jugements sont équitables, les humbles aussi vivent en tranquillité.</p>
       </div>
@@ -5347,7 +5346,7 @@
           <pb ed="perry" n="P142"/>
           <p><milestone unit="recitprose"/>Λέων γηράσας καὶ μὴ δυνάμενος δι’ ἀλκῆς ἑαυτῷ τροφὴν πορίζειν ἔγνω δεῖν δι’ ἐπινοίας τοῦτο πρᾶξαι. Καὶ δὴ παραγενόμενος εἴς τι σπήλαιον καὶ ἐνταῦθα κατακλιθεὶς προσεποιεῖτο νοσεῖν· καὶ οὕτω τὰ παραγενόμενα πρὸς αὐτὸν ἐπὶ τὴν ἐπίσκεψιν ζῷα συλλαμϐάνων κατήσθιε. Πολλῶν δὲ θηρίων καταναλωθέντων, ἀλώπηξ τὸ τέχνασμα αὐτοῦ συνεῖσα παρεγένετο, καὶ στᾶσα ἄποθεν τοῦ σπηλαίου ἐπυνθάνετο αὐτοῦ πῶς ἔχοι. Τοῦ δὲ εἰπόντος· « Κακῶς, » καὶ τὴν αἰτίαν ἐρομένου δι’ ἣν οὐκ εἴσεισιν, ἔφη· « Ἀλλ’ ἔγωγε εἰσῆλθον ἄν, εἰ μὴ ἑώρων πολλῶν εἰσιόντων ἴχνη, ἐξιόντος δὲ οὐδενός. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ φρόνιμοι τῶν ἀνθρώπων ἐκ τεκμηρίων προορώμενοι τοὺς κινδύνους ἐκφεύγουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 137 Pb 140 Ma 96 Ca 91.</p>
+          <bibl>Codd. Pa 137 Pb 140 Ma 96 Ca 91.</bibl>
           <p><milestone unit="traduction"/>Un lion devenu vieux, et dès lors incapable de se procurer de la nourriture par la force, jugea qu’il fallait le faire par adresse. Il se rendit donc dans une caverne et s’y coucha, contrefaisant le malade ; et ainsi, quand les animaux vinrent le visiter, il les saisit et les dévora. Or beaucoup avaient déjà péri, quand le renard, ayant deviné son artifice, se présenta, et s’arrêtant à distance de la caverne, s’informa comment il allait. « Mal », dit le lion, qui lui demanda pourquoi il n’entrait pas. « Moi, dit le renard, je serais entré, si je ne voyais beaucoup de traces d’animaux qui entrent, mais d’animal qui sorte, aucune. »</p>
           <p><milestone unit="traduction"/>Ainsi les hommes judicieux prévoient à certains indices les dangers, et les évitent.</p>
         </div>
@@ -5357,14 +5356,14 @@
           <pb ed="perry" n="P142"/>
           <p><milestone unit="recitprose"/>Λέων γηράσας καὶ μὴ δυνάμενος διακρέσαι αὑτῷ εἰς τροφὴν ἔγνω δι’ ἐπινοίας τι πρᾶξαι. Καὶ δὴ παραγενόμενος ἐν σπηλαίῳ τινὶ καὶ κατακλιθεὶς προσεποιεῖτο νοσεῖν. Παραγενόμενα οὖν τὰ ζῷα ἐπισκέψεως χάριν συλλαμϐάνων, κατήσθιεν αὐτά. Πολλῶν οὖν ζῴων ἀναλωθέντων, ἀλώπηξ τὸ τέχνασμα τοῦτο γνοῦσα παρεγένετο πρὸς αὐτὸν καὶ στᾶσα ἔξωθεν τοῦ σπηλαίου, ἐπυνθάνετο πῶς ἔχει. Τοῦ δὲ εἰπόντος· « Κακῶς, » καὶ τὴν αἰτίαν πυνθανομένου δι’ ἣν οὐκ εἰσέρχεται, ἡ ἀλώπηξ ἔφη· « Ὅτι ὁρῶ ἴχνη πολλῶν εἰσιόντων, ὀλίγων δὲ ἐξιόντων. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ἀνθρώπων ἐκ τεκμηρίων προορώμενοι τοὺς κινδύνους ἐκφεύγουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 141 Lc 50 Lg 50 Mc 63 Md 73 Mg 106 Mh 68 Ml 100 Mm 88 — Cb 63 Ce 70 Cf 74 Ch 74.</p>
+          <bibl>Codd. La 141 Lc 50 Lg 50 Mc 63 Md 73 Mg 106 Mh 68 Ml 100 Mm 88 — Cb 63 Ce 70 Cf 74 Ch 74.</bibl>
         </div>
         <div>
           <head>Chambry 197.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P142"/>
           <p><milestone unit="recitprose"/>Λέων γηράσας καὶ μὴ δυνάμενος θηρᾶν καὶ ἑαυτὸν διατρέφειν, ἔγνω μηχανήσασθαί τι πρὸς ὠφέλειαν ἑαυτοῦ. Καὶ δὴ παραγενόμενος ἐν σπηλαίῳ τινὶ καὶ κατακλιθεὶς προσεποιεῖτο νοσεῖν. Παραγινομένων δὲ τῶν ζῴων πρὸς αὐτὸν ἐπισκέψεως χάριν, συλλαμϐάνων αὐτὰ κατήσθιε. Πολλῶν οὖν θηρίων οὕτως ἀναλωθέντων, ἡ ἀλώπηξ τὸ τέχνασμα τούτου γνοῦσα παρεγένετο πρὸς αὐτὸν καὶ στᾶσα ἔξωθεν τοῦ σπηλαίου ἠρώτα αὐτόν· « Πῶς ἔχεις ; » Τοῦ δὲ εἰπόντος· « Κακῶς, » καὶ ἐρωτήσαντος· « Διὰ τί, ὦ συντέκνισα, οὐκ εἰσέρχῃ εἴσω ; » ἡ ἀλώπηξ ἔφη· « Ὅτι ὁρῶ, κύριέ μου, πολλὰ μὲν εἰσιόντα τῶν θηρίων, ὀλίγα δὲ ἐξιόντα. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 63.</p>
+          <bibl>Cod. Mk 63.</bibl>
         </div>
         <div>
           <head>Chambry 197.4</head>
@@ -5387,7 +5386,7 @@
           <l><milestone unit="recitvers"/>« Μέδων, οἱ ἐρχόμενοι, εἶπέ μοι ποῦ γε·</l>
           <p><milestone unit="recitprose"/>οἱ μὲν εἰσερχόμενοι πολλοί, ἐξέρχονται δ’ ὀλίγοι ἐντεῦθεν· οὐκ ἔρχομαι· καλῶς γὰρ οἶμαι· τοῦτο δὲ λέγε. »</p>
           <p><milestone unit="epimythiumprose"/>Οἴδασιν οἱ φρόνιμοι ἐκ τεκμηρίων φεύγειν ὕψαλα πανοῦργα τῶν δυναστῶν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 74.</p>
+          <bibl>Cod. Cd 74.</bibl>
         </div>
         <div>
           <head>Chambry 197.5</head>
@@ -5395,14 +5394,14 @@
           <pb ed="perry" n="P142"/>
           <p><milestone unit="recitprose"/>Λέων γηράσας κυνηγεῖν οὐκ ἠδύνατο· ἔκειτο δὲ ἐν τῷ σπηλαίῳ προσποιούμενος νοσεῖν, καὶ τὴν φωνὴν λεπτύνων καὶ ἀσθμαίνων. Ἐξῆλθε δὲ φήμη εἰς τὰ θηρία ἀσθενεῖν τὸν βασιλέα αὐτῶν· ἓν δὲ ἕκαστον εἰσήρχετο πρὸς ἐπίσκεψιν· ὁ δὲ ἀκόπως λαμϐάνων κατήσθιεν. Ἡ δὲ πανοῦργος ἀλώπηξ νοήσασα, πόρρωθεν στᾶσα, ἔφη· « Βασιλεῦ, πῶς ἔχεις ; – Κακῶς, εἶπεν· ἀλλὰ τί οὐ προσέρχῃ μοι, ἀλλὰ μακρόθεν ἐρωτᾷς ; δεῦρο, γλυκεῖα, καὶ τοῖς λόγοις σου παρηγόρησον. » Ἡ δὲ ἔφη· « Ὑγίαινε, ἐγὼ δὲ ἄπειμι· πολλῶν γὰρ θηρίων ἴχνη με κωλύει εἰσιόντων μέν, μηδ’ ὅλως δὲ ἐξιόντων. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι φρόνιμός ἐστιν ὁ συμφοραῖς ἑτέρων παιδευθεὶς καὶ μὴ προλαϐὼν πταίσας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 73 Bb 47.</p>
+          <bibl>Codd. Ba 73 Bb 47.</bibl>
         </div>
         <div>
           <head>Chambry 197.6</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P142"/>
           <p><milestone unit="recitprose"/>Λέων γηράσας καὶ τροφῆς ἀπορῶν νοσεῖν ὑπεκρίνετο· πάντα δὲ τὰ ζῷα εἰς θέαν αὐτοῦ ἀφικόμενα ἀπόνως ταῦτα συλλαμϐάνων κατήσθιεν. Ἀλώπηξ δὲ τοῦτο νοήσασα πόρρωθεν αὐτὸν προσηγόρευε. Ὁ δὲ λέων ἔφη· « Δεῦρο, γλυκεῖα, καὶ τοῖς λόγοις ἀσθενοῦντα παραμύθησαι. » Ἡ δὲ ἔφη· « Ὑγίαινε, βασιλεῦ, ἐγὼ δὲ ἄπειμι· πολλῶν γὰρ θηρίων ἴχνη βλέπω εἰσιόντων, ἐξιόντα δὲ οὐδενός. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 37.</p>
+          <bibl>Cod. Bd 37.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-198">
@@ -5411,7 +5410,7 @@
         <pb ed="perry" n="P144"/>
         <p><milestone unit="recitprose"/>Λέων εἰς γεωργοῦ ἔπαυλιν εἰσῆλθεν. Ὁ δὲ συλλαϐεῖν βουλόμενος τὴν αὐλείαν θύραν ἔκλεισε. Καὶ ὃς ἐξελθεῖν μὴ δυνάμενος πρῶτον μὲν τὰ ποίμνια διέφθειρεν, ἔπειτα δὲ καὶ ἐπὶ τοὺς βόας ἐτράπη. Καὶ ὁ γεωργὸς φοϐηθεὶς περὶ αὑτοῦ τὴν θύραν ἀνέῳξεν. Ἀπαλλαγέντος δὲ τοῦ λέοντος, ἡ γυνὴ θεασαμένη αὐτὸν στένοντα εἶπεν· « Ἀλλὰ σύ γε δίκαια πέπονθας· τί γὰρ τοῦτον συγκλεῖσαι ἐϐούλου ὃν καὶ μακρόθεν σε ἔδει φεύγειν ; »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοὺς ἰσχυροτέρους διερεθίζοντες εἰκότως τὰς ἐξ αὑτῶν πλημμελείας ὑπομένουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 139 Pb 142 Pc 80 Pf 76 Ma 98 Mb 87 Me 99 Mf 83 Mj 93 Ca 93.</p>
+        <bibl>Codd. Pa 139 Pb 142 Pc 80 Pf 76 Ma 98 Mb 87 Me 99 Mf 83 Mj 93 Ca 93.</bibl>
         <p><milestone unit="traduction"/>Un lion pénétra dans l’étable d’un laboureur. Celui-ci, voulant le prendre, ferma la porte de la cour. Ne pouvant sortir, le lion dévora d’abord les moutons, puis s’attaqua aux bœufs. Alors le laboureur, prenant peur pour lui-même, ouvrit la porte. Le lion parti, la femme du laboureur, le voyant gémir, lui dit : « Tu n’as que ce que tu mérites ; car pourquoi vouloir enfermer une bête que tu devais craindre même de loin ? »</p>
         <p><milestone unit="traduction"/>Ainsi les gens qui excitent de plus forts qu’eux ont naturellement à supporter les conséquences de leur folie.</p>
       </div>
@@ -5423,7 +5422,7 @@
           <pb ed="perry" n="P140"/>
           <p><milestone unit="recitprose"/>Λέων ἐρασθεὶς γεωργοῦ θυγατρὸς, ταύτην ἐμνηστεύσατο. Ὁ δὲ μὴ ἐκδοῦναι θηρίῳ τὴν θυγατέρα ὑπομένων, μηδὲ ἀρνήσασθαι διὰ φόϐον δυνάμενος τοιοῦτόν τι ἐπενόησεν. Ἐπειδὴ συνεχῶς αὐτῷ ὁ λέων ἐπέκειτο, ἔλεγεν ὡς νυμφίον μὲν αὐτὸν ἄξιον τῆς θυγατρὸς δοκιμάζει· μὴ ἄλλως δὲ αὐτῷ δύνασθαι ἐκδοῦναι, ἐὰν μὴ τούς τε ὀδόντας ἐξέλῃ καὶ τοὺς ὄνυχας ἐκτέμῃ· τούτους γὰρ δεδοικέναι τὴν κόρην. Τοῦ δὲ ῥᾳδίως διὰ τὸν ἔρωτα ἑκάτερα ὑπομείναντος, ὁ γεωργὸς καταφρονήσας αὐτοῦ, ὡς παρεγένετο πρὸς αὐτόν, ῥοπάλοις αὐτὸν παίων ἐξήλασεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ ῥᾳδίως τοῖς πέλας πιστεύοντες, ὅταν τῶν ἰδίων πλεονεκτημάτων ἑαυτοὺς ἀπογυμνώσωσιν, εὐάλωτοι τούτοις γίνονται οἷς πρότερον φοϐεροὶ καθεστήκεσαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 135 Pb 138 Pc 77 Pg 92 Ma 94.</p>
+          <bibl>Codd. Pa 135 Pb 138 Pc 77 Pg 92 Ma 94.</bibl>
           <p><milestone unit="traduction"/>Un lion s’étant épris de la fille d’un laboureur, la demanda en mariage ; mais lui, ne pouvant ni se résoudre à donner sa fille à une bête féroce, ni la lui refuser à cause de la crainte qu’il en avait, imagina l’expédient que voici. Comme le lion ne cessait de le presser, il lui dit qu’il le jugeait digne d’être l’époux de sa fille, mais qu’il ne pouvait la lui donner qu’à une condition, c’est qu’il s’arracherait les dents et se rognerait les griffes ; car c’était cela qui faisait peur à la jeune fille. Il se résigna facilement, parce qu’il aimait, à ce double sacrifice. Dès lors le laboureur n’eut plus que mépris pour lui, et, lorsqu’il se présenta, il le mit à la porte à coups de bâton.</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui se fient aisément aux autres, une fois qu’ils se sont dépouillés de leurs propres avantages, sont facilement vaincus par ceux qui les redoutaient auparavant.</p>
         </div>
@@ -5433,7 +5432,7 @@
           <pb ed="perry" n="P140"/>
           <p><milestone unit="recitprose"/>Λέων ἐρασθεὶς θυγατρὸς γεωργοῦ, ταύτῃ μνηστευθῆναι ἐϐούλετο. Ἐπέκειτο οὖν ἐκϐιάζων τὸν πατέρα αὐτῆς· ὁ δὲ πατὴρ αὐτῆς ἔλεγε μὴ ἐκδοῦναι θηρίῳ τὴν ἑαυτοῦ θυγατέρα. Ὁ λέων οὖν ἠπείλει αὐτῷ· ὁ δὲ μὴ δυνάμενος διὰ τὸν φόϐον ἀναϐάλλεσθαι, ἐπενόησεν ἐμφρόνως καί φησι πρὸς τὸν λέοντα· « Οὐ δύναμαί σοι δοῦναι τὴν ἐμὴν θυγατέρα, ἐὰν μὴ τοὺς ὀδόντας καὶ τοὺς ὄνυχάς σου ἐκτίλλῃς· ταῦτα γὰρ ἡ κόρη δέδοικεν. » Ὁ δὲ εὐθέως διὰ τὸν ἔρωτα ἑκάτερα ῥᾳδίως ἐξέϐαλε, καὶ ἀπελθὼν κατὰ τὸ σύνηθες ἐζήτει τὴν κόρην. Ὁ δὲ γεωργὸς καταφρονήσας αὐτοῦ ῥοπάλοις αὐτὸν ἐδίωξεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοῖς ἐχθροῖς ἑαυτοὺς καταπιστεύοντες εὐάλωτοι τούτοις γίνονται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 78.</p>
+          <bibl>Cod. Cd 78.</bibl>
         </div>
         <div>
           <head>Chambry 199.3</head>
@@ -5461,7 +5460,7 @@
           <l><milestone unit="recitvers"/>Ῥοπάλοις γε διώκει τοῦτον ὁ γέρων·</l>
           <l><milestone unit="recitvers"/>« Ἔξελθ’ οἴκων ἐμῶν· ἄοπλος ὑπάρχεις. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ ἐχθροῖς πιστεύων ὅλος φθείρεται ὑπὸ τούτων.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 76.</p>
+          <bibl>Cod. Ba 76.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-200">
@@ -5472,7 +5471,7 @@
           <pb ed="perry" n="P336"/>
           <p><milestone unit="recitprose"/>Λέων νοσήσας ἔκειτο ἐν φάραγγι· τῇ προσφιλεῖ δὲ ἀλώπεκι, ᾗ προσωμίλει, εἶπεν· « Εἰ θέλεις ὑγιᾶναί με καὶ ζῆν, τὴν ἔλαφον τὴν μεγίστην, τὴν εἰς τὸν δρυμὸν οἰκοῦσαν, τοῖς γλυκέσι σου λόγοις ἐξαπατήσασα ἄγε εἰς ἐμὰς χεῖρας· ἐπιθυμῶ γὰρ αὐτῆς ἐγκάτων καὶ καρδίας. » Ἡ δὲ ἀλώπηξ ἀπελθοῦσα εὗρε τὴν ἔλαφον σκιρτῶσαν ἐν ταῖς ὕλαις· προσπαίσασα δὲ αὐτῇ καὶ χαίρειν εἰποῦσα ἔφη· « Ἀγαθά σοι ἦλθον μηνῦσαι· οἶδας ὡς ὁ βασιλεὺς ἡμῶν λέων γείτων ἐστί μοι· νοσεῖ δὲ καὶ ἔστιν ἐγγὺς τοῦ θνῄσκειν. Ἐϐουλεύετο οὖν ποῖον τῶν θηρίων μετ’ αὐτὸν βασιλεύσει. Ἔφη δὲ ὅτι σῦς μέν ἐστιν ἀγνώμων, ἄρκτος δὲ νωθρός, πάρδαλις δὲ θυμώδης, τίγρις ἀλαζών· ἡ ἔλαφος ἀξιωτάτη ἐστὶν εἰς βασιλείαν, ὅτι ὑψηλή ἐστι τὸ εἶδος, πολλὰ δὲ ἔτη ζῇ, τὸ κέρας αὐτῆς ὄφεσι φοϐερόν. Καὶ τί σοι τὰ πολλὰ λέγω ; ἐκυρώθης βασιλεύειν. Τί μοι ἔσται πρώτῃ σοι εἰπούσῃ ; Ἀλλ’ εὖξαί μοι σπευδούσῃ, μὴ πάλιν με ζητήσῃ· χρῄζει γάρ με σύμϐουλον ἐν πᾶσιν. Εἰ δὲ ἐμοῦ τῆς γραὸς ἀκούσῃς, συμϐουλεύω καὶ σὲ ἐλθεῖν καὶ προσμένειν τελευτῶντι αὐτῷ. » Οὕτως εἶπεν ἡ ἀλώπηξ. Τῆς δὲ ὁ νοῦς ἐτυφώθη τοῖς λόγοις, καὶ ἦλθεν εἰς τὸ σπήλαιον μὴ γινώσκουσα τὸ μέλλον. Ὁ λέων δὲ ἐφορμήσας αὐτῇ ἐν σπουδῇ τὰ ὦτα μόνον τοῖς ὄνυξιν ἐσπάραξεν. Ἡ δὲ ταχέως ἔσπευδεν ἐν ταῖς ὕλαις. Καὶ ἡ μὲν ἀλώπηξ τὰς χεῖρας ἐκρότησεν, ὅτι εἰς μάτην ἐκοπίασεν. Ὁ δὲ λέων μέγα βρυχώμενος ἐστέναξεν· λιμὸς γὰρ αὐτὸν εἶχε καὶ λύπη· καὶ ἱκέτευε τὴν ἀλώπεκα ἐκ δευτέρου τι ποιῆσαι καὶ δόλῳ πάλιν ταύτην ἀγαγεῖν. Ἡ δὲ εἶπεν· « Χαλεπὸν καὶ δύσκολον ἐπιτάττεις ἐμοὶ πρᾶγμα, ἀλλ’ ὅμως ὑπουργήσω σοι. » Καὶ δὴ ὡς ἰχνευτὴς κύων ἐπηκολούθει, πλέκουσα πανουργίας· ποιμένας δὲ ἐπηρώτα εἰ εἶδον ἔλαφον ᾑμαγμένην. Οἱ δὲ ἔδειξαν ἐν τῇ ὕλῃ. Εὗρε δὲ αὐτὴν καταψυχομένην, καὶ ἔστη ἀναιδῶς. Ἡ δὲ ἔλαφος χολωθεῖσα καὶ φρίξασα τὴν χαίτην εἶπεν· « Ὦ κάθαρμα, ἀλλὰ οὐκέτι χειρώσῃ με· εἰ δὲ καὶ πλησιάσεις μοι, οὐ ζήσεις ἔτι. Ἄλλους ἀλωπέκιζε τοὺς ἀπείρους, ἄλλους ποιεῖ βασιλεῖς καὶ ἐρέθιζε. » Ἡ δὲ εἶπεν· « Οὕτως ἄνανδρος εἶ καὶ δειλή ; Οὕτως ἡμᾶς τοὺς φίλους ὑποπτεύεις ; Ὁ μὲν λέων τοῦ ὠτὸς κρατήσας ἤμελλε συμϐουλεύειν καὶ ἐντολάς σοι δοῦναι περὶ τῆς τηλικαύτης βασιλείας ὡς ἀποθνῄσκων· σὺ δὲ οὐδὲ κνίσμα χειρὸς ἀρρώστου ὑπέστης. Καὶ νῦν ὑπὲρ σὲ πλεῖον ἐκεῖνος θυμοῦται, καὶ βασιλέα τὸν λύκον θέλει ποιῆσαι· οἴμοι, πονηρὸν δεσπότην. Ἀλλ’ ἐλθὲ καὶ μηδὲν πτοηθῇς καὶ γενοῦ ὡς πρόϐατον. Ὄμνυμι γάρ σοι εἰς τὰ φύλλα πάντα καὶ πηγὰς μηδὲν κακὸν παθεῖν παρὰ τοῦ λέοντος· ἐγὼ δὲ μόνῃ σοι δουλεύσω. » Οὕτως ἀπατήσασα τὴν δειλαίαν ἔπεισε δεύτερον ἐλθεῖν. Ἐπεὶ δὲ εἰς τὸ σπήλαιον εἰσῆλθεν, ὁ μὲν λέων δεῖπνον εἶχε, πάντα τὰ ὀστᾶ καὶ μυελοὺς καὶ ἔγκατα αὐτῆς καταπίνων. Ἡ δὲ ἀλώπηξ εἱστήκει ὁρῶσα· καρδίαν δὲ ἐκπεσοῦσαν ἁρπάζει λαθραίως, τοῦ κόπου κέρδος ταύτην φαγοῦσα. Ὁ δὲ λέων ἅπαντα ἐρευνήσας μόνην καρδίαν ἐπεζήτει. Ἀλώπηξ δὲ μηκόθεν σταθεῖσα ἔφη· « Αὕτη ἀληθῶς καρδίαν οὐκ εἶχεν· μὴ ἔτι ζήτει· ποίαν γὰρ καρδίαν αὕτη εἶχεν, ἥτις δὶς εἰς οἶκον καὶ χεῖρας λέοντος εἰσῆλθεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὁ τῆς φιλοδοξίας ἔρως τὸν ἀνθρώπινον νοῦν ἐπιθολοῖ καὶ τὰς τῶν κινδύνων συμφορὰς οὐ κατανοεῖ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 75 Bb 88.</p>
+          <bibl>Codd. Ba 75 Bb 88.</bibl>
           <p><milestone unit="traduction"/>Le lion étant tombé malade était couché dans une caverne. Il dit au renard, qu’il aimait et avec qui il entretenait commerce : « Si tu veux que je guérisse et que je vive, séduis par tes douces paroles le gros cerf qui habite la forêt, et amène-le entre mes mains ; car j’ai envie de ses entrailles et de son cœur. » Le renard se mit en campagne et trouva le cerf qui bondissait dans les bois. Il l’aborda d’un air caressant, le salua et dit : « Je viens t’annoncer une bonne nouvelle. Tu sais que notre roi, le lion, est mon voisin ; or il est malade et sur le point de mourir. Alors il s’est demandé qui des animaux régnerait après lui. Le sanglier, a-t-il dit, est dépourvu d’intelligence, l’ours balourd, la panthère irascible, le tigre fanfaron : c’est le cerf qui est le plus digne de régner, parce qu’il est haut de taille, qu’il vit de longues années, et que sa corne est redoutable aux serpents. Mais à quoi bon m’étendre davantage ? Il a été décidé que tu serais roi. Que me donneras-tu pour te l’avoir annoncé le premier ? Parle, je suis pressé, je crains qu’il ne me réclame ; car il ne peut se passer de mes conseils en rien. Mais, si tu veux bien écouter un vieillard, je te conseille de venir aussi et d’attendre sa mort près de lui. » Ainsi parla le renard, et le cœur du cerf se gonfla de vanité à ces discours, et il vint à l’antre sans se douter de ce qui allait arriver. Or le lion bondit sur lui précipitamment ; mais il ne fit que lui déchirer les oreilles avec ses griffes. Le cerf se sauva en toute hâte dans les bois. Alors le renard claqua ses mains l’une contre l’autre, dépité d’avoir perdu sa peine ; et le lion se mit à gémir en poussant de grands rugissements ; car la faim le tenaillait, et le chagrin aussi ; et il supplia le renard de faire une autre tentative et de trouver une nouvelle ruse pour amener le cerf. Le renard répondit : « C’est une commission pénible et difficile que celle dont tu me charges ; pourtant je t’y servirai encore. » Alors, comme un chien de chasse, il suivit la trace du cerf, ourdissant des fourberies, et il demanda à des bergers s’ils n’avaient pas vu un cerf ensanglanté. Ils lui indiquèrent son gîte dans la forêt. Il le trouva qui reprenait haleine et se présenta impudemment. Le cerf, plein de colère et le poil hérissé, lui répondit : « Misérable, tu ne m’y prendras plus ; si tu t’approches tant soit peu de moi, c’en est fait de ta vie. Va renarder avec d’autres qui ne te connaissent pas, choisis d’autres bêtes pour en faire des rois et leur monter la tête. » Le renard répondit : « Es-tu si couard et si lâche ? Est-ce ainsi que tu nous soupçonne », nous, tes amis ? Le lion, en te prenant l’oreille, allait te donner ses conseils et ses instructions sur ta grande royauté, comme quelqu’un qui va mourir ; et toi, tu n’as pas supporté même une égratignure de la patte d’un malade. À présent il est encore plus en colère que toi, et il veut créer roi le loup. Hélas ! le méchant maître ! Mais viens, ne crains rien et sois doux comme un mouton. Car, j’en jure par toutes les feuilles et les sources, tu n’as aucun mal à craindre du lion. Quant à moi, je ne veux servir que toi. » En abusant ainsi le malheureux, il le décida à venir de nouveau. Quant il eut pénétré dans l’antre, le lion eut de quoi dîner, et il avala tous les os, les moelles et les entrailles. Le renard était là, qui regardait. Le cœur étant tombé, il le saisit à la dérobée, et le mangea pour se dédommager de sa peine. Mais le lion, après avoir cherché tous les morceaux, ne retrouvait pas le cœur. Alors le renard, se tenant à distance, lui dit : « Véritablement ce cerf n’avait pas de cœur ; ne le cherche plus ; car quel cœur pouvait avoir un animal qui est venu par deux fois dans le repaire et les pattes du lion ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’amour des honneurs trouble la raison et ferme les yeux sur l’imminence du danger.</p>
         </div>
@@ -5481,7 +5480,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P336"/>
           <p><milestone unit="recitprose"/>Λέων νοσήσας πρὸς τὴν ἀλώπεκα ἔφη· « Εἰ χαριεῖσθαι μοι θέλεις, τὴν ἔλαφον τοῖς πιθανοῖς σου λόγοις ἐξαπατήσασα κόμιζε· τῶν γὰρ ἐγκάτων αὐτῆς ἐπιθυμῶ καὶ τῆς καρδίας. » Ἡ δὲ πρὸς τὴν ἔλαφον ἀπελθοῦσα· « Ἀγαθῶν μηνυτὴς ἧκον, » ἔφη. Ἡ δὲ τὴν ἀγγελίαν ἠρώτα. Ἡ δὲ ἀλώπηξ· « Ὁ λέων, φησίν, ἀποθνῄσκων διάδοχον βασιλείας ἐζήτει· τὸν σῦν οὖν παρῃτήσατο ὡς ἀγνώμονα, ἄρκον δὲ ὡς νωθρόν, πάρδαλιν ὡς θυμώδη καὶ τίγριν ὡς ἀλαζόνα· μόνη δ’ αὐτῷ εἰς βασιλείαν ἐκρίθης ἀξία διά τε τὸ μέγεθος καὶ κάλλος, τῶν κεράτων τήν δύναμιν καὶ τῆς ζωῆς τὴν μακρότητα· δεῦρο οὖν μετ’ ἐμοῦ καὶ παρακαθημένη ζῶντι τῷ λέοντι τὴν βασιλείαν μετὰ τὸν ἐκείνου θάνατον λάμϐανε. » Ἀκούσασα δὲ τῶν λόγων τῆς ἀλώπεκος καὶ πεισθεῖσα ἡ ἔλαφος ἠκολούθησε μεχρὶ τοῦ σπηλαίου ἐν ᾧ ὁ λέων ἔκειτο. Ὁ δὲ λέων ἰδὼν αὐτὴν καὶ ὑπὸ τῆς χαρᾶς παρὰ καιρὸν ὁρμήσας ἐπ’ αὐτὴν τὰ ὦτα μόνον τοῖς ὄνυξιν ἔνυξεν. Ἡ δὲ ἔλαφος φοϐηθεῖσα αὖθις ταῖς ὕλαις ἐκρύπτετο. Ὁ λέων δὲ βρυχώμενος ἐδυσχέραινε καὶ τὴν ἀλώπεκα αὖθις ἱκέτευε αὖθις πανουργεύσασαν αὐτὴν ἀγαγεῖν. Ἡ δὲ δύσκολον τὸ πρᾶγμα τιθεμένη, ὅμως πρὸς τὴν ἔλαφον αὖθις ἐγένετο. Ἡ δὲ ταύτην ἰδοῦσα ἔφη· « Μηδαμῶς πλησιάσῃς μοι· ἄλλους ποιεῖ βασιλεῖς, καὶ προσάγαγε λέοντι· ἔγνων γάρ σου τὰ πανουργεύματα. » Ἡ δὲ ἔφη· « Ὦ ἀνόητε, ἄνανδρε πασῶν ἐλάφων καὶ δειλή, πῶς ἀκαίρως τοὺς φιλοῦντας ὑποπτεύεις ; Ὁ γὰρ λέων τῶν ὠτῶν σου λαϐόμενος ἔμελλέν σοι κρύφα κοινολογεῖσθαι καὶ συμϐουλεύειν καὶ τὰς ἐντολὰς αὐτοῦ περὶ τηλικαύτης ἀρχῆς παραδοῦναι. Σὺ δὲ οὐδὲ κνίσμα χειρὸς ἀρρώστου ὑπέμεινας. Καὶ νῦν θυμωθεὶς βασιλέα, οἴμοι, ποιεῖν αἱρεῖται τὸν πίθηκον, πικρὸν θηρίον καὶ πονηρόν. Ἀλλ’ ἐλθὲ μηδὲν φοϐουμένη καὶ ταπεινώθητι. Ὄμνυμι γάρ σοι φύλλα πάντα καὶ τὰς πηγὰς μηδέν τι κακὸν παρὰ τοῦ λέοντος ὑποστῆναί σε. » Τουτοῖς πεισθεῖσα ἡ δειλαία ἔλαφος αὖθις πρὸς τὸ σπήλαιον εἰσῆλθε τοῦ λέοντος. Διασπάσας οὖν ταύτην ὁ λέων δεῖπνον εἶχεν τὰ ὀστᾶ αὐτῆς καὶ μυελοὺς καὶ τὰ ἔγκατα. Τὴν δὲ καρδίαν λάθρα ἡ ἀλώπηξ ἁρπάσασα ἔφαγε, κέρδος ἡγησαμένη τοῦτο τῆς ταλαιπωρίας δι’ ἧς ταῦτα κατώρθωσε. Ὁ δὲ λέων πάντα καταφαγών, καὶ τὴν καρδίαν ἐπιμελῶς ἐξεζήτει. Ἡ δ’ ἀλώπηξ μακρόθεν ἑστῶσα ἔφη· « Ὦ λέον, μὴ ζήτει καρδίαν· αὕτη γὰρ ἀληθῶς καρδίαν οὐκ εἶχεν· εἰ γὰρ καρδίαν εἶχεν, δὶς εἰς χεῖρας λέοντος οὐκ ἂν ἦλθεν. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 38.</p>
+          <bibl>Cod. Bd 38.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-201">
@@ -5492,7 +5491,7 @@
           <pb ed="perry" n="P147"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ἄρκτος, ἐλάφου νεϐρὸν εὑρόντες, περὶ τούτου ἐμάχοντο. Δεινῶς δὲ ὑπ’ ἀλλήλων διατεθέντες, ἐπειδὴ ἐσκοτώθησαν, ἡμιθανεῖς ἔκειντο. Ἀλώπηξ δὲ παριοῦσα, ὡς ἐθεάσατο τοὺς μὲν παρειμένους, τὸν δὲ νεϐρὸν ἐν μέσῳ κείμενον, ἀραμένη αὐτόν, διὰ μέσων αὐτῶν ἀπηλλάττετο. Οἱ δὲ ἐξαναστῆναι μὴ δυνάμενοι ἔφασαν· « Ἄθλιοι ἡμεῖς, εἴ γε ἀλώπεκι ἐμοχθοῦμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι εὐλόγως ἐκεῖνοι ἄχθονται οἳ τῶν ἰδίων πόνων τοὺς τυχόντας ὁρῶσι τὰς ἐπικαρπίας ἀποφερομένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 142 Pb 145 Pg 96 Mb 94.</p>
+          <bibl>Codd. Pa 142 Pb 145 Pg 96 Mb 94.</bibl>
           <p><milestone unit="traduction"/>Un lion et un ours, ayant trouvé un faon de biche, se battaient à qui l’aurait. Ils se portèrent l’un à l’autre des coups terribles, tant qu’enfin, pris de vertige, ils s’abattirent à demi morts. Un renard, qui passait, les voyant énervés, et le faon gisant au milieu, l’enleva et s’en alla en passant entre eux deux. Et eux, hors d’état de se relever, murmurèrent : « Malheureux que nous sommes ! c’est pour le renard que nous avons pris tant de peine. »</p>
           <p><milestone unit="traduction"/>La fable montre qu’on a raison de se dépiter, quand on voit les premiers venus emporter le fruit de ses propres travaux.</p>
         </div>
@@ -5502,7 +5501,7 @@
           <pb ed="perry" n="P147"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ἄρκος ἔλαφον εὗρον. Περὶ τούτου ἀμφότεροι ἐμάχοντο ποῖος αὐτὸν καταθοινήσεται. Δεινῶς δὲ ὑπ’ ἀλλήλων διατεθέντες, ἐπειδὴ ἐσκοτώθησαν, ἔκειντο ἀπεναντὶ ἀλλήλων ὡς εἰ νεκροί. Ἀλώπηξ δὲ παριοῦσα, ὡς ἐθεάσατο τούτους μὲν παρειμένους καὶ τὴν νεϐρὸν ἐν μέσῳ κειμένην, προσέδραμεν καὶ ταύτην ἐκ μέσου αὐτῶν ἀραμένη ἀπῆλθεν. Οἱ δὲ θεασάμενοι καὶ ἀναστῆναι μὴ δυνάμενοι ἔφασαν· « Ἄθλιοι ἡμεῖς, εἴγε δι’ ἀλώπεκα ἐμοχθοῦμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος ὅτι εὐλόγως ἐκεῖνοι ἄχθονται οἳ δι’ ὀργῆς ἄμυναν τῶν ἰδίων καμάτων τοὺς τυχόντας ὁρῶσι τὰς ἐπικαρπίας ἐπιφερομένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 79 Me 102 Mf 86 Mj 96.</p>
+          <bibl>Codd. Pf 79 Me 102 Mf 86 Mj 96.</bibl>
         </div>
         <div>
           <head>Chambry 201.3</head>
@@ -5510,7 +5509,7 @@
           <pb ed="perry" n="P147"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ἄρκτος ἐλάφου νεϐρὸν εὑρόντες περὶ τούτου ἐμάχοντο. Δεινῶς οὖν ὑπ’ ἀλλήλων διατεθέντων, καὶ ἐκ τῆς πολλῆς μάχης ἀμφοτέρων σκοτισθέντων, καὶ ἡμιθανῶν κειμένων, ἀλώπηξ παριοῦσα, ὡς ἐθεάσατο τοὺς μὲν παρειμένους, τὸ δὲ νεϐρὸν ἐν μέσῳ κείμενον, εἰσελθοῦσα διὰ μέσου αὐτῶν, ἀραμένη τοῦτο, δρομαίως ᾤχετο. Οἱ δὲ ἰδόντες αὐτὴν καὶ ἀναστῆναι μὴ δυνάμενοι εἶπον· « Ἄθλιοι ἡμεῖς, ὅτι δι’ ἀλώπεκα ἐμοχθοῦμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος διδάσκει ὅτι εὐλογως ἐκεῖνοι ἄχθονται οἳ τῶν ἰδίων καμάτων τοὺς τυχόντας ὁρῶσι τὰς ἐπικαρπίας ἀποφερομένους. Ἢ· ὅτι πολλοὶ μόχθον καὶ κόπον ἑτέρων ποιοῦνται ἴδιον κέρδος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 96 Ce 73 Cf 77 Cg 2 Ch 77.</p>
+          <bibl>Codd. Ca 96 Ce 73 Cf 77 Cg 2 Ch 77.</bibl>
         </div>
         <div>
           <head>Chambry 201.4</head>
@@ -5518,7 +5517,7 @@
           <pb ed="perry" n="P147"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ἄρκτος, ὁμοῦ νεϐρῷ περιτυχόντες, περὶ τούτου ἐμάχοντο. Δεινῶς οὖν ὑπ’ ἀλλήλων διατεθέντες, ὡς ἐκ τῆς πολλῆς μάχης καὶ σκοτοδινιᾶσαι, ἀπαυδήσαντες ἔκειντο. Ἀλώπηξ δὲ κύκλῳ περιιοῦσα, πεπτωκότας αὐτοὺς ἰδοῦσα καὶ τὸν νεϐρὸν ἐν τῷ μέσῳ κείμενον, διὰ μέσου ἀμφοῖν διαδραμοῦσα καὶ τοῦτον ἁρπάσασα, φεύγουσα ᾤχετο. Οἱ δὲ βλέποντες μὲν αὐτήν, μὴ δυνάμενοι δὲ ἀναστῆναι· « Δείλαιοι ἡμεῖς, εἶπον, ὅτι δι’ ἀλώπεκα ἐμοχθοῦμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἄλλων κοπιώντων ἄλλοι κερδαίνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 39 Lb 76 Le 76 Lf 39 Lh 33 Mg 101 Ml 96.</p>
+          <bibl>Codd. La 39 Lb 76 Le 76 Lf 39 Lh 33 Mg 101 Ml 96.</bibl>
         </div>
         <div>
           <head>Chambry 201.5</head>
@@ -5526,7 +5525,7 @@
           <pb ed="perry" n="P147"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ἄρκτος βρῶμά τι εὑρόντες ἐν ἕλει, περὶ τούτου ἐμάχοντο. Δεινῶς οὖν ὑπ’ ἀλλήλων κατακοπέντες ἐσκοτίσθησαν ἐκ τῆς πολλῆς μάχης, καὶ ἔκειντο ἡμιθανεῖς. Ἀλώπηξ δὲ περιιοῦσα καὶ θεασαμένη πεπτωκότας, ἰδοῦσα τὸ βρῶμα κείμενον ἐν μέσῳ, ἄρασα τοῦτο δρομαίως ᾦχετο. Οἱ δὲ ἰδόντες αὐτὴν καὶ μὴ δυνάμενοι ἀναστῆναι, εἶπον· « Ἄθλιοι ὄντως ἡμεῖς, ὅτι δι’ ἀλώπεκα ἐμαχόμεθα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ κοπιῶντες καὶ μοχθοῦντες ἑτέροις κέρδος προσκτῶνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ma 179 Md 76 Mh 71 Mm 91 Lc 53 Lg 53.</p>
+          <bibl>Codd. Ma 179 Md 76 Mh 71 Mm 91 Lc 53 Lg 53.</bibl>
         </div>
         <div>
           <head>Chambry 201.6</head>
@@ -5546,7 +5545,7 @@
           <l><milestone unit="recitvers"/>[ἔτυπτον, ἐσπάραττον, ἔθλιϐον πέρνα]</l>
           <l><milestone unit="recitvers"/>« Ἄθλιοί ἐσμεν, δι’ ἄλλους ἐμοχθοῦμεν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι δικαίως ἐκεῖνοι ἄχθονται οἳ τῶν ἰδίων καμάτων τοὺς τυχόντας ὁρῶσιν τὰς ἐπικαρπίας ἐπιφερομένους. – Ὅμοιον δ’ ἔστι τοῦτο τῷ λόγῳ ἐκείνῳ· ἄλλοι σκάπτουν καὶ κλαδεύουν καὶ ἄλλοι τραγούδουν καὶ πίνουν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 77.</p>
+          <bibl>Cod. Cd 77.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-202">
@@ -5557,7 +5556,7 @@
           <pb ed="perry" n="P141"/>
           <p><milestone unit="recitprose"/>Λέων ἀκούσας βατράχου κεκραγότος ἐπεστράφη πρὸς τὴν φωνήν, οἰόμενος μέγα τι ζῷον εἶναι. Προσμείνας δὲ μικρὸν χρόνον, ὡς ἐθεάσατο αὐτὸν ἀπὸ τῆς λίμνης ἐξελθόντα, προσελθὼν καταπάτησεν εἰπών· « Εἶτα τηλικοῦτος ὢν τηλικαῦτα βοᾷς ; »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα γλωσσαλγίαν οὐδὲν πλέον τοῦ λαλεῖν δυνάμενον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 136 Pb 139 Pc 78 Pf 75 Pg 93 Ph 71 Ma 95 Me 98 Mf 82 Mj 92.</p>
+          <bibl>Codd. Pa 136 Pb 139 Pc 78 Pf 75 Pg 93 Ph 71 Ma 95 Me 98 Mf 82 Mj 92.</bibl>
           <p><milestone unit="traduction"/>Un lion, ayant entendu coasser une grenouille, se retourna au son, pensant que c’était quelque gros animal. Il attendit quelque temps, puis, la voyant sortir de l’étang, il s’approcha et l’écrasa, en disant : « Eh quoi ! c’est avec une telle taille que tu pousses de tels cris ! »</p>
           <p><milestone unit="traduction"/>Cette fable s’applique au bavard, incapable d’autre chose que de parler.</p>
         </div>
@@ -5567,7 +5566,7 @@
           <pb ed="perry" n="P141"/>
           <p><milestone unit="recitprose"/>Λέων ἀκούσας βατράχου μέγα κεκραγότος, ἐστράφη πρὸς τὴν φωνήν, οἰόμενος μέγα τι ζῷον εἶναι. Προσμείνας δὲ [αὐτὸν] μικρὸν χρόνον, ὡς ἐθεάσατο τοῦτον ἐκ τῆς λίμνης ἐξελθόντα, προσελθὼν κατεπάτησεν αὐτὸν, εἰπών· « Μηδένα ἀκοὴ ταραττέτω πρὸ τῆς θέας [ἤγουν μηδεὶς πρὸ τοῦ ἰδεῖν ταραττέσθω ὑπό τινος]. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος οὗτος πρὸς ἄνδρα γλωσσώδη, μηδὲν πλέον τοῦ λαλεῖν δυνάμενον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 90 Cb 62 Ce 69 Cf 73 Ch 73 Mc 62 Md 72 Mh 67.</p>
+          <bibl>Codd. Ca 90 Cb 62 Ce 69 Cf 73 Ch 73 Mc 62 Md 72 Mh 67.</bibl>
         </div>
         <div>
           <head>Chambry 202.3</head>
@@ -5575,7 +5574,7 @@
           <pb ed="perry" n="P141"/>
           <p><milestone unit="recitprose"/>Λέων ἀκούσας ποτὲ βατράχου μέγα βοῶντος, ἐπεστράφη πρὸς τὴν φωνήν, οἰόμενος μέγα τι ζῷον εἶναι. Προσμείνας δὲ μικρόν, ὡς εἶδεν αὐτὸν προελθόντα τῆς λίμνης, προσελθὼν αὐτὸν κατέπατησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ δεῖ πρὸ τῆς ὄψεως δι’ ἀκοῆς μόνης ταράττεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 37 Lb 74 Lc 18 Le 74 Lf 37 Lg 18 Lh 31 Mg 99 Ml 95.</p>
+          <bibl>Codd. La 37 Lb 74 Lc 18 Le 74 Lf 37 Lg 18 Lh 31 Mg 99 Ml 95.</bibl>
         </div>
         <div>
           <head>Chambry 202.4</head>
@@ -5583,7 +5582,7 @@
           <pb ed="perry" n="P141"/>
           <p><milestone unit="recitprose"/>Βατράχου μέγα κεκραγότος, ἐστράφη πρὸς τὴν φωνὴν ὁ λέων, οἰόμενος μέγα τι ζῷον εἶναι. Προσμείνας δὲ μικρόν, ὡς ἐθεάσατο τοῦτον ἐκ τῆς λίμνης ἐξίοντα, προσελθὼν κατεπάτησεν αὐτὸν εἰπών· « Μηδεὶς πρὸ τοῦ ἰδεῖν ταραττέσθω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος οὗτος πρὸς ἄνδρας γλωσσώδεις οἵτινες οὐδὲν πλέον τοῦ λαλεῖν δύνανται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mm 40.</p>
+          <bibl>Cod. Mm 40.</bibl>
         </div>
         <div>
           <head>Chambry 202.5</head>
@@ -5599,7 +5598,7 @@
           <l><milestone unit="recitvers"/>ἀλλ’ ἀνδρεία, φρόνησις, βουλὴ καλλίστη</l>
           <l><milestone unit="recitvers"/>στερρώτερον αὐτοῦ νοῦν ἀπεργαζέσθων. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρας γλωσσώδεις, μηδὲν δὲ πλέον τοῦ λαλεῖν δυναμένους· οὗτοι γλῶσσαν μὲν οὖν ἔχουσι, ἰσχὺν δ’ οὐδ’ ὅλως.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 73.</p>
+          <bibl>Cod. Cd 73.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-203">
@@ -5608,7 +5607,7 @@
         <pb ed="perry" n="P145"/>
         <p><milestone unit="recitprose"/>Λέων ἐπί τινι αἰγιαλῷ πλαζόμενος, ὡς ἐθεάσατο δελφῖνα παρακύψαντα, [ὡς] ἐπὶ συμμαχίαν τοῦτον παρεκάλεσε λέγων ὅτι ἁρμόττει μάλιστα φίλους αὐτοὺς καὶ βοηθοὺς γενέσθαι· ὁ μὲν γὰρ τῶν θαλαττίων ζῴων, αὐτὸς δὲ τῶν χερσαίων βασιλεύει. Τοῦ δὲ ἀσμένως ἐπινεύσαντος, ὁ λέων ἐπὶ πολὺν χρόνον μάχην ἔχων πρὸς ταῦρον ἄγριον ἐπεκαλεῖτο τὸν δελφῖνα ἐπὶ βοήθειαν. Ὡς δὲ ἐκεῖνος καίπερ βουλόμενος ἐκϐῆναι τῆς θαλάσσης οὐκ ἠδύνατο, ᾐτιᾶτο αὐτὸν ὁ λέων ὡς προδότην. Ὁ δὲ ὑποτυχὼν εἶπεν· « Ἀλλὰ μὴ ἐμὲ μέμφου, ἀλλὰ τὴν φύσιν, ἥτις με θαλάττιον ποιήσασα γῆς οὐκ ἐᾷ ἐπιϐαίνειν. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως καὶ ἡμᾶς δεῖ φιλίαν σπενδομένους τοιούτους ἐπιλέγεσθαι συμμάχους οἳ ἐν κινδύνοις παρεῖναι ἡμῖν δύνανται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 140 Pb 143 Pf 77 Ph 72 Me 100 Mf 84 Mj 94.</p>
+        <bibl>Codd. Pa 140 Pb 143 Pf 77 Ph 72 Me 100 Mf 84 Mj 94.</bibl>
         <p><milestone unit="traduction"/>Un lion errant sur une plage vit un dauphin qui sortait la tête hors de l’eau. Il lui proposa une alliance. « Il nous sied tout à fait, dit-il, d’être amis et alliés, puisque toi, tu es le roi des animaux marins, et moi, des animaux terrestres. » Le dauphin acquiesça volontiers. Or le lion, qui était depuis longtemps en guerre avec un taureau sauvage, appela le dauphin à son secours. Celui-ci essaya de sortir de l’eau, mais ne put y réussir. Alors le lion l’accusa de trahison. « Ce n’est pas à moi, répliqua le dauphin, mais à la nature qu’il faut t’en prendre : elle m’a fait aquatique et ne me permet pas de marcher sur terre ».</p>
         <p><milestone unit="traduction"/>Ceci prouve que nous aussi, quand nous contractons amitié, nous devons choisir des alliés qui puissent être à nos côtés au jour du danger.</p>
       </div>
@@ -5618,7 +5617,7 @@
         <pb ed="perry" n="P338"/>
         <p><milestone unit="recitprose"/>Θέρους ἐν ὥρᾳ, ὅτε τὸ καῦμα δίψαν ἐμποιεῖ, εἰς μικρὰν πηγὴν λέων καὶ κάπρος ἦλθον πιεῖν. Ἤριζον δὲ τίς πρῶτος αὐτῶν πίῃ· ἐκ τούτου δὲ πρὸς φόνον ἀλλήλων διηγέρθησαν. Ἄφνω δὲ ἐπιστραφέντες πρὸς τὸ ἀναπνεῦσαι, εἶδον γῦπας ἐκδεχομένους ὃς ἂν αὐτῶν πέσῃ, τοῦτον καταφαγεῖν. Διὰ τοῦτο λύσαντες τὴν ἔχθραν εἶπον· « Κρεῖσσόν ἐστιν ἡμᾶς φίλους γενέσθαι ἢ βρῶμα γυψί καὶ κόραξιν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι τὰς πονηρὰς ἔριδας καὶ τὰς φιλονεικίας καλόν ἐστι διαλύειν, ἐπειδὴ πᾶσιν ἐπικίνδυνον τέλος ἄγουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 49 Bb 31.</p>
+        <bibl>Codd. Ba 49 Bb 31.</bibl>
         <p><milestone unit="traduction"/>Dans la saison d’été, quand la chaleur fait naître la soif, un lion et un sanglier vinrent boire à une petite source. Ils se querellèrent à qui boirait le premier, et de la querelle ils en vinrent à une lutte à mort. Mais soudain s’étant retournés pour reprendre haleine, ils virent des vautours qui attendaient pour dévorer celui qui tomberait le premier. Aussi, mettant fin à leur inimitié, ils dirent : « Il vaut mieux devenir amis que de servir de pâture à des vautours et à des corbeaux. »</p>
         <p><milestone unit="traduction"/>Il est beau de mettre fin aux méchantes querelles et aux rivalités ; car l’issue en est dangereuse pour tous les partis.</p>
       </div>
@@ -5628,7 +5627,7 @@
         <pb ed="perry" n="P148"/>
         <p><milestone unit="recitprose"/>Λέων περιτυχών λαγωῷ κοιμωμένῳ, τοῦτον ἔμελλε καταφαγεῖν· μεταξὺ δὲ θεασάμενος ἔλαφον παριοῦσαν, ἀφεὶς τὸν λαγωόν, ἐκείνην ἐδίωκεν. Ὁ μὲν οὖν παρὰ τὸν ψόφον ἐξαναστὰς ἔφυγεν. Ὁ δὲ λέων ἐπὶ πολὺ διώξας τὴν ἔλαφον, ἐπειδὴ καταλαϐεῖν οὐκ ἠδυνήθη, ἐπανῆλθεν ἐπὶ τὸν λαγωόν· εὑρὼν δὲ καὶ αὐτὸν πεφευγότα ἔφη· « Ἀλλ’ ἐγὼ δίκαια πέπονθα, ὅτι ἀφεὶς τὴν ἐν χερσὶ βοράν, ἐλπίδα μείζονα προέκρινα. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων μετρίοις κέρδεσι μὴ ἀρκούμενοι, μείζονας δὲ ἐλπίδας διώκοντες λανθάνουσι καὶ τὰ ἐν χερσὶ προϊέμενοι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 143 Pb 146 Pc 81 Pd 34 Pf 78 Pg 97 Mb 95 Me 101 Mf 85 Mj 95 Ca 97.</p>
+        <bibl>Codd. Pa 143 Pb 146 Pc 81 Pd 34 Pf 78 Pg 97 Mb 95 Me 101 Mf 85 Mj 95 Ca 97.</bibl>
         <p><milestone unit="traduction"/>Un lion, étant tombé sur un lièvre endormi, allait le dévorer ; mais entre temps il vit passer un cerf : il laissa le lièvre et donna la chasse au cerf. Or le lièvre, éveillé par le bruit, prit la fuite ; et le lion, avant poursuivi le cerf au loin, sans pouvoir l’atteindre, revint au lièvre et trouva qu’il s’était sauvé lui aussi. « C’est bien fait pour moi, dit-il, puisque lâchant la pâture que j’avais en main, j’ai préféré l’espoir d’une plus belle proie. »</p>
         <p><milestone unit="traduction"/>Ainsi parfois les hommes, au lieu de se contenter de profils modérés, poursuivent de plus belles espérances, et lâchent imprudemment ce qu’ils ont en main.</p>
       </div>
@@ -5638,7 +5637,7 @@
         <pb ed="perry" n="P258"/>
         <p><milestone unit="recitprose"/>Λέων γηράσας ἐνόσει κατακεκλιμένος ἐν ἄντρῳ. Παρῆσαν δ’ ἐπισκεψόμενα τὸν βασιλέα, πλὴν ἀλώπεκος, τἄλλα τῶν ζῴων. Ὁ τοίνυν λύκος λαϐόνενος εὐκαιρίας κατηγόρει παρὰ τῷ λέοντι τῆς ἀλώπεκος, ἅτε δὴ παρ’ οὐδὲν τιθεμένης τὸν πάντων αὐτῶν κρατοῦντα, καὶ διὰ ταῦτα μηδ’ εἰς ἐπίσκεψιν ἀφιγμένης. Ἐν τοσούτῳ δὲ παρῆν καὶ ἡ ἀλώπηξ, καὶ τῶν τελευταίων ἠκροάσατο τοῦ λύκου ῥημάτων. Ὁ μὲν οὖν λέων κατ’ αὐτῆς ἐϐρυχᾶτο. Ἡ δ’ ἀπολογίας καιρὸν αἰτήσασα· « Καὶ τίς σε, ἐφη, τῶν συνελθόντων τοσοῦτον ὠφέλησεν ὅσον ἐγώ, πανταχόσε περινοστήσασα, καὶ θεραπείαν ὑπὲρ σοῦ παρ’ ἰατρῶν ζητήσασα καὶ μαθοῦσα ; » Τοῦ δὲ λέοντος εὐθὺς τὴν θεραπείαν εἰπεῖν κελεύσαντος, ἐκείνη φησίν· « Εἰ λύκον ζῶντα ἐκδείρας τὴν αὐτοῦ δορὰν θερμὴν ἀμφιέσῃ. » Καὶ τοῦ λύκου αὐτίκα νεκροῦ κειμένου, ἡ ἀλώπηξ γελῶσα εἶπεν οὕτως· « Οὐ χρὴ τὸν δεσπότην πρὸς δυσμένειαν παρακινεῖν, ἀλλὰ πρὸς εὐμένειαν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ καθ’ ἑτέρου μηχανώμενος καθ’ ἑαυτοῦ τὴν μηχανὴν περιτρέπει.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 73 Lb 77 Lf 73 Lh 34 Md 127 Me 109 Mf 91 Mg 103 Mi 101 Mm 95.</p>
+        <bibl>Codd. La 73 Lb 77 Lf 73 Lh 34 Md 127 Me 109 Mf 91 Mg 103 Mi 101 Mm 95.</bibl>
         <p><milestone unit="traduction"/>Le lion devenu vieux était couché, malade, dans son antre, et tous les animaux étaient venus rendre visite à leur prince, à l’exception du renard. Alors le loup, saisissant l’occasion favorable, accusa le renard par-devant le lion : « il n’avait, disait-il, aucun égard pour celui qui était leur maître à tous, et c’est pour cela qu’il n’était même pas venu le visiter. » Sur ces entrefaites le renard arrivait lui aussi, et il entendit les dernières paroles du loup. Alors le lion poussa un rugissement contre le renard. Mais celui-ci, ayant demandé un moment pour se justifier : « Et qui, dit-il, parmi tous ceux qui sont ici réunis, t’a rendu un aussi grand service que moi, qui suis allé partout demander aux médecins un remède pour te guérir, et qui l’ai trouvé ? » Le lion lui enjoignit de dire aussitôt quel était ce remède. Le renard répondit : « C’est d’écorcher vif un loup, et de te revêtir de sa peau toute chaude. » Le loup fut incontinent mis à mort, et le renard dit en riant : « Il ne faut pas exciter le maître à la malveillance, mais à la douceur, »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’en dressant des embûches à un autre on se tend un piège à soi-même.</p>
       </div>
@@ -5650,7 +5649,7 @@
           <pb ed="perry" n="P150"/>
           <p><milestone unit="recitprose"/>Λέοντος κοιμωμένου μῦς τῷ σώματι ἐπέδραμεν. Ὁ δὲ ἐξαναστὰς καὶ συλλαϐὼν αὐτὸν οἷός τε ἦν καταθοινήσασθαι. Τοῦ δὲ δεηθέντος μεθεῖναι αὐτὸν καὶ λέγοντος ὅτι σωθεὶς χάριτας αὐτῷ ἀποδώσει, γελάσας ἀπέλυσεν αὐτόν. Συνέϐη δὲ αὐτὸν μετ’ οὐ πολὺ τῇ τοῦ μυὸς χάριτι περισωθῆναι· ἐπειδὴ γὰρ συλληφθεὶς ὑπό τινων κυνηγετῶν κάλῳ ἐδέθη τινὶ δένδρῳ, τὸ τηνικαῦτα ἀκούσας ὁ μῦς αὐτοῦ στένοντος ἐλθὼν τὸν κάλων περιέτρωγε καὶ λύσας αὐτὸν ἔφη· « Σὺ μὲν οὕτω μου τότε κατεγέλασας ὡς μὴ προσδεχόμενος παρ’ ἐμοῦ ἀμοιϐὴν κομιεῖσθαι· νῦν δὲ εὖ ἴσθι ὅτι ἐστὶ καὶ παρὰ μυσὶ χάρις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι καιρῶν μεταϐολαῖς οἱ σφόδρα δυνατοὶ τῶν ἀσθενεστέρων ἐνδεεῖς γίνονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 145 Pb 148 Pc 83 Ma 101 Mb 97 Ca 98.</p>
+          <bibl>Codd. Pa 145 Pb 148 Pc 83 Ma 101 Mb 97 Ca 98.</bibl>
           <p><milestone unit="traduction"/>Un lion dormait ; un rat s’en vint trottiner sur son corps. Le lion, se réveillant, le saisit, et il allait le manger, quand le rat le pria de le relâcher, promettant, s’il lui laissait la vie, de le payer de retour. Le lion se mit à rire et le laissa aller. Or il arriva que peu de temps après il dut son salut à la reconnaissance du rat. Des chasseurs en effet le prirent et l’attachèrent à un arbre avec une corde. Alors le rat l’entendant gémir accourut, rongea la corde et le délivra. « Naguère, dit-il, tu t’es moqué de moi, parce que tu n’attendais pas de retour de ma part ; sache maintenant que chez les rats aussi on trouve de la reconnaissance. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que dans les changements de fortune les gens les plus puissants ont besoin des faibles.</p>
         </div>
@@ -5660,7 +5659,7 @@
           <pb ed="perry" n="P150"/>
           <p><milestone unit="recitprose"/>Λέων ἀγρεύσας μῦν ἔμελλε φαγεῖν. Ὁ δὲ ἱκέτευεν ἀφεθῆναι λέγων· « Ἔλαφον ἢ ἕτερον ζῷον δεῖ φαγεῖν σε καὶ χορτασθῆναι· ἐγὼ γὰρ οὐδὲ τὸ χεῖλός σου ἀλείψω αἵματι, ἀλλὰ φεῖσαί μου καὶ χάριν σοι ἐν καιρῷ ποτε ἀποδώσω. » Γελάσας δὲ ὁ λέων εἴασε τοῦτον ζῆν καὶ ἀφῆκεν αὐτόν. Χρόνῳ δέ τινι &lt;παγίδι&gt; ἐμπεσὼν ἠγρεύθη ὁ λέων καὶ δεθεὶς ἀπέγνω τῆς ἑαυτοῦ σωτηρίας. Ὁ μῦς δὲ ἐπιστὰς ἔφη· « Δύναμαι τὴν ἀντιχάριτά σοι ἀποδοῦναι καὶ σῶσαί σε, » καὶ τὰ δεσμὰ περιφαγὼν ἔλυσε τὸν λέοντα, ἐπάξιον δοὺς μισθόν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ εὐνοοῦντες ἄνθρωποι, κἂν πένητες ὦσι, δύνανται ἐν καιρῷ καὶ δυνάστην ὠφελεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 77 Bb 48.</p>
+          <bibl>Codd. Ba 77 Bb 48.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-208">
@@ -5671,7 +5670,7 @@
           <pb ed="perry" n="P339"/>
           <p><milestone unit="recitprose"/>Θῆρας ἐθήρευον λέων καὶ ὄναγρος, ὁ μὲν λέων διὰ τῆς δυνάμεως ὁ δὲ ὄναγρος διὰ τῆς ἐν ποσὶ ταχύτητος. Ἐπεὶ δὲ ζῷά τινα ἐθήρευσαν, ὁ λέων μερίζει καὶ τίθησι τρεῖς μοίρας, καί· « Τὴν μὲν μίαν, εἶπεν, λήψομαι ὡς πρῶτος· βασιλεὺς γάρ εἰμι· τὴν δὲ δευτέραν, ὡς ἐξ ἰσοῦ κοινωνός· ἡ δὲ τρίτη μοῖρα αὕτη κακὸν μέγα σοι ποιήσει, εἰ μὴ θελήσεις φυγεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καλὸν ἑαυτὸν μετρεῖν ἐν πᾶσι κατὰ τὴν ἑαυτοῦ ἰσχὺν καὶ δυνατωτέροις ἑαυτοῦ μὴ συνάπτειν μηδὲ κοινωνεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 52 Bb 32.</p>
+          <bibl>Codd. Ba 52 Bb 32.</bibl>
           <p><milestone unit="traduction"/>Le lion et l’onagre chassaient aux bêtes sauvages, le lion usant de sa force, l’onagre de la vitesse de ses pieds. Quand ils eurent pris un certain nombre de pièces, le lion partagea et fit trois parts qu’il étala. « Je prendrai la première, dit-il, comme étant le premier, puisque je suis roi ; la deuxième aussi, comme associé à part égale ; quant à la troisième, celle-là te portera malheur, si tu ne te décides pas à décamper. »</p>
           <p><milestone unit="traduction"/>Il convient en toutes choses de se mesurer à sa propre force, et de ne point se lier ni s’associer à de plus puissants que soi.</p>
         </div>
@@ -5688,7 +5687,7 @@
           <l><milestone unit="recitvers"/>εἰ δὲ τὴν τρίτην λάϐῃς, σὺν πόνῳ λήψῃ·</l>
           <l><milestone unit="recitvers"/>ἧ δ’ οὖν φυγὲ σύ, μὴ μόρον εὕρῃς τάχα. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι καλόν ἐστι μετρεῖν &lt;ἑαυτὸν&gt; ἐν ἅπασι κατὰ τὴν ἰδίαν ἰσχύν, τοῖς δὲ δυνατοῖς μὴ συνάπτειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 100.</p>
+          <bibl>Cod. Mb 100.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-209">
@@ -5697,7 +5696,7 @@
         <pb ed="perry" n="P151"/>
         <p><milestone unit="recitprose"/>Λέων καὶ ὄνος κοινωνίαν πρὸς ἀλλήλους ποιησάμενοι ἐξῆλθον ἐπὶ θήραν. Γενομένων δὲ αὐτῶν κατά τι σπήλαιον ἐν ᾧ ἦσαν αἶγες ἄγριαι, ὁ μὲν λέων πρὸ τοῦ στομίου στὰς ἐξιούσας παρετηρεῖτο, ὁ δὲ εἰσελθὼν ἐνήλατό τε αὐταῖς καὶ ὠγκᾶτο ἐκφοϐεῖν βουλόμενος. Τοῦ δὲ λέοντος τὰς πλείστας συλλαϐόντος, ἐξελθὼν ἐπυνθάνετο αὐτοῦ εἰ γενναίως ἠγωνίσατο καὶ τὰς αἶγας ἐξεδίωξεν. Ὁ δὲ εἶπεν· « Ἀλλ’ εὖ ἴσθι ὅτι κἀγὼ ἄν σε ἐφοϐήθην, εἰ μὴ ᾔδειν σε ὄνον ὄντα. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ παρὰ τοῖς εἰδόσιν ἀλαζονευόμενοι εἰκότως γέλωτα ὀφλισκάνουσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 146 Pb 149 Pc 84 Pf 81 Ph 73 Mb 99 Me 104 Mf 88 Mj 98 Ca 99.</p>
+        <bibl>Codd. Pa 146 Pb 149 Pc 84 Pf 81 Ph 73 Mb 99 Me 104 Mf 88 Mj 98 Ca 99.</bibl>
         <p><milestone unit="traduction"/>Le lion et l’âne, ayant lié partie ensemble, étaient sortis pour chasser. Étant arrivés à une caverne où il y avait des chèvres sauvages, le lion se posta à l’entrée pour guetter leur sortie, et l’âne, ayant pénétré à l’intérieur, se mit à bondir au milieu d’elles et à braire pour les faire fuir. Quand le lion en eut pris la plus grande partie, l’âne sortit et lui demanda s’il n’avait pas bravement combattu et poussé les chèvres dehors, « Sache bien, répondit le lion, que tu m’aurais fait peur à moi-même, si je n’avais pas su que tu étais un âne. »</p>
         <p><milestone unit="traduction"/>C’est ainsi que les gens qui se vantent devant ceux qui les connaissent prêtent justement à la moquerie.</p>
       </div>
@@ -5709,7 +5708,7 @@
           <pb ed="perry" n="P149"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ὄνος καὶ ἀλώπηξ κοινωνίαν εἰς ἀλλήλους σπεισάμενοι ἐξῆλθον εἰς ἄγραν. Πολλὴν δὲ αὐτῶν συλλαϐόντων, ὁ λέων προσέταξε τῷ ὄνῳ διελεῖν αὐτοῖς. Τοῦ δὲ τρεῖς μοίρας ἐξ ἴσου ποιήσαντος, καὶ ἐκλέξασθαι αὐτῷ παραινοῦντος, ὁ λέων ἀγανακτήσας ἁλλόμενος κατεθοινήσατο καὶ τῇ ἀλώπεκι μερίσαι προσέταξεν. Ἡ δε πάντα εἰς μίαν μερίδα συναθροίσασα καὶ μικρὰ ἑαυτῇ ὑπολιπομένη παρῄνει αὐτῷ ἑλέσθαι. Ἐρομένου δὲ αὐτὴν τοῦ λέοντος τίς αὐτὴν οὕτω διανέμειν ἐδίδαξεν, ἡ ἀλώπηξ εἶπεν· « Ἡ τοῦ ὄνου συμφορά. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι σωφρονισμὸς γίνεται τοῖς ἀνθρώποις τὰ τῶν πέλας δυστυχήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 144 Pb 147 Pc 82 Pf 80 Pg 98 Ma 100 Mb 96 Me 103 Mj 97.</p>
+          <bibl>Codd. Pa 144 Pb 147 Pc 82 Pf 80 Pg 98 Ma 100 Mb 96 Me 103 Mj 97.</bibl>
           <p><milestone unit="traduction"/>Le lion, l’âne et le renard, ayant lié société ensemble, partirent pour la chasse. Quand ils eurent pris du gibier en abondance, le lion enjoignit à l’âne de le partager entre eux. L’âne fit trois parts égales et dit au lion de choisir. Le lion indigné bondit sur lui et le dévora. Puis il enjoignit au renard de faire le partage. Celui-ci entassa tout sur un seul lot, ne se réservant que quelques bribes ; après quoi il pria le lion de choisir. Celui-ci lui demanda qui lui avait appris à partager ainsi : « Le malheur de l’âne », répliqua t-il.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’on s’instruit en voyant le malheur de son prochain.</p>
         </div>
@@ -5719,7 +5718,7 @@
           <pb ed="perry" n="P149"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ὄνος καὶ ἀλώπηξ κοινωνίαν πρὸς ἀλλήλους ποιησάμενοι ἐξῆλθον πρὸς ἄγραν. Πολλὴν οὖν θήραν συλλαϐόντες ἦλθον εἰς τὸ φαγεῖν. Προσέταξε γοῦν τῷ ὄνῳ ὁ λέων διελεῖν αὐτήν. Τοῦ δὲ τρεῖς μοίρας ἐξ ἴσου ποιήσαντος, καὶ ἐκλέξασθαι παραινοῦντος αὐτούς, ὁ λέων ἀγανακτήσας κατεθοινήσατο τὸν ὄνον· εἶτα προσέταξε τῇ ἀλώπεκι μοιράσαι. Ἡ δὲ ἅπαντα εἰς μίαν μερίδα συνῆξε, καταλιποῦσα μικρὰν καὶ οὐδαμινὴν μερίδα ἑαυτῇ. Ὁ δὲ λέων ἔφη· « Ὦ φίλη, τίς σε οὕτως διανέμειν ἐδίδαξεν ; » Ἡ δὲ ἀλώπηξ ἔφη· « Ἡ τοῦ ὄνου συμφορά. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι σωφρονισμοὶ τοῖς ἀνθρώποις γίνονται τὰ τῶν πέλας δυστυχήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 109 Cb 65 Ce 72 Cf 76 Cg 1 Ch 76 Mc 65 Md 75 Mh 70 Mm 90 Lc 49 Lg 49.</p>
+          <bibl>Codd. Ca 109 Cb 65 Ce 72 Cf 76 Cg 1 Ch 76 Mc 65 Md 75 Mh 70 Mm 90 Lc 49 Lg 49.</bibl>
         </div>
         <div>
           <head>Chambry 210.3</head>
@@ -5727,7 +5726,7 @@
           <pb ed="perry" n="P149"/>
           <p><milestone unit="recitprose"/>Λέων καὶ ὄνος καὶ ἀλώπηξ κοινωνίαν ποιησάμενοι ἐξῆλθον πρὸς ἄγραν. Πολλῆς οὖν θήρας συλληφθείσης, προσέταξεν ὁ λέων τῷ ὄνῳ διελεῖν αὐτοῖς. Ὁ δὲ τρεῖς μερίδας ποιησάμενος ἐκ τῶν ἴσων, ἐκλέξασθαι τούτους προὐτρέπετο. Καὶ ὁ λέων θυμωθεὶς τὸν ὄνον κατέφαγεν. Εἶτα τῇ ἀλώπεκι μερίζειν ἐκέλευσεν. Ἡ δ’ εἰς μίαν μερίδα πάντα σωρεύσασα ἑαυτῇ βραχύ τι κατέλιπε. Καὶ ὁ λέων πρὸς αὐτήν· « Τίς σε, ὦ βελτίστη, διαιρεῖν οὕτως ἐδίδαξεν ; » Ἡ δ’ εἶπεν· « Ἡ τοῦ ὄνου συμφορά. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι σωφρονισμοὶ γίνονται τοῖς ἀνθρώποις τὰ τῶν πέλας δυστυχήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 38 Lb 75 Le 75 Lf 38 Lh 32 Me 103 Mf 87 Mg 100 Ml 94.</p>
+          <bibl>Codd. La 38 Lb 75 Le 75 Lf 38 Lh 32 Me 103 Mf 87 Mg 100 Ml 94.</bibl>
         </div>
         <div>
           <head>Chambry 210.4</head>
@@ -5747,7 +5746,7 @@
           <l><milestone unit="recitvers"/>« Τίς σ’ ἐδίδαξε μερίζειν οὕτως, φίλη ; »</l>
           <l><milestone unit="recitvers"/>« Ἡ συμφορὰ τοῦ ὄνου τοῦ μακαρίτου. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι σωφρονισμοὶ τοῖς ἀνθρώποις τυγχάνουσι τὰ τῶν πέλας δυστυχήματα.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 76.</p>
+          <bibl>Cod. Cd 76.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-211">
@@ -5756,7 +5755,7 @@
         <pb ed="perry" n="P259"/>
         <p><milestone unit="recitprose"/>Λέων κατεμέμφετο Προμηθέα πολλάκις ὅτι μέγαν αὐτὸν ἔπλασε καὶ καλόν, καὶ τὴν μὲν γένυν ὥπλισε τοῖς ὀδοῦσι, τοὺς δὲ πόδας ἐκράτυνε τοῖς ὄνυξιν, ἐποίησέ τε τῶν ἄλλων θηρίων δυνατώτερον· « ὁ δὲ τοιοῦτος, ἔφασκε, τὸν ἀλεκτρυόνα φοϐοῦμαι. » Καὶ ὁ Προμηθεὺς ἔφη· « Τί με μάτην αἰτιᾷ ; τὰ γὰρ ἐμὰ πάντα ἔχεις ὅσα πλάττειν ἐδυνάμην· ἡ δέ σου ψυχὴ πρὸς τοῦτο μόνον μαλακίζεται. » Ἔκλαιεν οὖν ἑαυτὸν ὁ λέων καὶ τῆς δειλίας κατεμέμφετο καὶ τέλος ἀποθανεῖν ἤθελεν. Οὕτω δὲ γνώμης ἔχων ἐλέφαντι περιτυγχάνει, καὶ προσαγορεύσας εἱστήκει διαλεγόμενος, καὶ ὁρῶν διαπαντὸς τὰ ὦτα κινοῦντα· « Τί πάσχεις ; ἔφη, καὶ τί ποτε οὐδὲ μικρὸν ἀτρεμεῖ σου τὸ οὖς ; » Καὶ ὁ ἐλέφας, κατὰ τυχὴν περιπτάντος αὐτῷ κώνωπος· « Ὁρᾷς, ἔφη, τοῦτο τὸ βραχύ, τὸ βομϐοῦν ; ἢν εἰσδύνῃ μου &lt;τῇ&gt; τῆς ἀκοῆς ὁδῷ, τέθνηκα. » Καὶ ὁ λέων· « Τί οὖν ἔτι ἀποθνῄσκειν, ἔφη, με δεῖ τοσοῦτον ὄντα καὶ ἐλέφαντος εὐτυχέστερον ὅσῳ κρείττων κώνωπος ὁ ἀλεκτρυών ; »</p>
         <p><milestone unit="epimythiumprose"/>Ὁρᾷς ὅσον ἰσχύος ὁ κώνωψ ἔχει, ὡς καὶ ἐλεφαντα φοϐεῖν.</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 90.</p>
+        <bibl>Cod. Mb 90.</bibl>
         <p><milestone unit="traduction"/>Le lion se plaignait souvent de Prométhée. Sans doute Prométhée l’avait fait grand et beau, il lui avait armé la mâchoire de dents et muni les pattes de griffes, il l’avait lait plus fort que tous les autres animaux ; « mais avec tout cela, ajoutait-il, j’ai peur du coq. » Prométhée lui répondit : « Pourquoi m’accuses-tu à la légère ? N’as-tu pas tous les avantages physiques que j’ai pu modeler ? Mais c’est ton âme qui faiblit à ce seul objet. » Le lion déplorait donc son sort et s’accusait de lâcheté ; à la fin il voulut en finir avec la vie. Il était dans ces dispositions, quand il rencontra l’éléphant ; il le salua et s’arrêta pour causer. Ayant remarqué qu’il remuait continuellement les oreilles : « Qu’as-tu, lui demanda-t-il » et pourquoi donc ton oreille ne saurait-elle rester tant soit peu sans bouger ? — Tu vois », répondit l’éléphant, tandis qu’un cousin voltigeait par hasard autour de lui, « tu vois cet être minuscule, qui bourdonne ; s’il pénètre dans le conduit de mon oreille, je suis mort. » Alors le lion se dit : « Qu’ai-je encore besoin de mourir, moi qui suis si puissant et qui surpasse en bonheur l’éléphant autant que le coq surpasse en force le cousin ? »</p>
         <p><milestone unit="traduction"/>On voit que le cousin est assez fort pour faire peur même à l’éléphant.</p>
       </div>
@@ -5768,7 +5767,7 @@
           <pb ed="perry" n="P143"/>
           <p><milestone unit="recitprose"/>Λέων ταῦρῳ παμμεγέθει ἐπιϐουλεύων ἐϐουλήθη δόλῳ αὐτοῦ περιγενέσθαι. Διόπερ πρόϐατον τεθυκέναι φήσας ἐφ’ ἑστίασιν αὐτὸν ἐκάλεσε, βουλόμενος κατακλιθέντα αὐτὸν καταγωνίσασθαι. Ὁ δὲ ἐλθὼν καὶ θεασάμενος λέϐητάς τε πολλοὺς καὶ ὀϐελίσκους μεγάλους, τὸ δὲ πρόϐατον οὐδαμοῦ, μηδὲν εἰπὼν ἀπηλλάττετο. Τοῦ δὲ λέοντος αἰτιωμένου αὐτὸν καὶ τὴν αἰτίαν πυνθανομένου δι’ ἣν οὐδὲν δεινὸν παθὼν ἄλογος ἄπεισιν, ἔφη· « Ἀλλ’ ἔγωγε οὐ μάτην τοῦτο ποιῶ· ὁρῶ γὰρ παρασκευὴν οὐχὶ ὡς εἰς πρόϐατον, ἀλλ’ εἰς ταῦρον ἡτοιμασμένην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοὺς φρονίμους τῶν ἀνθρώπων αἱ τῶν πονηρῶν τέχναι οὐ λανθάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 138 Pb 141 Pc 79 Pg 94 Ma 97.</p>
+          <bibl>Codd. Pa 138 Pb 141 Pc 79 Pg 94 Ma 97.</bibl>
           <p><milestone unit="traduction"/>Un lion, qui tramait la mort d’un taureau énorme, projeta de s’en rendre maître par la ruse. Il lui dit qu’il avait sacrifié un mouton et l’invita au festin ; son intention était de le tuer, quand il serait couché à table. Le taureau vint ; mais apercevant force bassins, de grandes broches, mais de mouton nulle part, il s’en alla sans mot dire. Le lion lui en fit des reproches et lui demanda pourquoi, n’ayant souffert aucun mal, il s’en allait sans raison. Il répondit : « Ce n’est pas sans raison que j’en use ainsi ; car je vois des ustensiles comme on en prépare non pour un mouton, mais pour un taureau. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les gens sensés ne se laissent pas prendre aux artifices des méchants.</p>
         </div>
@@ -5778,7 +5777,7 @@
           <pb ed="perry" n="P143"/>
           <p><milestone unit="recitprose"/>Λέων ταύρῳ παμμεγέτει ἐπιϐουλεύων ἐϐουλήθη αὐτοῦ περιγενέσθαι. Καὶ δὴ προσκαλεσάμενος ὁ λέων τὸν ταῦρον ἔφη πρὸς αὐτόν· « Πρόϐατον ἔθυσα, ὦ φίλε, καί, εἰ βούλει, σήμερον συνεστιαθῶμεν ὁμοῦ. » Ἐϐούλετο δὲ ὁ λέων μετὰ τὸ κατακλιθῆναι τὸν ταῦρον καταθοινήσασθαι αὐτόν. Ὁ δὲ ἐλθὼν καὶ θεασάμενος λέϐητας πολλοὺς καὶ ὀϐελίσκους μεγάλους, τὸ δὲ πρόϐατον μηδαμοῦ, μηδὲν εἰπὼν ἀπηλλάττετο. Τοῦ δὲ λέοντος αἰτιωμένου αὐτὸν καὶ τὴν αἰτίαν μαθεῖν θέλοντος δι’ ἣν οὐδὲν δεινὸν παθὼν ἀλόγως ἄπεισιν, ἔφη ὁ ταῦρος· « Ἀλλ’ ἔγωγε οὐ μάτην τοῦτο ποιῶ καὶ φεύγω, ὦ λέον· ὁρῶ γὰρ κατασκευὴν οὐχ ὡς εἰς πρόϐατον, ἀλλ’ εἰς ταῦρον ἡτοιμασμένην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὕτω καὶ τοὺς φρονίμους τῶν ἀνθρώπων αἱ τῶν πονηρῶν τέχναι οὐ λανθάνουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 92 Cb 64 Ce 71 Cf 75 Ch 75 Mc 64 Md 74 Mh 69 Ml 101 Mm 89.</p>
+          <bibl>Codd. Ca 92 Cb 64 Ce 71 Cf 75 Ch 75 Mc 64 Md 74 Mh 69 Ml 101 Mm 89.</bibl>
         </div>
         <div>
           <head>Chambry 212.3</head>
@@ -5797,7 +5796,7 @@
           <l><milestone unit="recitvers"/>οὐκ εἰς πρόϐατον παρασκευὴν τυγχάνειν,</l>
           <l><milestone unit="recitvers"/>ἀλλ’ εἰς ταῦρον μήκιστον ἡτοιμασμένην. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοὺς φρονίμους τῶν ἀνθρώπων αἱ τῶν πονηρῶν τέχναι οὐ λανθάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 75.</p>
+          <bibl>Cod. Cd 75.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-213">
@@ -5808,7 +5807,7 @@
           <pb ed="perry" n="P341"/>
           <p><milestone unit="recitprose"/>Λέων ἐλύσσα. Τοῦτον δὲ ἔλαφος ἐξ ὕλης ἰδὼν εἶπεν· « Οὐαὶ ἡμῖν τοῖς ταλαιπώροις· τί γὰρ μαινόμενος οὗτος οὐχὶ ποιήσει, ὃς καὶ σωφρονῶν οὐκ ἦν ἡμῖν φορητός ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς θυμώδεις ἄνδρας καὶ ἀδικεῖν εἰθισμένους πάντες φευγέτωσαν ἀρχὴν λαϐόντας καὶ δυναστεύσαντας.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 74.</p>
+          <bibl>Cod. Ba 74.</bibl>
           <p><milestone unit="traduction"/>Un lion était enragé. Un cerf l’ayant vu de la forêt s’écria : « Hélas ! malheur à nous ! Que ne fera pas ce lion dans sa fureur, lui qui, même de sang-froid, nous était insupportable ? »</p>
           <p><milestone unit="traduction"/>Évitons les hommes emportés et habitués à faire du mal, quand ils ont pris le pouvoir et qu’ils règnent.</p>
         </div>
@@ -5821,7 +5820,7 @@
           <l><milestone unit="recitvers"/>τί γὰρ μεμηνὼς οὕτως οὐχὶ ποιήσει,</l>
           <l><milestone unit="recitvers"/>ὃς ὑπῆρχε οὐδὲ σωφρονῶν φορητός. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρα φύσει ὀργιλὸν καὶ αἱμοϐόρον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 89.</p>
+          <bibl>Cod. Mb 89.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-214">
@@ -5832,7 +5831,7 @@
           <pb ed="perry" n="P146"/>
           <p><milestone unit="recitprose"/>Λέοντος κοιμωμένου μῦς τὸ σῶμα διέδραμεν. Ὁ δὲ ἐξαναστὰς πανταχόθεν περιειλίττετο ζητῶν τὸν προσεληλυθότα. Ἀλώπηξ δὲ αὐτὸν θεασαμένη ὠνείδιζεν, εἰ λέων ὤν μῦν ηὐλαϐήθη. Καὶ ὃς ἀπεκρίνατο· « Οὐ τὸν μῦν ἐφοϐήθην, ἐθαύμασα δὲ εἴ τις λέοντος κοιμωμένου τὸ σῶμα ἐπιδραμεῖν ἐτόλμησεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος διδάσκει τοὺς φρονίμους τῶν ἀνθρώπων μηδὲ τῶν μετρίων πραγμάτων καταφρονεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 141 Pb 144 Pd 33 Pg 95 Ma 99 Ca 95.</p>
+          <bibl>Codd. Pa 141 Pb 144 Pd 33 Pg 95 Ma 99 Ca 95.</bibl>
           <p><milestone unit="traduction"/>Un lion dormait ; une souris courut tout le long de son corps. Le lion s’éveilla et se tourna dans tous les sens, cherchant celui qui l’avait affronté. Un renard, le voyant faire, le gourmanda d’avoir peur, lui lion, d’une souris. À quoi le lion répondit : « Ce n’est pas que j’aie eu peur de la souris, mais j’ai été surpris que quelqu’un ait osé courir sur le corps du lion endormi. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes sensés ne dédaignent pas même les petites choses.</p>
         </div>
@@ -5842,7 +5841,7 @@
           <pb ed="perry" n="P146"/>
           <p><milestone unit="recitprose"/>Λέων ποτὲ καύματος ὥρᾳ ἔν τινι σπηλαίῳ ἀνεπαύετο. Μυὸς δὲ διὰ τῆς χαίτης αὐτοῦ διαδραμόντος, ταραχθεὶς ἐξαναστὰς φοϐερὸν ἀπέϐλεπεν. Ἀλώπεκος δὲ καταγελώσης, εἶπεν· « Οὐ τὸν μῦν ἐφοϐήθην, ἀλλὰ τὴν πεῖραν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοῖς γενναίοις ἀπειρία χεῖρόν ἐστι τοῦ κολάζεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 108.</p>
+          <bibl>Cod. Ma 108.</bibl>
         </div>
         <div>
           <head>Chambry 214.3</head>
@@ -5850,7 +5849,7 @@
           <pb ed="perry" n="P146"/>
           <p><milestone unit="recitprose"/>Κοιμωμένου λέοντος, μῦς ἐπέδραμεν τῇ χαίτῃ αὐτοῦ. Ὁ δὲ ἀνεπήδησε καὶ ἐθυμώθη. Ἀλώπηξ δὲ ἰδοῦσα ἐπεγέλασεν, ὡς τοιοῦτος ὢν τὸν μῦν πτοεῖται. Ὁ δὲ ἔφη· « Οὐ τὸν μῦν δέδοικα, ἀλλὰ τὴν κακὴν ὁδὸν καὶ συνήθειαν ἀνακόπτω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁτι τῇ κακῇ συνηθείᾳ οὐ δεῖ παρέχειν ἄδειαν· νομὴν γὰρ λαϐοῦσα λύπην ἐσχάτην ποιεῖ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 65 Bb 41.</p>
+          <bibl>Codd. Ba 65 Bb 41.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-215">
@@ -5859,7 +5858,7 @@
         <pb ed="perry" n="P152"/>
         <p><milestone unit="recitprose"/>Λῃστὴς ἐν ὁδῷ τινα ἀποκτείνας, ἐπειδὴ ὑπὸ τῶν παρατυχόντων ἐδιώκετο, καταλιπὼν αὐτὸν ᾑμαγμένον, ἔφευγε. Τῶν δὲ ἀντικρὺς ὁδευόντων πυνθανομένων αὐτοῦ τίνι μεμελυσμένας ἔχει τὰς χεῖρας, ἔλεγεν ἀπὸ συκαμίνου νεωστὶ καταϐεϐηκέναι. Καὶ ὡς ταῦτα ἔλεγεν, οἱ διώκοντες αὐτὸν ἐπελθόντες καὶ συλλαϐόντες ἀπό τινος συκαμίνου ἀνεσταύρωσαν. Ἡ δὲ ἔφη πρὸς αὐτόν· « Ἀλλ’ ἔγωγε οὐκ ἄχθομαι πρὸς τὸν σὸν θάνατον ὑπηρετοῦσα· καὶ γὰρ ὃν αὐτὸς φόνον ἀπειργάσω, τοῦτον εἰς ἐμὲ ἀπεμάττου. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις καὶ οἱ φύσει χρηστοί, ὅταν ὑπ’ ἐνίων ὡς φαῦλοι διαϐάλλωνται, κατ’ αὐτῶν πονηρεύεσθαι οὐκ ὀκνοῦσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 147 Pb 150 Pg 99 Mb 104 Ca 100.</p>
+        <bibl>Codd. Pa 147 Pb 150 Pg 99 Mb 104 Ca 100.</bibl>
         <p><milestone unit="traduction"/>Un brigand, ayant assassiné un homme sur une route, et se voyant poursuivi par ceux qui se trouvaient là, abandonna sa victime ensanglantée et s’enfuit. Mais des voyageurs qui venaient en sens inverse, lui demandèrent ce qui lui avait souillé les mains ; il répondit qu’il venait de descendre d’un mûrier. Comme il disait cela, ceux qui le poursuivaient le rejoignirent, le saisirent et le pendirent à un mûrier. Et le mûrier lui dit : « Je ne suis pas fâché de servir à ton supplice : c’est toi en effet qui as commis le meurtre, et c’est sur moi que tu en as essuyé le sang. »</p>
         <p><milestone unit="traduction"/>Il arrive souvent ainsi que des hommes naturellement bons, quand ils se voient dénigrer par des calomniateurs, n’hésitent pas à se montrer méchants à leur égard.</p>
       </div>
@@ -5869,7 +5868,7 @@
         <pb ed="perry" n="P343"/>
         <p><milestone unit="recitprose"/>Λύκοις καὶ κυσὶν ἦν ποτε ἔχθρα. Κύων δὲ Ἕλλην ᾑρέθη στρατηγὸς κυσίν. Οὗτος πρὸς τὴν μάχην ἐϐράδυνεν· οἱ δὲ λύκοι ἠπείλουν σφοδρῶς. Ὁ δὲ εἶπεν· « Οἴδατε τίνος χάριν βραδύνω ; πρέπον ἐστὶν ἀεὶ προϐουλεύεσθαι. Ὑμῶν γὰρ τὸ γένος καὶ ἡ χροιὰ πάντων ἕν ἐστιν· οἱ ἡμέτεροι δὲ ἐκ πολλῶν τρόπων εἰσὶ καὶ τοῖς τόποις καυχῶνται. Ἀλλὰ καὶ ἡ χροιὰ πάντων οὐκ ἔστι μία καὶ ἴση, ἀλλ’ οἱ μὲν μέλανες, οἱ δὲ πυρροί, οἱ δὲ λευκοὶ καὶ τεφρώδεις. Καὶ πῶς ἂν δυνηθείην εἰς πόλεμον ἄρχειν τῶν ἀσυμφώνων καὶ μὴ ὅμοια πάντα ἐχόντων ; »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι ἐν μιᾷ βουλῇ καὶ γνώμῃ πάντων τῶν στρατευμάτων ὄντων κατὰ τῶν ἐναντίων νίκην ποιοῦνται.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 86.</p>
+        <bibl>Cod. Ba 86.</bibl>
         <p><milestone unit="traduction"/>Entre les loups et les chiens la haine se déchaîna un jour. Les chiens élurent pour général un chien grec. Or celui-ci ne se pressait pas d’engager la bataille, malgré les violentes menaces des loups, « Savez-vous, leur dit-il, pourquoi je temporise ; c’est que toujours il convient de délibérer avant d’agir. Vous autres, vous êtes tous de même race et de même couleur ; mais nos soldats à nous ont des mœurs très variées et chacun a son pays dont il est fier. Même la couleur n’est pas uniforme et pareille pour tous : les uns sont noirs, les autres roux, d’autres blancs ou cendrés. Comment pourrais-je mener à la guerre des gens qui ne sont pas d’accord et qui sont dissemblables en tout ? »</p>
         <p><milestone unit="traduction"/>Dans toutes les armées, c’est l’unité de volonté et de pensée qui assure la victoire sur les ennemis.</p>
       </div>
@@ -5881,7 +5880,7 @@
           <pb ed="perry" n="P342"/>
           <p><milestone unit="recitprose"/>Οἱ λύκοι τοῖς κυσὶν εἶπον· « Διὰ τί ὅμοιοι ὄντες ἡμῖν ἐν πᾶσιν, οὐχ ὁμοφρονεῖτε ἡμῖν ὡς ἀδελφοί ; οὐδὲν γὰρ ὑμῶν διαλλάττομεν, πλὴν τῇ γνώμῃ. Καὶ ἡμεῖς μὲν ἐλευθερίᾳ συζῶμεν· ὑμεῖς δὲ τοῖς ἀνθρώποις ὑποκύπτοντες καὶ δουλεύοντες πληγὰς παρ’ αὐτῶν ὑπομένετε, καὶ κλοιὰ περιτίθεσθε, καὶ φυλάττετε τὰ πρόϐατα· ὅτε δὲ ἐσθίουσιν, μόνα τὰ ὀστᾶ ὑμῖν ἐπιρρίπτουσιν. Ἀλλ’ ἐὰν πείθησθε, πάντα τὰ ποίμνια ἔκδοτε ἡμῖν καὶ ἕξομεν πάντα κοινὰ εἰς κόρον ἐσθίοντες. » Ὑπήκουσαν οὖν πρὸς ταῦτα οἱ κύνες· οἱ δὲ ἔνδον τοῦ σπηλαίου εἰσελθόντες πρότερον τοὺς κύνας διέφθειραν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ τὰς ἑαυτῶν πατρίδας προδιδόντες τοιούτους μισθοὺς λαμϐάνουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 102 Bb 63.</p>
+          <bibl>Codd. Ba 102 Bb 63.</bibl>
           <p><milestone unit="traduction"/>Les loups dirent aux chiens : « Pourquoi, étant de tout point pareils à nous, ne vous entendez-vous pas avec nous, comme des frères ? Car nous ne différons en rien, sauf de pensée. Nous, nous vivons dans la liberté ; vous, soumis et asservis aux hommes, vous endurez d’eux les coups, vous portez des colliers et vous gardez les troupeaux ; et quand vos maîtres mangent, ils ne vous jettent que les os. Mais croyez-nous ; livrez-nous tous les troupeaux et nous les mettrons en commun pour nous en rassasier. » Les chiens prêtèrent l’oreille à ces propositions ; et les loups, pénétrant à l’intérieur de l’étable, égorgèrent d’abord les chiens.</p>
           <p><milestone unit="traduction"/>Tel est le salaire que reçoivent ceux qui trahissent leur patrie.</p>
         </div>
@@ -5918,7 +5917,7 @@
         <pb ed="perry" n="P153"/>
         <p><milestone unit="recitprose"/>Λύκοι ἐπιϐουλεύοντες ποίμνῃ προϐάτων, ἐπειδὴ οὐκ ἠδύναντο αὐτῶν περιγενέσθαι διὰ τοὺς φυλάττοντας αὐτὰ κύνας, ἔγνωσαν δεῖν διὰ δόλου τοῦτο πρᾶξαι. Καὶ πέμψαντες πρέσϐεις ἐξῄτουν παρ’ αὐτῶν τοὺς κύνας, λέγοντες ὡς ἐκεῖνοι τῆς ἔχθρας αἴτιοί εἰσιν, καί, εἰ ἐγχειρίσουσιν αὐτούς, εἰρήνη μεταξὺ αὐτῶν γενήσεται. Τὰ δὲ πρόϐατα μὴ προϊδόμενα τὸ μέλλον ἐξέδωκαν αὐτούς, καὶ οἱ λύκοι περιγενόμενοι ἐκείνων ῥᾳδίως καὶ τὴν ποίμνην ἀφύλακτον οὖσαν διέφθειραν.</p>
         <p><milestone unit="epimythiumprose"/>Οὗτω καὶ τῶν πόλεων αἱ τοὺς δημαγωγοὺς ῥᾳδίως προδιδοῦσαι λανθάνουσι καὶ αὐταὶ ταχέως πολεμίοις χειρούμεναι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 148 Pb 151 Pd 35 Ma 102.</p>
+        <bibl>Codd. Pa 148 Pb 151 Pd 35 Ma 102.</bibl>
         <p><milestone unit="traduction"/>Des loups cherchaient à surprendre un troupeau de moutons. Ne pouvant s’en rendre maîtres, à cause des chiens qui les gardaient, ils résolurent d’user de ruse pour en venir à leurs fins. Ils envoyèrent des députés demander aux moutons de livrer leurs chiens. C’étaient les chiens, disaient-ils, qui étaient cause de leur inimitié ; on n’avait qu’à les leur livrer ; et la paix régnerait entre eux. Les moutons ne prévoyant pas ce qui allait arriver, livrèrent les chiens, et les loups, s’en étant rendus maîtres, égorgèrent facilement le troupeau qui n’était plus gardé.</p>
         <p><milestone unit="traduction"/>Il en est ainsi dans les États : ceux qui livrent facilement leurs orateurs ne se doutent pas qu’ils seront bientôt assujettis à leurs ennemis.</p>
       </div>
@@ -5928,7 +5927,7 @@
         <pb ed="perry" n="P153"/>
         <p><milestone unit="recitprose"/>Λύκοι πρέσϐεις ἔστειλαν τοῖς προϐάτοις εἰρήνην ποιῆσαι μετ’ αὐτῶν διηνεκῆ, εἰ τοὺς κύνας λάϐωσι καὶ διαφθείρωσι. Τὰ μωρὰ δὲ πρόϐατα συνέθεντο τοῦτο ποιῆσαι. Ἀλλά τις γέρων κριὸς εἶπεν· « Πῶς ὑμῖν πιστεύσω καὶ συνοικήσω, ὅπου, καὶ τῶν κυνῶν φυλαττόντων με, ἀκινδύνως νέμεσθαι οὐ δυνατόν μοι ; »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα ἀσφαλείας τῆς ἑαυτοῦ γυμνωθῆναι, τοῖς ἀκαταλλάκτοις ἐχθροῖς δι’ ὅρκων πεισθέντα.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 80 Bb 50.</p>
+        <bibl>Codd. Ba 80 Bb 50.</bibl>
         <p><milestone unit="traduction"/>Les loups envoyèrent des députés aux moutons, offrant de faire avec eux une paix perpétuelle, s’ils leur livraient les chiens pour les faire périr. Les stupides moutons convinrent de le faire ; mais un vieux bélier s’écria : « Comment pourrais-je vous croire et vivre avec vous, alors que, même sous la garde des chiens, il m’est impossible de paître en sécurité. »</p>
         <p><milestone unit="traduction"/>Il ne faut pas nous défaire de ce qui assure notre sécurité, en prêtant foi aux serments de nos ennemis irréconciliables.</p>
       </div>
@@ -5945,7 +5944,7 @@
         <l><milestone unit="recitvers"/>Λύκον δὲ γαυρωθέντα καρτερὸς λέων</l>
         <l><milestone unit="recitvers"/>ἑλὼν κατήσθι’· ὁ δ’ ἐϐόησε μετανοῶν·</l>
         <l><milestone unit="recitvers"/>« Οἴησις ἡμῖν πημάτων παραιτία. »</l>
-        <p><milestone unit="manuscrits"/>Cod. Mb 92.</p>
+        <bibl>Cod. Mb 92.</bibl>
         <p><milestone unit="traduction"/>Un loup errait un jour dans des lieux déserts, à l’heure où le soleil penchait sur son déclin. En voyant son ombre allongée, il dit : « Moi, craindre le lion, avec la taille que j’ai ! avec un plèthre de long, n’est-il pas tout simple que je devienne le roi de tous les animaux ? » Comme il s’abandonnait à l’orgueil, un puissant lion le prit et se mit à le dévorer. Le loup changeant d’avis s’écria : « La présomption nous est une cause de malheur. »</p>
       </div>
       <div type="poem" xml:id="chambry-221">
@@ -5954,7 +5953,7 @@
         <pb ed="perry" n="P157"/>
         <p><milestone unit="recitprose"/>Λύκος θεασάμενος αἶγα ἐπί τινος κρημνώδους ἄντρου νεμομένην, ἐπειδὴ οὐκ ἠδύνατο αὐτῆς ἐφικέσθαι, κατωτέρω παρῄνει αὐτῇ καταϐῆναι, μὴ καὶ πέσῃ λαθοῦσα, λέγων ὡς ἀμείνων ὁ παρ’ αὐτῷ λειμών ἐστι, ἐπεὶ καὶ ἡ πόα σφόδρα εὐανθής. Ἡ δὲ ἀπεκρίνατο πρὸς αὐτόν· « Ἀλλ’ οὐκ ἐμὲ ἐπὶ νομὴν καλεῖς, αὐτὸς δὲ τροφῆς ἀπορεῖς. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ κακοῦργοι, ὅταν παρὰ τοῖς εἰδόσι πονηρεύωνται, ἀνόνητοι τῶν τεχνασμάτων γίνονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 152 Pb 154 Pc 86 Pd 36 Pf 83 Ma 104 Mb 111 Me 106 Mf 89 Mj 100 Ca 103.</p>
+        <bibl>Codd. Pa 152 Pb 154 Pc 86 Pd 36 Pf 83 Ma 104 Mb 111 Me 106 Mf 89 Mj 100 Ca 103.</bibl>
         <p><milestone unit="traduction"/>Un loup vit une chèvre qui paissait au-dessus d’un antre escarpé. Ne pouvant arriver jusqu’à elle, il l’engagea à descendre ; car elle pourrait, disait-il, tomber par mégarde ; d’ailleurs le pré où il se trouvait était meilleur ; car le gazon y était tout fleuri. Mais la chèvre lui répondit : « Ce n’est pas pour moi que tu m’appelles au pâtis, c’est pour toi qui n’as pas de quoi manger. »</p>
         <p><milestone unit="traduction"/>Ainsi quand les scélérats exercent leur méchanceté parmi des gens qui les connaissent, ils ne gagnent rien à leurs machinations.</p>
       </div>
@@ -5966,7 +5965,7 @@
           <pb ed="perry" n="P155"/>
           <p><milestone unit="recitprose"/>Λύκος θεασάμενος ἄρνα ἀπό τινος ποταμοῦ πίνοντα, τοῦτον ἐϐουλήθη μετά τινος εὐλόγου αἰτίας καταθοινήσασθαι. Διόπερ στὰς ἀνωτέρω ᾐτιᾶτο αὐτὸν ὡς θολοῦντα τὸ ὕδωρ καὶ πιεῖν αὐτὸν μὴ ἐῶντα. Τοῦ δὲ λέγοντος ὡς ἄκροις τοῖς χείλεσι πίνει καὶ ἄλλως οὐ δυνατὸν κατωτέρω ἑστῶτα ἐπάνω ταράσσειν τὸ ὕδωρ, ὁ λύκος ἀποτυχὼν ταύτης τῆς αἰτίας ἔφη· « Ἀλλὰ πέρυσι τὸν πατέρα μου ἐλοιδόρησας. » Εἰπόντος δὲ ἐκείνου μηδὲ τότε γεγενῆσθαι, ὁ λύκος ἔφη πρὸς αὐτόν· « Ἐὰν σὺ ἀπολογιῶν εὐπορῇς, ἐγώ σε οὐχ &lt;ἧττον&gt; κατέδομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἷς ἡ πρόθεσίς ἐστιν ἀδικεῖν, παρ’ αὐτοῖς οὐδὲ δικαία ἀπολογία ἰσχύει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 150 Pb 152 Ma 103.</p>
+          <bibl>Codd. Pa 150 Pb 152 Ma 103.</bibl>
           <p><milestone unit="traduction"/>Un loup, voyant un agneau qui buvait à une rivière, voulut alléguer un prétexte spécieux pour le dévorer. C’est pourquoi, bien qu’il fût lui-même en amont, il l’accusa de troubler l’eau et de l’empêcher de boire. L’agneau répondit qu’il ne buvait que du bout des lèvres, et que d’ailleurs, étant à l’aval, il ne pouvait troubler l’eau à l’amont. Le loup, ayant manqué son effet, reprit : « Mais l’an passé tu as insulté mon père. — Je n’étais pas même né à cette époque, » répondit l’agneau. Alors le loup reprit : « Quelle que soit ta facilité à te justifier, je ne t’en mangerai pas moins. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’auprès des gens décidés à faire le mal la plus juste défense reste sans effet.</p>
         </div>
@@ -5991,7 +5990,7 @@
           <l><milestone unit="recitvers"/>« Ἀλλ’ ἐγὼ τέως νῦν ἄδειπνος οὐ μένω</l>
           <l><milestone unit="recitvers"/>διὰ τό σέ μου ἀφορμὴν πᾶσαν λύειν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι γνώμην κακούργου καὶ πλεονέκτου λόγος οὐ πείθει, κἂν ἀληθὴς τυγχάνῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 8 Ch 83 Ca 101 Cb 69 Cd 83 Ce 68 Cf 72 Mb 10 Mc 68 Md 71 Mh 66 Mm 86.</p>
+          <bibl>Codd. Cg 8 Ch 83 Ca 101 Cb 69 Cd 83 Ce 68 Cf 72 Mb 10 Mc 68 Md 71 Mh 66 Mm 86.</bibl>
         </div>
         <div>
           <head>Chambry 222.3</head>
@@ -5999,7 +5998,7 @@
           <pb ed="perry" n="P155"/>
           <p><milestone unit="recitprose"/>Λύκος ποτὲ ἄρνα πεπλανημένον εὑρὼν βίᾳ μὲν οὐχ ἥρπαζεν, ἔγκλημα δὲ ἐζήτει, εὐλόγως φαγεῖν θέλων. « Σύ, εἶπεν, πέρυσι μικρὸς ὢν ὕϐρισάς με. » Ὁ δέ· « Πῶς ἐγὼ πέρυσι, ὃς ἐν τούτῳ ἐγεννήθην τῷ χρόνῳ ; – Ἀλλά, φησί, τὴν ἄρουράν μου ἐπιϐόσκῃ. » Ὁ δέ· « Οὐδέπω ἐϐοσκήθην. – Ἀλλ’ ἐκ τῆς πηγῆς ἐξ ἧς ἐγὼ πίνω πίνεις. » Ὁ δὲ ἔφη· « Οὔπω ὕδωρ ἔπιον, ἀλλὰ τῆς μητρός μόνης τὸ γάλα πίνω καὶ τρέφομαι. » Ὁ δὲ συλλαϐὼν καὶ τρώγων εἶπεν· « Ἀλλ’ ἐγὼ ἄδειπνος οὐ μενῶ ἐν τῷ σε πᾶσάν μου ἀφορμὴν λύειν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι γνώμην κακουργοῦ καὶ πονηροῦ πλεονέκτου λόγος οὐ πείθει, κἂν ἀληθὴς ὑπάρχῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 83 Bb 53.</p>
+          <bibl>Codd. Ba 83 Bb 53.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-223">
@@ -6008,7 +6007,7 @@
         <pb ed="perry" n="P261"/>
         <p><milestone unit="recitprose"/>Λύκος ἀρνίον ἐδίωκε· τὸ δὲ εἴς τι ἱερὸν κατέφυγε. Προσκαλουμένου δὲ αὐτὸ τοῦ λύκου καὶ λέγοντος ὅτι θυσιάσει αὐτὸ ὁ ἱερεύς, εἰ καταλάϐῃ, τῷ θεῷ, ἐκεῖνο ἔφη· « Ἀλλ’ αἱρετώτερόν μοί ἐστι θεοῦ θυσίαν γενέσθαι ἢ ὑπὸ σοῦ διαφθαρῆναι. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἷς ἐπίκειται τὸ ἀποθανεῖν κρείττων ἐστὶν ὁ μετὰ δόξης θάνατος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ca 107 Ma 107 Mb 114 Pb 159.</p>
+        <bibl>Codd. Ca 107 Ma 107 Mb 114 Pb 159.</bibl>
         <p><milestone unit="traduction"/>Un loup poursuivait un jeune agneau. Celui-ci se réfugia dans un temple. Comme le loup l’appelait à lui et disait que le sacrificateur l’immolerait au dieu, s’il le trouvait là : « Eh bien ! répondit l’agneau, je préfère être victime du dieu que de périr par toi. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que, si l’on est réduit à mourir, il vaut mieux mourir avec honneur.</p>
       </div>
@@ -6020,7 +6019,7 @@
           <pb ed="perry" n="P158"/>
           <p><milestone unit="recitprose"/>Λύκος λιμώττων περιῄει ζητῶν ἑαυτῷ τροφήν. Ὡς δὲ ἐγένετο κατά τινα ἔπαυλιν, ἀκούσας γραὸς κλαυθμυριζομένῳ παιδὶ διαπειλούσης, ἐὰν μὴ παύσηται, βαλεῖν αὐτὸν λύκῳ, προσέμενεν οἰόμενος ἀληθεύειν αὐτήν. Ἑσπέρας δὲ γενομένης, ὡς οὐδὲν τοῖς λόγοις ἀκόλουθον ἐγίγνετο, ἀπαλλαττόμενος ἔφη πρὸς αὑτόν· « Ἐν ταύτῃ τῇ ἐπαύλει οἱ ἄνθρωποι ἄλλα μὲν λέγουσι, ἄλλα δὲ ποιοῦσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόσειεν ἂν πρὸς ἐκείνους τοὺς ἀνθρώπους οἳ τοῖς λόγοις οὐκ ἔχουσι τὰ ἔργα ἀκόλουθα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 153 Pb 155 Pc 87 Mb 112.</p>
+          <bibl>Codd. Pa 153 Pb 155 Pc 87 Mb 112.</bibl>
         </div>
         <div>
           <head>Chambry 224.2</head>
@@ -6028,7 +6027,7 @@
           <pb ed="perry" n="P158"/>
           <p><milestone unit="recitprose"/>Λύκος λιμώττων περιῄει ζητῶν ἑαυτῷ τροφήν. Γενόμενος δὲ κατά τινα τόπον ἤκουσε παιδίου κλαυθμυρίζοντος καὶ γραὸς ἀπειλουμένης καὶ λεγούσης αὐτῷ· « Παῦσαι τοῦ κλαίειν, μήπως τῇ ὥρᾳ ταύτῃ ἐπιδώσω σε τῷ λύκῳ. » Οἰόμενος δὲ ὁ λύκος ὅτι ἀληθεύει ἡ γραῦς, ἵστατο ἐπὶ πολλὴν ὥραν ἐκδεχόμενος. Ὡς δὲ ἑσπέρα κατέλαϐεν, ἀκούει πάλιν τῆς γραὸς κολακευούσης τὸ παιδίον καὶ λεγούσης αὐτῷ· « Ἐὰν ἔλθῃ ἐνταῦθα ὁ λύκος, ὦ τέκνον, φονεύσομεν αὐτόν. » Τούτων ἀκούσας ὁ λύκος, ὡς οὐδὲν τοῖς λόγοις ἀκόλουθον ἦν, ἀπηλλάττετο λέγων· « Ἐν ταύτῃ τῇ ἐπαύλει ἄλλα μὲν λέγουσιν, ἄλλα δὲ ποιοῦσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος οὗτος δηλοῖ τοὺς ἀνθρώπους οἵτινες τὰ ἔργα οὐκ ἔχουσι κατὰ τοὺς λόγους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 104 Ce 75 Cf 79 Cg 4 Ch 79 Mh 72 Ml 104.</p>
+          <bibl>Codd. Ca 104 Ce 75 Cf 79 Cg 4 Ch 79 Mh 72 Ml 104.</bibl>
         </div>
         <div>
           <head>Chambry 224.3</head>
@@ -6036,7 +6035,7 @@
           <pb ed="perry" n="P158"/>
           <p><milestone unit="recitprose"/>Λύκος λιμώττων περιῄει ζητῶν τροφήν. Γενόμενος δὲ κατά τινα τόπον, ἤκουσε παιδίου κλαίοντος καὶ γραὸς λεγούσης αὐτῷ· « Παῦσαι τοῦ κλαίειν· εἰ δὲ μή, τῇ ὥρᾳ ταύτῃ ἐπιδώσω σε τῷ λύκῳ. » Οἰόμενος δὲ ὁ λύκος ὅτι ἀληθεύει ἡ γραῦς, ἵστατο πολλὴν ἐκδεχόμενος ὥραν. Ὡς δ’ ἑσπέρα κατέλαϐεν, ἀκούει πάλιν τῆς γραὸς κολακευούσης τὸ παιδίον καὶ λεγούσης αὐτῳ· « Ἐὰν ἔλθῃ ὁ λύκος δεῦρο, φονεύσομεν, ὦ τέκνον, αὐτόν. » Ταῦτα ἀκούσας ὁ λύκος ἐπορεύετο λέγων· « Ἐν ταύτῃ τῇ ἐπαύλει ἄλλα μὲν λέγουσιν, ἄλλα δὲ πράττουσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἀνθρώπους οἵτινες τὰ ἔργα τοῖς λόγοις οὐκ ἔχουσιν ὅμοια.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 142 Lc 51 Lg 51 Ma 180 Md 77 Mg 106 Mm 92.</p>
+          <bibl>Codd. La 142 Lc 51 Lg 51 Ma 180 Md 77 Mg 106 Mm 92.</bibl>
           <p><milestone unit="traduction"/>Un loup affamé rôdait en quête de nourriture. Arrivé dans un certain endroit, il entendit un petit enfant qui pleurait et une vieille femme qui lui disait : « Ne pleure plus, sinon je te donne au loup à l’instant même. » Le loup pensant que la vieille disait vrai, s’arrêta et attendit longtemps. Quand le soir fut venu, il entendit de nouveau la vieille qui choyait le petit enfant et lui disait : « Si le loup vient ici, nous le tuerons, mon enfant. » En entendant ces mots, le loup se remit en route en disant : « Dans cette ferme on parle d’une façon, on agit d’une autre. »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse aux hommes qui ne conforment pas leurs actes à leurs paroles.</p>
         </div>
@@ -6061,7 +6060,7 @@
           <l><milestone unit="recitvers"/>ἄλλα λέγουσι, μακρᾶς αἴ αἴ μοι ποίνης,</l>
           <l><milestone unit="recitvers"/>ἄλλα πράττουσι· φεῦ, πῶς οἴσω τὴν πεῖναν ; »</l>
           <p><milestone unit="epimythiumprose"/>Λόγος ἁρμόζει πρὸς τοὺς ἀνθρώπους οἳ λόγους οὐκ ἔχουσιν ἴσους τοῖς ἔργοις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 79.</p>
+          <bibl>Cod. Cd 79.</bibl>
         </div>
         <div>
           <head>Chambry 224.5</head>
@@ -6069,7 +6068,7 @@
           <pb ed="perry" n="P158"/>
           <p><milestone unit="recitprose"/>Αἰτοῦντι τροφὴν νηπίῳ καὶ κλαίοντι ἠπείλησε γραῦς, εἰ μὴ ἡσυχάσαι, τῷ λύκῳ ῥῖψαι. Ὁ δὲ λύκος τὴν γραῦν ἀληθεύειν νομίσας ἐκαρτέρησε μέχρις ἑσπέρας πεινῶν, μηδὲν λαϐών. Εἰς δὲ τὴν σύνοικον ἐλθὼν ἠρωτᾶτο πῶς οὐδὲν ἄρας ἦλθεν, ὡς ἀεί. Ὁ δὲ εἶπεν· « Πῶς γάρ τις πιστεύσας γυναικί ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι κεναῖς ἐλπίσιν ἀπατᾶται ὁ πειθόμενος γυναικῶν ὁμιλίαις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 1 Bc 1.</p>
+          <bibl>Codd. Ba 1 Bc 1.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-225">
@@ -6080,7 +6079,7 @@
           <pb ed="perry" n="P156"/>
           <p><milestone unit="recitprose"/>Λύκος καταπιὼν ὀστοῦν περιῄει τὸν ἰασόμενον αὐτὸν ζητῶν. Περιτυχὼν δὲ ἐρωδιῷ, τοῦτον παρεκάλει ἐπὶ μισθῷ τὸ ὀστοῦν ἐκϐαλεῖν. Κἀκεῖνος καθεὶς τὴν ἑαυτοῦ κεφαλὴν εἰς τὴν φάρυγγα αὐτοῦ τὸ ὀστοῦν ἐξέσπασε καὶ τὸν ὡμολογημένον μισθὸν ἀπῄτει. Ὁ δὲ ὑποτυχὼν εἶπεν· « Ὦ οὗτος, οὐκ ἀγαπᾷς ἐκ λύκου στόματος σῴαν τὴν κεφαλὴν ἐξενεγκών, ἀλλὰ καὶ μισθὸν ἀπαιτεῖς ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι μεγίστη παρὰ τοῖς πονηροῖς εὐεργεσίας ἀμοιϐὴ τὸ μὴ προσαδικεῖσθαι ὑπ’ αὐτῶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 151 Pb 153 Pc 85 Mb 110 Ca 102.</p>
+          <bibl>Codd. Pa 151 Pb 153 Pc 85 Mb 110 Ca 102.</bibl>
           <p><milestone unit="traduction"/>Un loup, ayant avalé un os, allait partout cherchant qui le débarrasserait de son mal. Il rencontra un héron, et lui demanda moyennant salaire d’enlever l’os. Alors le héron descendit sa tête dans le gosier du loup, retira l’os, puis réclama le salaire convenu. « Hé ! l’ami, répondit le loup, ne te suffit-il pas d’avoir retiré ta tête saine et sauve de la gueule du loup, et te faut-il encore un salaire ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre que le plus grand service qu’on puisse attendre de la reconnaissance des méchants, c’est qu’à l’ingratitude ils n’ajoutent pas l’injustice.</p>
         </div>
@@ -6098,7 +6097,7 @@
           <l><milestone unit="recitvers"/>ὅτι ἐκ λύκου στόματος καὶ ὀδόντων</l>
           <l><milestone unit="recitvers"/>ἐξῆρας κάραν σῴαν μηδὲν παθοῦσαν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας δολίους οἵτινες ἐκ κινδύνων διασωθέντες τοῦτο παρέχουσι τοῖς εὐργέταις ἀντὶ χάριτος, τὸ μὴ βλάψαι αὐτούς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 6 Ch 81 Ca 94 Cb 68 Cd 81 Ce 67 Cf 71 Mc 67.</p>
+          <bibl>Codd. Cg 6 Ch 81 Ca 94 Cb 68 Cd 81 Ce 67 Cf 71 Mc 67.</bibl>
         </div>
         <div>
           <head>Chambry 225.3</head>
@@ -6115,7 +6114,7 @@
           <l><milestone unit="recitvers"/>ὅτι ἐκ λύκου στόματος καὶ ὀδόντων</l>
           <l><milestone unit="recitvers"/>ἐξῆρας κάραν σῴαν μηδὲν παθοῦσαν. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας οἵτινες ἀπὸ κινδύνου διασωθέντες τοῖς εὐεργέταις τοιαύτας ἀπονέμουσι χάριτας.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 148 Lc 61 Lg 61 Ma 181 Md 78 Mh 73 Mm 93.</p>
+          <bibl>Codd. La 148 Lc 61 Lg 61 Ma 181 Md 78 Mh 73 Mm 93.</bibl>
         </div>
         <div>
           <head>Chambry 225.4</head>
@@ -6123,7 +6122,7 @@
           <pb ed="perry" n="P156"/>
           <p><milestone unit="recitprose"/>Λύκου λαιμῷ ὀστοῦν ἐνεπάγη. Ὁ δὲ γεράνῳ μισθὸν παρέξειν εἶπεν, εἰ τὴν κεφαλὴν βαλὼν τὸ ὀστοῦν ἀνασπάσει καὶ τοῦ πόνου λύσει. Ὁ δὲ βαλὼν τὸν μακρὸν αὐχένα αὐτοῦ τὸ ὀστοῦν βίᾳ ἐξέσπασε, καὶ τοὺς μισθοὺς ᾖτει. Ὁ δὲ λύκος τοὺς ὀδόντας δείξας εἶπεν· « Ἀρκεῖ σοι εἰς μισθὸν ὅτι ἐκ στόματος λύκου κεφαλὴν σῴαν ἐξῆξας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι γνώμη κακούργου καὶ πονηροῦ πλεονέκτου οὐ ῥᾳδίως μαλαχθήσεται, οὐδὲ τοὺς εὐεργετήσαντας ἀνταμείψεται, κἂν δι’ ὅλης τῆς ἡμέρας πάντα τὰ καλὰ αὐτῷ προσενέγκῃς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 84 Bb 54.<space rend="tab">    </space></p>
+          <bibl>Codd. Ba 84 Bb 54.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-226">
@@ -6132,7 +6131,7 @@
         <pb ed="perry" n="P154"/>
         <p><milestone unit="recitprose"/>Λύκος κατά τινα ἄρουραν ὁδεύων κριθὰς εὗρε· μὴ δυνάμενος δὲ αὐταῖς τροφῇ χρήσασθαι, καταλιπὼν ἀπῄει. Ἵππῳ δὲ συντυχών, τοῦτον ἐπὶ τὴν ἄρουραν ἐπήγαγε λέγων ὡς εὑρὼν κριθὰς αὐτὸς μὲν οὐκ ἔφαγεν, αὐτῷ δὲ ἐφύλαξεν, ἐπεὶ καὶ ἡδέως αὐτοῦ τὸν ψόφον τῶν ὀδόντων ἀκούει. Καὶ ὁ ἵππος ὑποτυχὼν εἶπεν· « Ἀλλ’, ὦ οὗτος, εἰ λύκοι κριθῶν τροφῇ χρῆσθαι ἠδύναντο, οὐκ ἄν ποτε τὰ ὦτα τῆς γαστρὸς προέκρινας. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φύσει πονηροί, κἂν χρηστότητα ἐπαγγέλλωνται, οὐ πιστεύονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 149 Pf 82 Ph 74 Me 105 Mj 99.</p>
+        <bibl>Codd. Pa 149 Pf 82 Ph 74 Me 105 Mj 99.</bibl>
         <p><milestone unit="traduction"/>Un loup, passant dans un champ, y trouva de l’orge ; mais ne pouvant en faire sa nourriture, il la laissa et s’en alla. Il rencontra un cheval et l’amena dans le champ ; il avait, disait-il, trouvé de l’orge ; mais, au lieu de la manger lui-même, il la lui avait gardée, vu qu’il avait du plaisir à entendre le bruit de ses dents. Le cheval lui répondit : « Hé ! l’ami, si les loups pouvaient user de l’orge comme nourriture, tu n’aurais jamais préféré tes oreilles à ton ventre. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que ceux qui sont naturellement méchants, même quand ils se targuent d’être bons, n’obtiennent aucune créance.</p>
       </div>
@@ -6142,7 +6141,7 @@
         <pb ed="perry" n="P346"/>
         <p><milestone unit="recitprose"/>Λύκος ἐν κλοιῷ δεδεμένον ὁρῶν μέγιστον κύνα ἤρετο· « Δήσας τίς σ’ ἐξέθρεψε τοῦτον ; » Ὁ δὲ ἐφη· « Κυνηγός. - Ἀλλὰ τοῦτο μὴ πάθοι λύκος ἐμοὶ φίλος· λιμὸς γὰρ ἡ κλοιοῦ βαρύτης. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ τὸ ἐν ταῖς συμφοραῖς οὐδὲ γαστρίζεσθαι.</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 105.</p>
+        <bibl>Cod. Mb 105.</bibl>
         <p><milestone unit="traduction"/>Un loup voyant un très gros chien attaché par un collier lui demanda : « Qui t’a lié et nourri de la sorte ? — Un chasseur, » répondit le chien. « Ah ! Dieu garde de cela le loup qui m’est cher ! Autant la faim qu’un collier pesant. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que dans le malheur on n’a même pas les plaisirs du ventre.</p>
       </div>
@@ -6154,7 +6153,7 @@
           <pb ed="perry" n="P347"/>
           <p><milestone unit="recitprose"/>Λύκος ποτὲ ἄρας πρόϐατον ἐκ ποίμνης ἐκόμιζεν εἰς κοίτην. Λέων δὲ αὐτῷ συναντήσας ἀφεῖλε τὸ πρόϐατον. Ὁ δὲ πόρρωθεν σταθεὶς εἶπεν· « Ἀδίκως ἀφείλου τὸ ἐμόν. » Ὁ δὲ λέων γελάσας ἔφη· « Σοὶ γὰρ δικαίως ὑπὸ φίλου ἐδόθη ; »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] ἅρπαγας καὶ πλεονέκτας λῃστὰς ἔν τινι πταίσματι κειμένους καὶ ἀλλήλους μεμφομένους ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 85 Bb 55.</p>
+          <bibl>Codd. Ba 85 Bb 55.</bibl>
           <p><milestone unit="traduction"/>Un jour un loup, ayant enlevé un mouton dans un troupeau, l’emportait dans son repaire. Mais un lion, se trouvant sur son chemin, le lui ravit. Le loup se tenant à distance lui cria : « Tu es injuste de me prendre mon bien. » Le lion se mit à rire et dit : « Toi, en effet, tu l’as reçu justement d’un ami ! »</p>
           <p><milestone unit="traduction"/>Pillards et brigands insatiables qui, en butte à quelque revers, se chamaillent entre eux, peuvent se reconnaître dans cette fable.</p>
         </div>
@@ -6175,7 +6174,7 @@
           <l><milestone unit="recitvers"/>Σὺ δέ, ὦ λύκε, δικαίως τοῦτ’ ἂν ἔσχες,</l>
           <l><milestone unit="recitvers"/>εἴ τις τῶν φίλων αὐτὸ κεχάρικέ σοι. »</l>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] πρὸς πλεονέκτας καὶ ἅρπαγας τοὺς μεμφομένους ἀλλήλοις ὁ μῦθος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 108.<space rend="tab">    </space></p>
+          <bibl>Cod. Mb 108.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-229">
@@ -6203,7 +6202,7 @@
           <pb ed="perry" n="P348"/>
           <p><milestone unit="recitprose"/>Λύκος τῶν λοιπῶν στρατηγήσας λύκων νόμους ἔταξε πᾶσιν, ἵνα ὅ τι ἂν ἕκαστος κυνηγήσῃ, πάντα εἰς μέσον ἄξῃ καὶ μερίδα ἴσην ἑκάστῳ δώσῃ, ὅπως μὴ οἱ λοιποὶ ἐνδεεῖς ὄντες ἀλλήλους κατεσθίωσιν. Ὄνος δὲ παρελθὼν τὴν χαίτην σείσας ἔφη· « Ἐκ φρενὸς λύκου καλὴ γνώμη· ἀλλὰ πῶς σὺ τὴν χθεσινὴν ἄγραν τῇ κοίτῃ ἐναπέθου ; Ἄγε ταύτην εἰς μέσον ἀπομερίσας. » Ὁ δὲ ἐλεγχθεὶς τοὺς νόμους ἀνέλυσεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι αὐτοὶ οἱ τοὺς νόμους δικαίως ὁρίζειν δοκοῦντες καὶ ἐν οἷς ὁρίζουσιν καὶ δικάζουσιν οὐκ ἐμμένουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 82 Bb 52.</p>
+          <bibl>Codd. Ba 82 Bb 52.</bibl>
           <p><milestone unit="traduction"/>Un loup, étant devenu chef des autres loups, établit des lois générales portant que, tout ce que chacun aurait pris à la chasse, il le mettrait en commun et le partagerait également entre tous : de la sorte on ne verrait plus les loups, réduits à la disette, se manger les uns les autres. Mais un âne s’avança, et secouant sa crinière, dit : « C’est une belle pensée que son cœur a’inspirée au loup. Mais comment se fait-il que toi-même tu aies serré dans ton repaire ton butin d’hier ? Apporte-le à la communauté et partage-le. » Le loup confondu abolit ses lois.</p>
           <p><milestone unit="traduction"/>Ceux qui semblent légiférer selon la justice ne s’en tiennent pas eux-mêmes aux lois qu’ils établissent et décrètent.</p>
         </div>
@@ -6212,7 +6211,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P348"/>
           <p><milestone unit="recitprose"/>Λύκος τῶν λοιπῶν κρατήσας λύκων νόμους ἔταξε πᾶσι, ἵνα πᾶν ὅ τι ἄν τις θηρεύσῃ, εἰς τὸ μέσον ἀγάγῃ ἐξ ἴσου ἑκάστῳ μερισθησόμενον. Ὄνος δὲ παρελθὼν ἔφη· « Ἐκ φρενὸς λύκου καλὴ γνώμη· ἀλλὰ πῶς χθὲς συναντήσας σοι τὴν ἄγραν εἶδον ἐν τῇ κοίτῃ σου ἀποκρύψαντα ; » Ὁ δὲ ἐλεγχθεὶς τοὺς νόμους διέλυσεν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 39.</p>
+          <bibl>Cod. Bd 39.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-230">
@@ -6221,7 +6220,7 @@
         <pb ed="perry" n="P234"/>
         <p><milestone unit="recitprose"/>Λύκος ἀκολουθῶν ποίμνῃ προϐάτων οὐδὲν ἠδίκει. Ὁ δὲ ποιμὴν κατὰ μὲν ἀρχὰς ἐφυλάττετο αὐτὸν ὡς πολέμιον καὶ δεδοικὼς παρετηρεῖτο. Ἐπεὶ δὲ συνεχῶς ἐκεῖνος παρεπόμενος οὐδ’ ἀρχὴν ἁρπάζειν ἐπεχείρει, τὸ τηνικαῦτα νοήσας φύλακα μᾶλλον αὐτὸν εἶναι ἢ ἐπίϐουλον, ἐπειδὴ χρεία τις αὐτὸν κατέλαϐεν εἰς ἄστυ παραγενέσθαι, καταλιπὼν παρ’ αὐτῷ τὰ πρόϐατα ἀπηλλάγη. Καὶ ὃς καιρὸν ἔχειν ὑπολαϐὼν τὰ πλεῖστα εἰσπεσὼν διεφόρησεν. Ὁ δὲ ποιμὴν ἐπανελθὼν καὶ θεασάμενος τὴν ποίμνην διεφθαρμένην ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γὰρ λύκῳ πρόϐατα ἐπίστευον ; »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ τοῖς φιλαργύροις τὴν παρακαταθήκην ἐγχειρίζοντες εἰκότως ἀποστεροῦνται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 155 Pf 84 Ma 105 Me 107 Mf 90 Mj 101 Ca 105.</p>
+        <bibl>Codd. Pa 155 Pf 84 Ma 105 Me 107 Mf 90 Mj 101 Ca 105.</bibl>
         <p><milestone unit="traduction"/>Un loup suivait un troupeau de moutons sans lui faire de mal. Le berger tout d’abord se gardait de lui comme d’un ennemi et le surveillait peureusement. Mais comme le loup le suivait toujours sans faire la moindre tentative d’enlèvement, il pensa dès lors qu’il avait là un gardien plutôt qu’un ennemi aux aguets ; et comme il avait besoin de se rendre à la ville, il laissa ses moutons près du loup et partit. Le loup, pensant tenir l’occasion, se jeta sur le troupeau et en mit en pièces la plus grande partie. Quand le berger revint et vit son troupeau perdu, il s’écria : « C’est bien fait pour moi ; pourquoi confiais-je des moutons à un loup ? »</p>
         <p><milestone unit="traduction"/>Il en est de même chez les hommes : quand on confie un dépôt à des gens cupides, il est naturel qu’on le perde.</p>
       </div>
@@ -6233,7 +6232,7 @@
           <pb ed="perry" n="P159"/>
           <p><milestone unit="recitprose"/>Λύκος τροφῆς κεκορεσμένος, ἐπειδὴ ἐθεάσατο πρόϐατον ἐπὶ γῆς βεϐλημένον, αἰσθόμενος ὅτι διὰ τὸν ἑαυτοῦ φόϐον πέπτωκε, προσελθὼν παρεθάρσυνεν αὐτό, λέγων ὡς, ἐὰν αὐτῷ τρεῖς λόγους ἀληθεῖς εἴπῃ, ἀπολύσει αὐτό. &lt;Τὸ&gt; δὲ ἀρξάμενον ἔλεγε πρῶτον μὲν μὴ βεϐουλῆσθαι αὐτῷ περιτυχεῖν, δεύτερον δέ, εἰ ἄρα τοῦτο ἥμαρτε, τυφλῷ, τρίτον δὲ ὅτι « κακοὶ κακῶς ἀπόλοισθε πάντες οἱ λύκοι, ὅτι μηδὲν παθόντες ὑφ’ ἡμῶν κακῶς πολεμεῖτε ἡμᾶς. » Καὶ ὁ λύκος ἀποδεξάμενος αὐτοῦ τὸ ἀψευδὲς ἀπέλυσεν αὐτό.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλάκις ἀλήθεια καὶ παρὰ πολεμίοις ἰσχύει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 154 Pb 156 Pc 88 Mb 113.</p>
+          <bibl>Codd. Pa 154 Pb 156 Pc 88 Mb 113.</bibl>
           <p><milestone unit="traduction"/>Un loup gorgé de nourriture vit une brebis abattue sur le sol. Comprenant qu’elle s’était laissée tomber de frayeur, il s’approcha et la rassura, en lui promettant, si elle lui tenait trois propos vrais, de la laisser aller. Alors la brebis commença par lui dire qu’elle aurait voulu ne pas le rencontrer ; puis, qu’à défaut de cela, elle aurait voulu le trouver aveugle ; en troisième lieu, elle s’écria : « Puissiez-vous, méchants loups, périr tous de male mort, puisque, sans avoir souffert de nous aucun mal, vous nous faites méchamment la guerre ! » Le loup reconnut sa véracité et la laissa partir.</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent la vérité a son effet même sur des ennemis.</p>
         </div>
@@ -6243,21 +6242,21 @@
           <pb ed="perry" n="P159"/>
           <p><milestone unit="recitprose"/>Εἰς λύκον ἀλώπηξ ἐνέπεσεν· ἐδυσώπει δὲ ὡς γραῦν αὐτὴν οὖσαν μὴ ἀποκτεῖναι. Ὁ δὲ λύκος ἔφη· « Εἰ τρεῖς λόγους ἀληθεῖς εἴπῃς μοι, ἀπολυθήσῃ. » Ἡ δὲ εἶπεν· « Εἴθε μή σοι συνήντησα· εἰ δὲ συνήντησα, τυφλόν σε ὑπήντησα καὶ μηδαμῶς τῇ ὥρᾳ ταύτῃ ζήσαις καὶ πάλιν συναντήσαις μοι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐν περιστάσει τις ἐμπεσὼν καὶ τὰς κεκρυμμένας τῆς ψυχῆς βουλὰς ἐξάγει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 31 Bb 20 Mg 58.</p>
+          <bibl>Codd. Ba 31 Bb 20 Mg 58.</bibl>
         </div>
         <div>
           <head>Chambry 231.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P159"/>
           <p><milestone unit="recitprose"/>Εἰς λύκου χεῖρας ἀλώπηξ ἐνέπεσεν, ἣ καὶ τὴν τοῦ γήρως προϐαλλομένη ἀσθένειαν ἀπολῦσαι ἐδυσώπει. Ὁ δὲ λύκος ἀντέφησεν· « Ἄλλως οὐκ ἐπιτεύξῃ σου τοῦ αἰτήματος, εἰ μή γε πρῶτον τρεῖς ἀληθεῖς ἐξείπῃς μοι λόγους. » Ἡ δὲ εἶπεν· « Εἴθε μή σοι συνήντησα· εἰ δὲ συνήντησα, τυφλῷ σοι ἐνέτυχον· μηδαμῶς δὲ τῆς ὥρας ταύτης τὸ ζῆν σοι [μὴ] ἐπεϐραϐεύθη· ἴσως γὰρ πάλιν, εἰ ἐν βίῳ τούτῳ προσμενεῖς, τὴν ἐμὴν ψυχὴν ἐκθροήσεις. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 25.</p>
+          <bibl>Cod. Bc 25.</bibl>
         </div>
         <div>
           <head>Chambry 231.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P159"/>
           <p><milestone unit="recitprose"/>Εἰς λύκου χεῖρας γραῦς ἀλώπηξ ἐνέπεσεν. Ἡ δὲ τοῦτον ἐδυσώπει μὴ ἀποκτεῖναι αὐτήν. Ὁ δὲ λύκος ἔφη· « Εἰ τρεῖς ἀληθεῖς λόγους εἴποις μοι, ἀπολύσω σε. » Ἡ δὲ ἔλεγε· « Εἴθε μηδαμῶς σοι συνήντησα· εἰ δὲ συνήντησα, τυφλῷ σοι συνήντησα, καὶ εἴθε μοι τῇ ὥρᾳ ταύτῃ ἀπέθνῃσκες, ἵνα μὴ πάλιν συνήντησάς μοι. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 15.</p>
+          <bibl>Cod. Bd 15.</bibl>
         </div>
         <div>
           <head>Chambry 231.5</head>
@@ -6274,7 +6273,7 @@
           <l><milestone unit="recitvers"/>καὶ νῦν μὴ ζήσαις πάλιν τῇ ὥρᾳ ταύτῃ,</l>
           <l><milestone unit="recitvers"/>καὶ μή ποτ’ αὖθις συναντήσαις μοι, λύκε. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐν περιστάσει τις ἐμπεσὼν καὶ τὰς κεκρυμμένας τῆς ψυχῆς βουλὰς ἐξάγει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 4.</p>
+          <bibl>Cod. Mb 4.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-232">
@@ -6285,7 +6284,7 @@
           <pb ed="perry" n="P160"/>
           <p><milestone unit="recitprose"/>Λύκος ὑπὸ κυνῶν δηχθεὶς καὶ κακῶς διατεθεὶς ἐϐέϐλητο τροφὴν ἑαυτῷ περιποιεῖσθαι μὴ δυνάμενος· καὶ δὴ θεασάμενος πρόϐατον, τούτου ἐδεήθη ποτὸν αὐτῷ ὀρέξαι ἐκ τοῦ παραρρέοντος ποταμοῦ· « Ἐὰν γὰρ σύ μοι ποτὸν δῷς, ἐγὼ τὴν τροφὴν ἐμαυτῷ εὑρήσω. » Τὸ δὲ ὑποτυχὸν ἔφη· « Ἐὰν ποτόν σοι ἐπιδώσω ἐγώ, σὺ καὶ τροφῇ μοι χρήσῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα κακοῦργον δι’ ὑποκρίσεως ἐνεδρεύοντα ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 156 Pb 157 Pc 89 Pf 85 Me 108 Mf 92 Mj 102.</p>
+          <bibl>Codd. Pa 156 Pb 157 Pc 89 Pf 85 Me 108 Mf 92 Mj 102.</bibl>
           <p><milestone unit="traduction"/>Un loup, ayant été mordu et mis à mal par des chiens, s’était abattu sur le sol. Comme il était hors d’état de se procurer à manger, il aperçut une brebis et la pria de lui apporter à boire de la rivière voisine. « Si tu me donnes de quoi boire, je trouverai moi-même de quoi manger. — Mais si je te donne de quoi boire, répondit la brebis, c’est moi qui ferai les frais de ton repas. »</p>
           <p><milestone unit="traduction"/>Cette fable vise le malfaiteur qui tend d’hypocrites embûches.</p>
         </div>
@@ -6295,7 +6294,7 @@
           <pb ed="perry" n="P160"/>
           <p><milestone unit="recitprose"/>Λύκος ὑπὸ κυνῶν δηχθεὶς καὶ κακῶς πάσχων ἐϐέϐλητο. Τροφῆς δὲ ἀπορῶν, θεασάμενος πρόϐατον, ἐδεῖτο ποτὸν ἐκ τοῦ παραρρέοντος αὐτῷ ποταμοῦ κομίσαι. « Εἰ γὰρ σύ μοι, φησί, δώσεις ποτόν, ἐγὼ τροφὴν ἑμαυτῷ εὑρήσω. » Τὸ δὲ ὑποτυχὸν ἔφη· « Ἀλλ’ ἐὰν ἐγὼ ποτὸν ἐπιδῶ σοι, σὺ καὶ τροφῇ μοι χρήσῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρα κακοῦργον δι’ ὑποκρίσεως ἐνεδρεύοντα.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 110 Lb 78 Le 78 Lf 110 Lh 35 Ml 98.</p>
+          <bibl>Codd. La 110 Lb 78 Le 78 Lf 110 Lh 35 Ml 98.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-233">
@@ -6304,7 +6303,7 @@
         <pb ed="perry" n="P349"/>
         <p><milestone unit="recitprose"/>Μεθύων λύχνος ἐλαίῳ καὶ φέγγων ἐκαυχᾶτο ὡς ὑπὲρ ἥλιον πλέον λάμπει. Ἀνέμου δὲ πνοῆς συρισάσης, εὐθὺς ἐσϐέσθη. Ἐκ δευτέρου δὲ ἅπτων τις εἶπεν αὐτῷ· « Φαῖνε, λύχνε, καὶ σίγα· τῶν ἀστέρων τὸ φέγγος οὔποτε ἐκλείπει. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ τινα ἐν ταῖς δόξαις καὶ τοῖς λαμπροῖς τοῦ βίου τυφοῦσθαι· ὅσα γὰρ ἂν κτήσηταί τις, ξένα τυγχάνει.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 90 Bb 58.</p>
+        <bibl>Codd. Ba 90 Bb 58.</bibl>
         <p><milestone unit="traduction"/>Une lampe enivrée d’huile, jetant une vive lumière, se vantait d’être plus brillante que le soleil. Mais un souffle de vent ayant sifflé, elle s’éteignit aussitôt. Quelqu’un la ralluma et lui dit : « Éclaire, lampe, et tais-toi : l’éclat des astres ne s’éclipse jamais. »</p>
         <p><milestone unit="traduction"/>Il ne faut pas se laisser aveugler par l’orgueil, quand on est en réputation ou en honneur ; car tout ce qui s’acquiert nous est étranger.</p>
       </div>
@@ -6316,7 +6315,7 @@
           <pb ed="perry" n="P161"/>
           <p><milestone unit="recitprose"/>Μάντις ἐπὶ τῆς ἀγορᾶς καθεζόμενος ἠργυρολόγει. Ἐλθόντος δέ τινος αἰφνίδιον πρὸς αὐτὸν καὶ ἀπαγγείλαντος ὡς τῆς οἰκίας αὐτοῦ αἱ θύραι ἀνεσπασμέναι εἰσὶ καὶ πάντα τὰ ἔνδον ἐκπεφορημένα, ἐκταραχθεὶς ἀνεπήδησε καὶ στενάξας ᾔει δρόμῳ τὸ γεγονὸς ὀψόμενος. Τῶν δὲ παρατυχόντων τις θεασάμενος εἶπεν· « Ὦ οὗτος, σὺ τὰ ἀλλότρια πράγματα προειδέναι ἐπαγγελλόμενος τὰ σαυτοῦ οὐ προεμαντεύου ; »</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἐκείνους τοὺς ἀνθρώπους τοὺς τὸν ἑαυτῶν βίον φαύλως διοικοῦντας καὶ τῶν μηδὲν προσηκόντων προνοεῖσθαι πειρωμένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 158 Pc 90 Pf 86 Pg 100 Ma 109 Mb 119 Me 110 Mf 93 Mj 103 — Ca 113 Cb 71 Ce 78 Cf 82 Cg 10 Ch 85 Mh 75.</p>
+          <bibl>Codd. Pa 158 Pc 90 Pf 86 Pg 100 Ma 109 Mb 119 Me 110 Mf 93 Mj 103 — Ca 113 Cb 71 Ce 78 Cf 82 Cg 10 Ch 85 Mh 75.</bibl>
           <p><milestone unit="traduction"/>Un devin, installé sur la place publique, y faisait recette. Soudain un quidam vint à lui et lui annonça que les portes de sa maison étaient ouvertes et qu’on avait enlevé tout ce qui était à l’intérieur. Hors de lui, il se leva d’un bond et courut en soupirant voir ce qui était arrivé. Un des gens qui se trouvaient là, le voyant courir, lui cria : « Hé ! l’ami, toi qui te piquais de prévoir ce qui doit arriver aux autres, tu n’as pas prévu ce qui t’arrive. »</p>
           <p><milestone unit="traduction"/>On pourrait appliquer cette fable à ces gens qui règlent pitoyablement leur vie et qui se mêlent de diriger des affaires qui ne les regardent pas.</p>
         </div>
@@ -6326,7 +6325,7 @@
           <pb ed="perry" n="P161"/>
           <p><milestone unit="recitprose"/>Μάντις ἐπ’ ἀγορᾶς καθήμενος διελέγετο. Ἐπιστάντος δέ τινος αἴφνης καὶ ἀπαγγείλαντος ὡς αἱ τῆς οἰκίας αὐτοῦ θυρίδες ἀναπεπταμέναι τε πᾶσαι εἶεν καὶ πάντα τὰ ἔνδον ἀφῃρημένα, ἀνεπήδησέ τε στενάξας καὶ δρομαῖος ᾔει. Τρέχοντα δέ τις αὐτὸν θεασάμενος· « Ὦ οὗτος, εἶπεν, ὁ τἀλλότρια πράγματα προειδέναι ἐπαγγελλόμενος, τὰ σαυτοῦ οὐ προεμαντεύου ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς τὸν μὲν ἑαυτῶν βίον φαύλως διοικοῦντας, τῶν δὲ μηδὲν αὐτοῖς προσηκόντων προνοεῖσθαι πειρωμένους.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 40 Lb 81 Lc 19 Ld 25 Le 80 Lf 40 Lg 19 Mc 69 Md 80 Mg 102 Ml 106 Mm 96 Mn 25.</p>
+          <bibl>Codd. La 40 Lb 81 Lc 19 Ld 25 Le 80 Lf 40 Lg 19 Mc 69 Md 80 Mg 102 Ml 106 Mm 96 Mn 25.</bibl>
         </div>
         <div>
           <head>Chambry 234.3</head>
@@ -6347,7 +6346,7 @@
           <l><milestone unit="recitvers"/>Ὁ φαλακρὸς πῶς ἄλλῳ μαλλοὺς ποιήσει ;</l>
           <l><milestone unit="recitvers"/>Οὐκ ἔξεστιν. Ὁ δὲ κενοὺς λόγους λέγων</l>
           <l><milestone unit="recitvers"/>οὐδὲ ἑαυτὸν δύναται ὠφελῆσαι.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 85.</p>
+          <bibl>Cod. Cd 85.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-235">
@@ -6358,7 +6357,7 @@
           <pb ed="perry" n="P163"/>
           <p><milestone unit="recitprose"/>Μέλισσαι φθονήσασαι ἀνθρώποις τοῦ ἰδίου μέλιτος ἧκον πρὸς τὸν Δία καὶ τούτου ἐδέοντο ὅπως αὐταῖς ἰσχὺν παράσχηται παιούσαις τοῖς κέντροις τοὺς προσιόντας τοῖς κηρίοις ἀναιρεῖν. Καὶ ὁ Ζεὺς ἀγανακτήσας κατ’ αὐτῶν διὰ τὴν βασκανίαν παρεσκεύασεν αὐτάς, ἡνίκα ἂν τύπτωσί τινα, τὸ κέντρον ἀποϐαλεῖν, μετὰ δὲ τοῦτο καὶ τῆς σωτηρίας στερίσκεσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόσειεν ἂν πρὸς ἄνδρας βασκάνους οἳ καὶ αὐτοὶ βλάπτεσθαι ὑπομένουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 160 Pb 161 Pc 91 Pg 101 Ma 110.</p>
+          <bibl>Codd. Pa 160 Pb 161 Pc 91 Pg 101 Ma 110.</bibl>
           <p><milestone unit="traduction"/>Les abeilles, enviant leur miel aux hommes, allèrent trouver Zeus et le prièrent de leur donner de la force pour tuer à coups d’aiguillon ceux qui s’approcheraient de leurs cellules. Zeus, indigné de les voir envieuses, les condamna à perdre leur dard, toutes les fois qu’elles en frapperaient quelqu’un, et à mourir après.</p>
           <p><milestone unit="traduction"/>Cette fable peut s’appliquer aux envieux qui consentent à souffrir eux-mêmes des maux qu’ils font.</p>
         </div>
@@ -6389,7 +6388,7 @@
           <l><milestone unit="epimythiumenvers"/>κατὰ τῶν ἐχθρῶν ἐξαιτεῖσθαι κακόν τι·</l>
           <l><milestone unit="epimythiumenvers"/>ὃ γὰρ ἂν κακὸν κατ’ αὐτῶν ἐξαιτήσῃς</l>
           <l><milestone unit="epimythiumenvers"/>ἀνθυποστρέψει ἐπὶ σὲ παραυτίκα.</l>
-          <p><milestone unit="manuscrits"/>Codd. Cg 14 Ch 89 Ca 114 Cb 74 Cd 89 Mb 118 Mc 73.</p>
+          <bibl>Codd. Cg 14 Ch 89 Ca 114 Cb 74 Cd 89 Mb 118 Mc 73.</bibl>
         </div>
         <div>
           <head>Chambry 235.3</head>
@@ -6397,7 +6396,7 @@
           <pb ed="perry" n="P163"/>
           <p><milestone unit="recitprose"/>Μέλισσα μήτηρ κηρίων οὖσα ἀνελήλυθεν εἰς θεούς, φέρουσα κηροὺς καὶ μέλι. Τερφθεὶς δὲ ὁ Ζεὺς τῇ προσφορᾷ τῆς μελίσσης συνετάξατο δοῦναι αὐτῇ ὃ ἂν αἰτήσῃ. Ἡ δέ· « Δός, ἔφη, τῇ σῇ θεραπαινίδι κέντρον πρὸς ἄμυναν τῶν πόνων μου καὶ εἰς φυλακήν μου. » Ἀπορήσας δὲ ὁ Ζεὺς πρὸς τὰς αἰτήσεις, ἐπεὶ ἐφίλει τῶν ἀνθρώπων τὸ γένος, ἔφη τῇ μελίσσῃ· « Οὐχ ὡς ᾔτησας γενήσεται, ἀλλ’ ἐάν τις τῶν ἀνθρώπων ἥκῃ λαϐεῖν μέλι, σὺ δὲ βούλῃ αὐτὸν ἀμύνασθαι, ἔχε τὸ κέντρον· πλὴν ἴσθι ὅτι, εἰ πλήξεις ἄνθρωπον, ἐμϐληθέντος τοῦ κέντρου, παρευθὺς ἀποθνήξῃ· ζωὴ γάρ σοι ἐντυγχάνει τὸ κέντρον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἐν ταῖς προσευχαῖς καὶ ταῖς δεήσεσιν μηδεὶς κατὰ τῶν ἐχθρῶν ζητείτω κακόν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 82 Cf 86.</p>
+          <bibl>Codd. Ce 82 Cf 86.</bibl>
         </div>
         <div>
           <head>Chambry 235.4</head>
@@ -6405,7 +6404,7 @@
           <pb ed="perry" n="P163"/>
           <p><milestone unit="recitprose"/>Ὑμηττία μέλισσα, κηρίων μήτηρ, ἀνῆλθεν εἰς θεῶν οἴκους, φέρουσα τῷ Διὶ μέλι μήπω καπνισθέν. Ὁ Ζεὺς δὲ τῷ δώρῳ ἐτέρφθη, καὶ ὑπέσχετο δοῦναι γέρας ὃ ἂν αἰτήσηται. Ἡ δὲ εἶπεν· « Δός μοι κέντρον, ἵνα, εἴ τις ἀνθρώπων τὸ ἐμὸν ἔργον πλησιάσῃ ἆραι, ἀναιρῶ τοῦτον. » Ἀπηρέσθη δὲ ὁ Ζεὺς τῇ αἰτήσει· ἠγάπα γὰρ τοὺς ἀνθρώπους· ὅμως καὶ μὴ θέλων ἔδωκεν· εἶπε γὰρ δώσειν· τοιοῦτον δὲ δέδωκεν ὡς αὐτὴν ἀποθνῄσκειν ἅμα τῷ πλῆξαι· ζωὴ δὲ αὐτῆς ἐστι [πετομένης] τὸ κέντρον.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐν ταῖς εὐχαῖς καὶ δεήσεσι μηδεὶς κατὰ τῶν ἐχθρῶν αἰτείτω τι· ὃ γὰρ ἂν κακὸν αἰτήσηται ἐπ’ αὐτὸν ἥξει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 136.</p>
+          <bibl>Cod. Ba 136.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-236">
@@ -6416,7 +6415,7 @@
           <pb ed="perry" n="P72"/>
           <p><milestone unit="recitprose"/>Εἰς μελισσουργοῦ τις εἰσελθών, ἐκείνου ἀπόντος, τό τε μέλι καὶ τὰ κηρία ὑφείλετο. Ὁ δὲ ἐπανελθών, ἐπειδὴ ἐθεάσατο ἐρήμους τὰς κυψέλας, εἱστήκει ταύτας διερευνῶν. Αἱ δὲ μέλισσαι ἐπανελθοῦσαι ἀπὸ τῆς νομῆς, ὡς κατέλαϐον αὐτόν, παίουσαι τοῖς κέντροις, τὰ πάνδεινα διετίθεσαν. Κἀκεῖνος ἔφη πρὸς αὐτάς· « Ὦ κάκιστα ζῷα, ὑμεῖς τὸν μὲν κλέψαντα ὑμῶν τὰ κηρία ἀθῷον ἀφήκατε, ἐμὲ δὲ τὸν ἐπιμελούμενον ὑμῶν δεινῶς τύπτετε. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων δι’ ἄγνοιαν τοὺς ἐχθροὺς μὴ φυλαττόμενοι, τοὺς φίλους ὡς ἐπιϐούλους ἀπωθοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 69 Pb 73 Pc 36 Pe 39 Pf 36 Pg 46 Ph 36 Ma 52 Me 53 Mf 48.</p>
+          <bibl>Codd. Pa 69 Pb 73 Pc 36 Pe 39 Pf 36 Pg 46 Ph 36 Ma 52 Me 53 Mf 48.</bibl>
           <p><milestone unit="traduction"/>Un homme, ayant pénétré chez un éleveur d’abeilles, en son absence, avait dérobé miel et rayons. À son retour, l’éleveur, voyant les ruches vides, s’arrêta à les examiner. Mais les abeilles, revenant de picorer et le trouvant là, le piquèrent de leurs aiguillons et le maltraitèrent terriblement. « Méchantes bêtes, leur dit-il, vous avez laissé partir impunément celui qui a volé vos rayons, et moi qui vous soigne, vous me frappez impitoyablement ! »</p>
           <p><milestone unit="traduction"/>Il arrive assez souvent ainsi que par ignorance on ne se méfie pas de ses ennemis, et qu’on repousse ses amis, les tenant pour suspects.</p>
         </div>
@@ -6426,7 +6425,7 @@
           <pb ed="perry" n="P72"/>
           <p><milestone unit="recitprose"/>Εἰς μελιττουργεῖόν τις εἰσελθών, τοῦ κεκτημένου ἀπόντος, τὸ κηρίον ἀφείλετο. Ὁ δὲ ἐπανελθών, ἐπειδὴ τὰς κυψέλας εἶδεν ἐρήμους, εἱστήκει τὸ κατ’ αὐτὰς διερευνώμενος. Αἱ δὲ μέλισσαι ἀπὸ τῆς νομῆς ἐπανήκουσαι, ὡς κατέλαϐον αὐτόν, τοῖς κέντροις ἔπαιον καὶ τὰ χείριστα διετίθουν. Ὁ δὲ πρὸς αὐτάς· « Κάκιστα ζῷα, τὸν μὲν κλέψαντα ὑμῶν τὰ κηρία ἀθῷον ἀφήκατε, ἐμὲ δὲ τὸν ἐπιμελούμενον ὑμῶν πλήττετε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτω τῶν ἀνθρώπων τινὲς δι’ ἄγνοιαν τοὺς ἐχθροὺς μὴ φυλαττόμενοι, τοὺς φίλους ὡς ἐπιϐούλους ἀπωθοῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 89 Lb 46 Lc 35 Le 46 Lf 89 Lg 35 Md 142 Mg 69 Mi 116 Mj 56 Ml 59 Mm 68.</p>
+          <bibl>Codd. La 89 Lb 46 Lc 35 Le 46 Lf 89 Lg 35 Md 142 Mg 69 Mi 116 Mj 56 Ml 59 Mm 68.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-237">
@@ -6435,7 +6434,7 @@
         <pb ed="perry" n="P164"/>
         <p><milestone unit="recitprose"/>Μηναγύρται ὄνον ἔχοντες τούτῳ εἰώθεσαν τὰ σκεύη ἐπιτιθέντες ὁδοιπορεῖν. Καὶ δή ποτε ἀποθανόντος αὐτοῦ ἀπὸ κόπου, ἐκδείραντες αὐτόν, ἐκ τοῦ δέρματος τύμπανα κατεσκεύασαν καὶ τούτοις ἔχρωντο. Ἑτέρων δὲ αὐτοῖς μηναγυρτῶν ἀπαντησάντων καὶ πυνθανομένων αὐτῶν ποῦ εἴη ὁ ὄνος, ἔφασαν τεθνηκέναι μὲν αὐτόν, πληγὰς δὲ τοσαύτας λαμϐάνειν ὅσας ποτὲ οὐδὲ ζῶν ὑπέμεινεν.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν οἰκετῶν ἕνιοι, καίπερ τῆς δουλείας ἀφειμένοι, τῶν δουλικῶν ἀρχῶν οὐκ ἀπαλλάττονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 161 Pb 162 Pf 87 Pg 102 Ma 111 Me 111 Mf 94 Mj 104.</p>
+        <bibl>Codd. Pa 161 Pb 162 Pf 87 Pg 102 Ma 111 Me 111 Mf 94 Mj 104.</bibl>
         <p><milestone unit="traduction"/>Des ménagyrtes avaient un âne qu’ils chargeaient de leurs bagages, quand ils se mettaient en route. Or un jour cet âne mourut de fatigue ; ils le dépouillèrent, firent de sa peau des tambourins, et ils s’en servirent. D’autres ménagyrtes les ayant rencontrés leur demandèrent où était leur âne. « Il est mort, dit-il ; mais il reçoit autant de coups qu’il en a jamais reçus de son vivant. »</p>
         <p><milestone unit="traduction"/>Ainsi parfois les serviteurs, même affranchis de l’esclavage, ne sont pas délivrés des charges de la servitude.</p>
       </div>
@@ -6456,7 +6455,7 @@
           <l><milestone unit="recitvers"/>ἐπὰν δὲ κυνὸς ὑλακὴν ἐπακούσω,</l>
           <l><milestone unit="recitvers"/>εὐθὺς σκοτοῦμαι καὶ τῇ φυγῇ κινοῦμαι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἀνθρώπους τοὺς φύσει δειλοὺς οὐδεμία παραίνεσις ἀνθρώπου ἐπιρρώννυσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 12 Ch 87 Ca 120 Cb 73 Cd 87 Mb 124 Mc 72.</p>
+          <bibl>Codd. Cg 12 Ch 87 Ca 120 Cb 73 Cd 87 Mb 124 Mc 72.</bibl>
         </div>
         <div>
           <head>Chambry 238.2</head>
@@ -6464,7 +6463,7 @@
           <pb ed="perry" n="P351"/>
           <p><milestone unit="recitprose"/>Νεϐρός ποτε πρὸς τὸν ἔλαφον εἶπε· « Πάτερ, σὺ καὶ μείζων καὶ ταχύτερος κυνῶν πέφυκας, καὶ κέρατα πρὸς τούτοις ὑπερφυᾶ φέρεις εἰς ἄμυναν. Τί δή ποτ’ οὖν οὕτω τούτους φοϐῇ ; » Κἀκεῖνος γελῶν εἶπεν· « Ἀληθῆ μὲν ταῦτα φῇς, τέκνον· ἓν δ’ οἶδα, ὡς, ἐπειδὰν κυνὸς ὑλακὴν ἀκούσω, αὐτίκα πρὸς φυγὴν οὐκ οἶδ’ ὅπως ἐκφέρομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς φύσει δειλοὺς οὐδεμία παραίνεσις ῥώννυσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 56 Lb 87 Le 87 Lf 56 Lg 34 Lh 43 Md 115 Me 118 Mf 100 Mg 112 Mi 31 Ml 115 Mm 102.</p>
+          <bibl>Codd. La 56 Lb 87 Le 87 Lf 56 Lg 34 Lh 43 Md 115 Me 118 Mf 100 Mg 112 Mi 31 Ml 115 Mm 102.</bibl>
         </div>
         <div>
           <head>Chambry 238.3</head>
@@ -6472,7 +6471,7 @@
           <pb ed="perry" n="P351"/>
           <p><milestone unit="recitprose"/>Μόσχος πρὸς τὴν ἔλαφον εἶπεν· « Σὺ καὶ μεγέθει μείζων εἶ τῶν κυνῶν καὶ ταχύτητι διαφέρεις καὶ κέρατα πρὸς ἄμυναν ἔχεις. Τί οὖν τοσοῦτον φοϐῇ τοὺς κύνας ; » Καὶ ἡ ἔλαφος ἔφη· « Ὅτι μὲν ταῦτα πάντα ἔχω, οἶδα· ὑλακῆς δὲ εἰ ἀκούσω, τὸν λογισμὸν σκοτοῦμαι καὶ ὅλη τῆς φυγῆς γίνομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς φύσει δειλοὺς οὐδεμία λόγου παραίνεσις ἐπιρρώννυσι, κἂν καὶ εὐμήκεις καὶ στερεοὶ τῷ σώματι φαίνωνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 88 Bb 56.</p>
+          <bibl>Codd. Ba 88 Bb 56.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-239">
@@ -6483,7 +6482,7 @@
           <pb ed="perry" n="P165"/>
           <p><milestone unit="recitprose"/>Μυσὶ καὶ γαλαῖς πόλεμος ἦν. Ἀεὶ δὲ οἱ μύες ἡττώμενοι, ἐπειδὴ συνῆλθον εἰς ταὐτόν, ὑπέλαϐον ὅτι δι’ ἀναρχίαν τοῦτο πάσχουσιν· ὅθεν ἐπιλεξάμενοί τινας ἑαυτῶν στρατηγοὺς ἐχειροτόνησαν. Οἱ δὲ βουλόμενοι ἐπισημότεροι τῶν ἄλλων φανῆναι, κέρατα κατασκευάσαντες ἑαυτοῖς συνῆψαν. Ἐνστάσης δὲ τῆς μάχης, συνέϐη πάντας τοὺς μύας ἡττηθῆναι. Οἱ μὲν οὖν ἄλλοι πάντες ἐπὶ τὰς ὀπὰς καταφεύγοντες ῥᾳδίως εἰσέδυνον· οἱ δὲ στρατηγοὶ μὴ δυνάμενοι εἰσελθεῖν διὰ τὰ κέρατα αὐτῶν συλλαμϐανόμενοι κατησθίοντο.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοῖς ἡ κενοδοξία κακῶν αἰτία γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 162 Pb 163 Pg 103 Ma 112 Ca 115.</p>
+          <bibl>Codd. Pa 162 Pb 163 Pg 103 Ma 112 Ca 115.</bibl>
           <p><milestone unit="traduction"/>Les rats et les belettes étaient en guerre. Or les rats, se voyant toujours battus, se réunirent en assemblée, et, s’imaginant que c’était faute de chefs qu’ils éprouvaient ces revers, ils se choisirent des stratèges et les élurent à main levée. Or ceux-ci, voulant être distingués des simples soldats, se façonnèrent des cornes et se les ajustèrent. La bataille s’étant livrée, il arriva que l’armée des rats eut le dessous. Alors les soldats s’enfuirent vers leurs trous, où ils pénétrèrent aisément ; mais les généraux, ne pouvant y entrer à cause de leurs cornes, furent pris et dévorés.</p>
           <p><milestone unit="traduction"/>Ainsi souvent la vaine gloire est une cause de malheur.</p>
         </div>
@@ -6517,7 +6516,7 @@
           <l><milestone unit="recitvers"/>μὴ δυνάμενοι ἐν ταῖς ὀπαῖς εἰσδῦναι</l>
           <l><milestone unit="recitvers"/>διεφθάρησαν ὑπὸ τῶν γαλῶν πάντες.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πρὸς τὸ ζῆν ἀκινδύνως κρεῖττόν ἐστιν ἡ εὐτέλεια ὑπὲρ τὴν λαμπρότητα καὶ τὴν δόξαν τοῦ βίου.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 41 Ch 116 Ca 175 Cd 110.</p>
+          <bibl>Codd. Cg 41 Ch 116 Ca 175 Cd 110.</bibl>
         </div>
         <div>
           <head>Chambry 239.3</head>
@@ -6525,14 +6524,14 @@
           <pb ed="perry" n="P165"/>
           <p><milestone unit="recitprose"/>Γαλαῖ καὶ μύες πρὸς ἀλλήλους ἄσπονδον εἶχον μάχην. Ἐνίκων δὲ ἀεὶ αἱ γαλαῖ. Οἱ δὲ μύες βουλευσάμενοι ὅτι διὰ τὸ μὴ ἔχειν στρατηγοὺς ἡττῶνται, τοὺς μεγάλους μύας στρατηγοὺς προχειρισάμενοι καὶ καθοπλίσαντες τοῖς μείζοσι ξύλοις τῶν ἀχύρων ἀντὶ δοράτων, συγκροτοῦσι τὸν πόλεμον καὶ πάλιν ἡττῶνται. Καὶ οἱ μὲν ἄνοπλοι μύες, ὑπὸ τὰς τρυμαλιὰς ὑπελθόντες, ἐσώθησαν· οἱ δὲ καθωπλισμένοι, μὴ δυνάμενοι εἰς τὰς ὀπὰς εἰσελθεῖν, διεφθάρησαν ὑπὸ τῶν γαλῶν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πρὸς τὸ ζῆν ἀκινδύνως ἡ εὐτέλεια ὑπὲρ τὴν δόξαν καὶ τὴν λαμπρότητα τοῦ βίου κρείττων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 20 Mg 37.</p>
+          <bibl>Codd. Ba 20 Mg 37.</bibl>
         </div>
         <div>
           <head>Chambry 239.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P165"/>
           <p><milestone unit="recitprose"/>Γαλαῖ καὶ μύες πρὸς ἀλλήλους ἄσπονδον μάχην ἐκέκτηντο. Ἡ δὲ νίκη ἀεὶ ταῖς γαλαῖς προσεγέλα. Οἱ δὲ μύες στοχασάμενοι τὴν ἧτταν αὑτοῖς ἐκ τοῦ μὴ ἔχειν στρατηγοὺς ὡπλισμένους συμϐαίνειν, τοὺς μεγίστους τῶν μυῶν στρατηγοὺς προχειρισάμενοι, ξύλοις τούτους καθώπλιζον. Συγκροτήσαντες δὲ αὖθις πόλεμον καὶ ἡττηθέντες, οἱ μὲν ἄοπλοι μύες ὑπὸ ταῖς ὀπαῖς διέδυσαν· οἱ δὲ ὡπλισμένοι, ὑπὸ τῶν ξύλων εἰσελθόντες κωλυόμενοι, ὑπὸ τῶν γαλῶν διεφθάρησαν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 6.</p>
+          <bibl>Cod. Bd 6.</bibl>
         </div>
         <div>
           <head>Chambry 239.5</head>
@@ -6540,7 +6539,7 @@
           <pb ed="perry" n="P165"/>
           <p><milestone unit="recitprose"/>Γαλαῖ καὶ μύες ἄσπονδον εἶχον μάχην. Οἱ δὲ μύες, δόρατα καὶ ἅρματα ἐξ ἀχύρου λαϐόντες, συνεκρότησαν τὸν πόλεμον. Αἱ δὲ γαλαῖ ὥρμησαν κατ’ αὐτῶν. Οἱ δὲ μύες βουλόμενοι εἰς τὰς τρυμαλιὰς εἰσελθεῖν, ἔχοντες τὰ ξύλα τῶν ἀχύρων καὶ μὴ δυνάμενοι κρυϐῆναι, διεφθάρησαν ὑπὸ τῶν γαλῶν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἀδύνατόν τιν’ οὐ δεῖ συγκροτεῖν τοὺς πολέμους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ma 159.</p>
+          <bibl>Cod. Ma 159.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-240">
@@ -6551,7 +6550,7 @@
           <pb ed="perry" n="P167"/>
           <p><milestone unit="recitprose"/>Μυῖα ἐμπεσοῦσα εἰς χύτραν κρέως, ἐπειδὴ ὑπὸ τοῦ ζωμοῦ ἀποπνίγεσθαι ἔμελλεν, ἔφη πρὸς ἑαυτήν· « Ἀλλ’ ἔγωγε καὶ βέϐρωκα καὶ πέπωκα καὶ λέλουμαι· κἂν ἀποθάνω, οὐδέν μοι μέλει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ῥᾴδιον φέρουσι τὸν θάνατον οἱ ἄνθρωποι, ὅταν ἀϐασανίστως παρακολουθήσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 164 Pc 93 Ma 113 Ml 110 Ca 117 Cb 75 Ce 80 Cf 84 Cg 16 Ch 91.</p>
+          <bibl>Codd. Pa 164 Pc 93 Ma 113 Ml 110 Ca 117 Cb 75 Ce 80 Cf 84 Cg 16 Ch 91.</bibl>
           <p><milestone unit="traduction"/>Une mouche était tombée dans une marmite remplie de viande. Sur le point d’être noyée dans la sauce, elle se dit à elle-même : « J’ai mangé, j’ai bu, j’ai pris un bain ; la mort peut venir : il ne m’en chaut. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les hommes supportent facilement la mort, quand elle survient sans douleur.</p>
         </div>
@@ -6566,7 +6565,7 @@
           <l><milestone unit="recitvers"/>οὐ μέλει μοι θάνατος, νὴ τοὺς θεούς μου. »</l>
           <l><milestone unit="recitvers"/>Φέρουσί τινες τὸν θάνατον ῥᾳδίως,</l>
           <l><milestone unit="recitvers"/>ὅταν ἐπέλθῃ ἀϐασανίστως τούτοις.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 90.</p>
+          <bibl>Cod. Cd 90.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-241">
@@ -6577,7 +6576,7 @@
           <pb ed="perry" n="P80"/>
           <p><milestone unit="recitprose"/>Ἔν τινι ταμιείῳ μέλιτος ἐπεκχυθέντος, μυῖαι προσπτᾶσαι κατήσθιον· διὰ δὲ τὴν γλυκύτητα τοῦ καρποῦ οὐκ ἀφίσταντο. Ἐμπαγέντων δὲ αὐτῶν τῶν ποδῶν, ὡς οὐκ ἐδύναντο ἀναπτῆναι, ἀποπνιγόμεναι ἔφασαν· « Ἄθλιαι ἡμεῖς, αἳ διὰ βραχεῖαν ἡδονὴν ἀπολλύμεθα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοῖς ἡ λιχνεία πολλῶν αἰτία κακῶν γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 77 Pb 81 Pf 39 Pg 52 Ph 41 Ma 60 Ca 68.</p>
+          <bibl>Codd. Pa 77 Pb 81 Pf 39 Pg 52 Ph 41 Ma 60 Ca 68.</bibl>
           <p><milestone unit="traduction"/>Du miel s’étant répandu dans un cellier, des mouches y volèrent et se mirent à le manger. C’était un régal si doux qu’elles ne pouvaient s’en détacher. Mais leurs pattes s’y étant engluées, elles ne purent prendre l’essor, et se sentant étouffer, elles dirent : « Malheureuses que nous sommes, nous périssons pour un instant de plaisir. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que la gourmandise est souvent la cause de bien des maux.</p>
         </div>
@@ -6587,7 +6586,7 @@
           <pb ed="perry" n="P80"/>
           <p><milestone unit="recitprose"/>Ἔν τινι ταμείῳ μέλιτος ἐκχυθέντος, μυῖαι προσπτᾶσαι κατήσθιον. Ἐμπαγέντων δὲ τῶν ποδῶν αὐτῶν, ἀναπτῆναι οὐκ εἶχον. Ἀποπνιγόμεναι δ’ ἔλεγον· « Ἄθλιαι ἡμεῖς, ὅτι διὰ βραχεῖαν βρῶσιν ἀπολλύμεθα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοῖς ἡ λιχνεία πολλῶν κακῶν αἰτία γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 93 Lb 48 Le 48 Lf 93 Me 55 Mf 49 Mg 71 Mj 58 Ml 61.</p>
+          <bibl>Codd. La 93 Lb 48 Le 48 Lf 93 Me 55 Mf 49 Mg 71 Mj 58 Ml 61.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-242">
@@ -6598,7 +6597,7 @@
           <pb ed="perry" n="P166"/>
           <p><milestone unit="recitprose"/>Μύρμηξ ὁ νῦν τὸ πάλαι ἄνθρωπος ἦν· καὶ τῇ γεωργίᾳ προσέχων τοῖς ἰδίοις πόνοις οὐκ ἠρκεῖτο, ἀλλὰ καὶ τοῖς ἀλλοτρίοις ἐποφθαλμιῶν διετέλει τοὺς τῶν γειτόνων καρποὺς ὑφαιρούμενος. Ζεὺς δὲ ἀγανακτήσας κατὰ τῆς πλεονεξίας αὐτοῦ μετεμόρφωσεν αὐτὸν εἰς τοῦτο τὸ ζῷον ὃς μύρμηξ καλεῖται. Ὁ δὲ καὶ τὴν μορφὴν ἀλλάξας τὴν διάθεσιν οὐ μετεϐάλετο· μέχρι γὰρ νῦν κατὰ τὰς ἀρούρας περιιὼν τοὺς ἄλλων πυροὺς καὶ κριθὰς συλλέγει καὶ ἑαυτῷ ἀποθησαυρίζει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ φύσει πονηροί, κἂν τὰ μάλιστα κολάζωνται, τὸν τρόπον οὐ μετατίθενται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 163 Pb 164 Pc 92 Pg 104 Mb 121 Ca 116.</p>
+          <bibl>Codd. Pa 163 Pb 164 Pc 92 Pg 104 Mb 121 Ca 116.</bibl>
           <p><milestone unit="traduction"/>La fourmi d’à présent était autrefois un homme qui, adonné à l’agriculture, ne se contentait pas du produit de ses propres travaux ; il regardait d’un œil d’envie ceux des autres et ne cessait de dérober les fruits de ses voisins. Zeus indigné de sa cupidité le changea en l’animal que nous appelons fourmi. Mais pour avoir changé de forme, il n’a pas changé de caractère ; car aujourd’hui encore il parcourt les champs, ramasse le blé et l’orge d’autrui, et les met en réserve pour son usage.</p>
           <p><milestone unit="traduction"/>Cette fable montre que les gens naturellement méchants ont beau être punis très sévèrement, ils ne changent pas pour cela de caractère.</p>
         </div>
@@ -6608,7 +6607,7 @@
           <pb ed="perry" n="P166"/>
           <p><milestone unit="recitprose"/>Μύρμηξ ὁ νῦν τὸ παλαιὸν ἄνθρωπος ἦν· καὶ τῇ γεωργίᾳ διηνεκῶς προσέχων, οὐ τοῖς ἰδίοις ἠρκεῖτο πόνοις, ἀλλὰ καὶ τοὺς τῶν γειτόνων καρποὺς ὑφῃρεῖτο. Ὁ δὲ Ζεὺς ἀγανακτήσας ἐπὶ τῇ τούτου πλεονεξίᾳ, μετεμόρφωσεν αὐτὸν εἰς τοῦτο τὸ ζῷον ὃ μύρμηξ καλεῖται. Ὁ δὲ τὴν μορφὴν ἀλλάξας τὴν διάθεσιν οὐ μετέϐαλε· μέχρι γὰρ τοῦ νῦν τὰς ἀρούρας περιιὼν τοὺς τῶν ἑτέρων πόνους συλλέγει καὶ ἑαυτῷ ἀποθησαυρίζει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φύσει πονηροί, κἂν τὰ μάλιστα τὸ εἶδος μεταϐληθῶσι, τὸν τρόπον οὐ μεταϐάλλονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 112 Lb 80 Le 81 Lf 112 Lh 37 Me 114 Mf 96 Mg 108 Ml 109.</p>
+          <bibl>Codd. La 112 Lb 80 Le 81 Lf 112 Lh 37 Me 114 Mf 96 Mg 108 Ml 109.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-243">
@@ -6619,7 +6618,7 @@
           <pb ed="perry" n="P112"/>
           <p><milestone unit="recitprose"/>Θέρους ὥρᾳ μύρμηξ περιπατῶν κατὰ τὴν ἄρουραν πυροὺς καὶ κριθὰς συνέλεγεν, ἀποθησαυριζόμενος ἑαυτῷ τροφὴν εἰς τὸν χειμῶνα. Κάνθαρος δὲ τοῦτον θεασάμενος ἐθαύμασεν ὡς ἐπιπονώτατον, εἴγε παρ’ αὐτὸν τὸν καιρὸν μοχθεῖ παρ’ ὃν τὰ ἄλλα ζῷα πόνων ἀφειμένα ῥᾳστώνην ἄγει. Ὁ δὲ τότε μὲν ἡσύχαζεν· ὕστερον δέ, ὅτε χειμὼν ἐνέστη, τῆς κόπρου ὑπὸ τοῦ ὄμϐρου ἐκλυθείσης, ὁ κάνθαρος ἧκε πρὸς αὐτὸν λιμώττων καὶ τροφῆς μεταλαϐεῖν δεόμενος. Ὁ δὲ ἔφη πρὸς αὐτόν· « Ὦ κάνθαρε, ἀλλ’ εἰ τότε ἐπόνεις, ὅτε ἐμόχθουν καὶ ἐμὲ ὠνείδιζες, οὐκ ἂν νῦν τροφῆς ἐπεδέου. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ παρὰ τὰς εὐθηνείας τοῦ μέλλοντος μὴ προνοούμενοι παρὰ τὰς τῶν καιρῶν μεταϐολὰς τὰ μέγιστα δυστυχοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 104 et 235 Pb 111 Pg 72 Ca 84 Cd 50.</p>
+          <bibl>Codd. Pa 104 et 235 Pb 111 Pg 72 Ca 84 Cd 50.</bibl>
           <p><milestone unit="traduction"/>Dans la saison d’été, une fourmi rôdant dans la campagne, ramassait des grains de blé et d’orge, et les mettait en réserve pour s’en nourrir en hiver. Un escarbot l’aperçut et s’étonna de la voir si laborieuse, elle qui travaillait au temps même où les autres animaux, débarrassés de leurs travaux, se donnent du bon temps. Sur le moment, la fourmi ne répondit rien ; mais plus tard, quand vint l’hiver et que la pluie détrempa les bouses, l’escarbot affamé vint demander à la fourmi l’aumône de quelque aliment. La fourmi lui dit alors : « Ô escarbot, si tu avais travaillé au temps où je prenais de la peine et où tu m’injuriais, tu ne manquerais pas à présent de nourriture. »</p>
           <p><milestone unit="traduction"/>Pareillement les hommes qui, dans les temps d’abondance, ne se préoccupent pas de l’avenir, tombent dans une misère extrême, lorsque les temps viennent à changer.</p>
         </div>
@@ -6629,7 +6628,7 @@
           <pb ed="perry" n="P112"/>
           <p><milestone unit="recitprose"/>Ὥρᾳ θέρους μύρμηξ περιιὼν κατά τινα ἄρουραν πυροὺς καὶ κριθὰς συνέλεγεν ἀποθησαυριζόμενος ἑαυτῷ τροφὴν εἰς τὸν χειμῶνα. Κάνθαρος δὲ τοῦτον θεασάμενος ἐταλάνιζεν ὡς ἐπιπονώτατον, εἴγε παρ’ ὅλον τὸν καιρὸν μοχθεῖ παρὰ πάντα τὰ ζῷα. Ὁ δὲ μύρμηξ τότε μὲν ἡσυχάσας ὑπήνεγκεν. Χειμῶνος δὲ γενομένου καὶ τῆς κόπρου ὑπὸ τῶν ὑδάτων κατακλυσθείσης, ὁ κάνθαρος λιμώττων ἧκε πρὸς τὸν μύρμηκα τροφῆς μεταλαϐεῖν δεόμενος. Ὁ δὲ ἔφη πρὸς αὐτόν· « Ὦ κάνθαρε, ἀλλ’ εἰ τότε ἐπόνεις ὅτε με μοχθοῦντα ὠνείδιζες, οὐκ ἂν νῦν τροφῆς ἐπεδέου. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος διδάσκει μὴ ἀμελεῖν ἡμᾶς ἐπὶ τῇ τῶν ἀναγκαίων φροντίδι, ἀλλὰ καιρῷ εὐθέτῳ τὰ πρὸς σωτηρίαν μεριμνᾶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 143 Me 180 Mf 151 Mj 151.</p>
+          <bibl>Codd. Pf 143 Me 180 Mf 151 Mj 151.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-244">
@@ -6640,7 +6639,7 @@
           <pb ed="perry" n="P235"/>
           <p><milestone unit="recitprose"/>Μύρμηξ διψήσας, κατελθὼν εἴς τινα πηγὴν βουλόμενος πιεῖν, ἀπεπνίγετο. Περιστερὰ δὲ ἐν τῷ παρεστηκότι δένδρῳ κλάσασα φύλλον ἔϐαλε, δι’ οὗ ἐπιϐὰς ὁ μύρμηξ διεσώθη. Ἰξευτὴς δὲ παραστὰς καὶ συνθεὶς τοὺς καλάμους τὴν περιστερὰν λαϐεῖν ἤθελεν· ὁ δὲ μύρμηξ δακὼν εἰς τὸν πόδα τὸν ἰξευτὴν τοὺς καλάμους διασεῖσαι ἐποίησε, τὴν δὲ περιστερὰν φυγεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ τὰ ἄλογα ζῷα αἴσθησιν ἔχει καὶ ἀλλήλοις ὠφελεῖ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 165 Pf 88 Pg 105 Ma 114 Mb 122 Me 112 Mf 95 Mj 105.</p>
+          <bibl>Codd. Pb 165 Pf 88 Pg 105 Ma 114 Mb 122 Me 112 Mf 95 Mj 105.</bibl>
         </div>
         <div>
           <head>Chambry 244.2</head>
@@ -6648,7 +6647,7 @@
           <pb ed="perry" n="P235"/>
           <p><milestone unit="recitprose"/>Μύρμηξ διψήσας, κατελθὼν εἰς πηγὴν καὶ βουλόμενος πιεῖν, ἀπεπνίγετο. Περιστερὰ δὲ καθεζομένη ἐν τῷ παρεστηκότι δένδρῳ, ἐθεάσατο αὐτὸν καὶ κόψασα φύλλον ἀπὸ τοῦ δένδρου ἔρριψεν εἰς τὴν πηγήν, δι’ οὗ ἐπιϐὰς ὁ μύρμηξ ἐσώθη. Ἰξευτὴς δέ τις παρασταθεὶς καὶ συνθεὶς τοὺς καλάμους τὴν περιστερὰν συλλαϐεῖν ἐϐουλήθη. Ὁ δὲ μύρμηξ θεασάμενος ἔδακε τὸν πόδα τοῦ ἰξευτοῦ. Ὁ δὲ ἀλγήσας, ῥίψας τοὺς καλάμους, ἐποίησε φυγεῖν τὴν περιστεράν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, εἰ καὶ τὰ ἄλογα ζῷα αἴσθησιν ἔχουσι τοῦ καλοῦ, πῶς οὐ δεῖ ἡμᾶς τοὺς εὐεργέτας ἀμείϐεσθαι ; ἢ · Δύνανται καὶ τὰ μικρὰ τοῖς εὐεργέταις μεγάλας ἀμοιϐὰς παρέχειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 118 Cb 72 Cg 11 Ch 86 Mc 71.</p>
+          <bibl>Codd. Ca 118 Cb 72 Cg 11 Ch 86 Mc 71.</bibl>
         </div>
         <div>
           <head>Chambry 244.3</head>
@@ -6656,7 +6655,7 @@
           <pb ed="perry" n="P235"/>
           <p><milestone unit="recitprose"/>Μύρμηξ διψήσας καὶ κατελθὼν εἰς τὸν αἰγιαλὸν τῆς πηγῆς καὶ πιεῖν βουλόμενος ἀπεπνίγετο. Περιστερὰ δὲ ἐν τῷ πέρα ἑστηκυῖα εἰς δένδρον καθεζομένη ἐθεάσατο αὐτὸν καὶ κόψασα κλάδον ἀπὸ τοῦ δένδρου ἔρριψεν εἰς τὴν πηγήν· καὶ καθεσθεὶς ὁ μύρμηξ ἐπὶ τοῦ κλάδου ἐσώθη δι’ αὐτοῦ. Ἰξευτὴς δέ τις συνθεὶς τοὺς καλάμους τὴν περιστερὰν κρατῆσαι ἠϐούλετο. Ὁ δὲ μύρμηξ θεασάμενος ἔδακε τὸν πόδα τοῦ ἰξευτοῦ. Ὁ δὲ ἀλγήσας ἔρριψε τοὺς καλάμους καὶ ἐποίησε φυγεῖν τὴν περιστεράν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοὺς εὐεργέτας ἀντευεργετεῖν τὰ ὅμοια.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 79 Cf 83.</p>
+          <bibl>Codd. Ce 79 Cf 83.</bibl>
         </div>
         <div>
           <head>Chambry 244.4</head>
@@ -6676,7 +6675,7 @@
           <l><milestone unit="recitvers"/>καὶ χεῖρα σείσαντος τοῦ κνίσαι τὸν πόδα,</l>
           <l><milestone unit="recitvers"/>πίπτουσιν οἱ κάλαμοι, πέλεια φεύγει.</l>
           <l><milestone unit="recitvers"/>Πράττων καλὸν κάλλιστον μισθὸν εὑρήσεις.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 86.</p>
+          <bibl>Cod. Cd 86.</bibl>
         </div>
         <div>
           <head>Chambry 244.5</head>
@@ -6684,7 +6683,7 @@
           <pb ed="perry" n="P235"/>
           <p><milestone unit="recitprose"/>Μύρμηξ διψήσας, κατελθὼν εἰς πηγήν, παρασυρεὶς ὑπὸ τοῦ ῥεύματος ἀπεπνίγετο. Περιστερὰ δὲ τοῦτο θεασαμένη κλῶνα δένδρου περιελοῦσα εἰς τὴν πηγὴν ἔρριψεν, ἐφ’ οὗ καὶ καθίσας ὁ μύρμηξ διεσώθη. Ἰξευτὴς δέ τις μετὰ τοῦτο τοὺς καλάμους συνθεὶς ἐπὶ τὸ τὴν περιστερὰν συλλαϐεῖν ᾔει. Τοῦτο δ’ ὁ μύρμηξ ἑωρακὼς τὸν τοῦ ἰξευτοῦ πόδα ἔδακεν. Ὁ δὲ ἀλγήσας τούς τε καλάμους ἔρριψε καὶ τὴν περιστερὰν αὐτίκα φυγεῖν ἐποίησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοῖς εὐεργέταις χάριν ἀποδιδόναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 41 Lb 82 Lc 20 Le 82 Lf 41 Lg 20 Lh 38 Md 82 Mg 108 Ml 107 Mm 98.</p>
+          <bibl>Codd. La 41 Lb 82 Lc 20 Le 82 Lf 41 Lg 20 Lh 38 Md 82 Mg 108 Ml 107 Mm 98.</bibl>
           <p><milestone unit="traduction"/>Une fourmi pressée par la soif était descendue dans une source et, entraînée par le courant, elle était en train de se noyer. Une colombe, l’ayant aperçue, détacha un rameau d’un arbre et le jeta dans la source ; la fourmi monta dessus et fut sauvée. Sur ces entrefaites un oiseleur s’avança avec ses gluaux ajustés pour prendre la colombe. La fourmi s’en étant aperçue, mordit le pied de l’oiseleur, qui, sous le coup de la douleur, jeta ses gluaux et fit aussitôt envoler la colombe.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut payer de retour ses bienfaiteurs.</p>
         </div>
@@ -6725,7 +6724,7 @@
           <l><milestone unit="epimythiumenvers"/>Ὁ μῦθος δηλοῖ ὅτι</l>
           <l><milestone unit="epimythiumenvers"/>τὸ λιτῶς διάγειν καὶ ζῆν ἀταράχως</l>
           <l><milestone unit="epimythiumenvers"/>ὑπὲρ τὸ τρυφᾶν ἐν φόϐῳ μετ’ ὀδύνης.</l>
-          <p><milestone unit="manuscrits"/>Codd. Ch 88 Cg 13 Ca 121 Cd 88 Mb 116.</p>
+          <bibl>Codd. Ch 88 Cg 13 Ca 121 Cd 88 Mb 116.</bibl>
           <p><milestone unit="traduction"/>Un rat des champs avait pour ami un rat de maison. Le rat de maison invité par son ami s’empressa d’aller dîner à la campagne. Mais comme il n’avait à manger que de l’herbe et du blé, il dit : « Sais-tu bien, mon ami, que tu mènes une vie de fourmi ? Moi, au contraire, j’ai des biens en abondance. Viens avec moi, je les mets tous à ta disposition. » Ils partirent aussitôt tous les deux. Le rat de maison fit voir à son camarade des légumes et du blé, et avec cela des figues, un fromage, du miel, des fruits. Et celui-ci émerveillé le bénissait de tout son cœur, et maudissait sa propre fortune. Comme ils s’apprêtaient à commencer le festin, soudain un homme ouvrit la porte. Effrayés du bruit, nos rats se précipitèrent peureusement dans les fentes. Puis comme ils revenaient pour prendre des figues sèches, une autre personne vint chercher quelque chose à l’intérieur de la chambre. À sa vue, ils se précipitèrent encore une fois dans un trou pour s’y cacher. Et alors le rat des champs, oubliant la faim, soupira et dit à l’autre : « Adieu, mon ami, tu manges à satiété et tu t’en donnes à cœur joie, mais au prix du danger et de mille craintes. Moi, pauvret, je vais vivre en grignotant de l’orge et du blé, mais sans craindre ni suspecter personne. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il vaut mieux mener une existence simple et paisible que de nager dans les délices en souffrant de la peur.</p>
         </div>
@@ -6735,7 +6734,7 @@
           <pb ed="perry" n="P352"/>
           <p><milestone unit="recitprose"/>Μύες δύο, ὁ μὲν ἀρουραῖος, ὁ δὲ οἰκόσιτος κοινὸν εἶχον τὸν βίον. Ὁ δὲ οἰκόσιτος ἦλθε πρῶτος δειπνήσων ἐπὶ τῆς ἀρούρης ἔτι ἀνθούσης. Τρώγων δὲ σῖτον καὶ ῥίζας σὺν τοῖς βώλοις εἶπεν· « Μύρμηκος ζῇς βίον ταλαιπώρου· ἐμοὶ δὲ πολλὰ ἔνεστιν ἀγαθά· τὸ κέρας οἰκῶ τῆς Ἀμαλθείας ὡς πρὸς σέ. Ἐὰν ἔλθῃς μετ’ ἐμοῦ, ὡς θέλεις ἀσωτεύσῃ. » Ἀπῆγε πείσας τὸν μῦν ἐν τῷ οἴκῳ. Ἔδειξε δὲ αὐτῷ σῖτον καὶ ἄλευρα καὶ ὄσπρια καὶ σῦκα καὶ μέλι καὶ φοίνικας. Οὗτος δὲ ἐτέρφθη καὶ διεχύθη. Ὁ δὲ ἤγαγε καὶ τυρὸν ἐκ κανισκίου σύρων. Ἤνοιξέ τις τὴν θύραν· οἱ δὲ ἔφυγον εἰς στενὴν τρώγλην, ἔτριζον δὲ ὑπ’ ἀλλήλων στενούμενοι. Ὡς δὲ πάλιν ἤμελλον ἐκκύψαι καὶ μικρὰν ἰσχάδα σῦραι, ἕτερος ἦλθεν ἄλλο τι ἆραι· οἱ δὲ ἔνδον ἐκρύπτοντο. Ὁ δὲ ἀρουραῖος μῦς, καίπερ τοσαῦτα πεινῶν, εἶπε· « Χαῖρε καὶ πλούτει καὶ τρύφα, ἔχων τὰ πάντα μετὰ κινδύνων· ἐγὼ δὲ βοτάνας καὶ ῥίζας τρώγων ἀφόϐως καὶ λιτῶς ζήσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι λιτῶς διάγειν καὶ ζῆν ἀταράχως &lt;μᾶλλον&gt; συμφέρει ἢ ἐν φόϐῳ καὶ κινδύνῳ δαψιλῶς τρυφᾶν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 94.</p>
+          <bibl>Cod. Ba 94.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-246">
@@ -6763,7 +6762,7 @@
           <l><milestone unit="recitvers"/>δεῖπνον καὶ αὐτὸς προσήχθη τοῖς ὀρνέοις</l>
           <l><milestone unit="recitvers"/>παθὼν ὅμοια οἷς αὐτὸς ἐδεδράκει.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι, εἰ καὶ νεκρός τις ὑπό τινος γένηται, ἀλλ’ ἡ θεία πρόνοια, ἡ πάντα ἐφορῶσα, ἀποδίδωσιν ἴσως ζυγοστατοῦσα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 15 Ch 90 Mb 117.</p>
+          <bibl>Codd. Cg 15 Ch 90 Mb 117.</bibl>
         </div>
         <div>
           <head>Chambry 246.2</head>
@@ -6771,7 +6770,7 @@
           <pb ed="perry" n="P384"/>
           <p><milestone unit="recitprose"/>Χερσαῖος μῦς κακῇ μοίρᾳ βατράχῳ ἐφιλιώθη. Ὁ δὲ βάτραχος κακῶς βουλευσάμενος τὸν πόδα τοῦ μυὸς τῷ ἑαυτοῦ ποδὶ συνέδησε. Καὶ πρῶτον μὲν ἐπὶ τῆς χώρας ἦλθον σῖτον δειπνήσοντες· ἔπειτα δὲ τῷ χείλει τῆς λίμνης πλησιάσαντες, ὁ μὲν βάτραχος τὸν μῦν εἰς τὸ βάθος κατῆγεν, αὐτὸς βρυάζων τῷ ὕδατι καὶ τὸ βρεκεκεκὲξ ἀνακράζων. Ὁ δὲ ἄθλιος μῦς τῷ ὕδατι φυσηθεὶς ἐτεθνήκει· ἐπέπλει δὲ τῷ ποδὶ τοῦ βατράχου συνδεδεμένος. Ἰκτῖνος δὲ τοῦτον ἰδὼν τοῖς ὄνυξιν ἣρπασεν· βάτραχος δὲ δεσμώτης ἐπηκολούθει, δεῖπνον καὶ αὐτὸς τῷ ἰκτίνῳ γενόμενος.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι, κἂν νεκρὸς ᾖ τις, ἰσχύει πρὸς ἄμυναν· ἡ γὰρ θεία δίκη ἐφορᾷ πάντα καὶ τὸ ἴσον ἀποδίδωσι ζυγοστατοῦσα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 144 Bb 88.</p>
+          <bibl>Codd. Ba 144 Bb 88.</bibl>
           <p><milestone unit="traduction"/>Un rat de terre, pour son malheur, se lia d’amitié avec une grenouille. Or la grenouille, qui avait de mauvais desseins, attacha la patte du rat à sa propre patte. Et tout d’abord ils allèrent sur la terre manger du blé ; ensuite ils s’approchèrent du bord de l’étang. Alors la grenouille entraîna le rat au fond, tandis qu’elle s’ébattait dans l’eau en poussant ses brekekekex. Et le malheureux rat, gonflé d’eau, fut noyé ; mais il surnageait, attaché à la patte de la grenouille. Un milan, l’ayant aperçu, l’enleva dans ses serres, et la grenouille enchaînée suivit et servit, elle aussi, de dîner au milan.</p>
           <p><milestone unit="traduction"/>Même mort, on peut se venger ; car la justice divine à l’œil sur tout, et proportionne dans sa balance le châtiment à la faute.</p>
         </div>
@@ -6781,7 +6780,7 @@
           <pb ed="perry" n="P384"/>
           <p><milestone unit="recitprose"/>Βάτραχος καὶ μῦς κακῇ μοίρᾳ ἐφιλιώθησαν. Ὁ τοίνυν βάτραχος ἔφη τῷ μυΐ· « Ἐγὼ μὲν ἐν ὕδασι γλυκεροῖς καὶ χλοεροῖς βοτάνοις ἀεὶ τρέφομαι· σὺ δὲ μόνος ἐν οἴκῳ κατοικεῖς μετὰ φόϐου· καὶ ἡνίκα τις τῇ θύρᾳ προσκρούσῃ, ἐν στενῷ τόπῳ εἰσέρχῃ· ἀλλ’ εἰ θέλεις ἀφόϐως μετ’ ἐμοῦ εἶναι καὶ ζῆν ἐν ἀμερίμνῳ διαίτῃ, ἐλθὲ καὶ μάθω σε κολυμϐᾶν. » Ἀπελθὼν οὖν ὁ μῦς συνέδησεν ἑαυτὸν τῷ ποδὶ τοῦ βατράχου. Ὁ οὖν βάτραχος εἰσιὼν ἐν τῷ βυθῷ ἀναϐρυάζων καὶ κράζων κεκὲξ ἔπνιξε τὸν μῦν. Ὁ δὲ μῦς φυσηθεὶς ἐκ τοῦ ὕδατος ἀνῆλθεν ἄνω. Τοῦτον ἰκτῖνος ἰδὼν καὶ κατελθὼν ἧρε τοῖς ὄνυξι καὶ συνηκολούθει δεδεμένος καὶ ὁ βάτραχος ὅμοια παθὼν καὶ αὐτὸς ἃ ἐδίδασκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅστις καθ’ ἑτέρου δόλια μηχανᾶται καὶ ἑαυτοῦ γίνεται τῶν κακῶν ἀρχηγός.</p>
-          <p><milestone unit="manuscrits"/>Codex Vaticanus 1745.</p>
+          <bibl>Codex Vaticanus 1745.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-247">
@@ -6792,7 +6791,7 @@
           <pb ed="perry" n="P168"/>
           <p><milestone unit="recitprose"/>Ναυαγὸς ἐκϐρασθεὶς εἰς τὸν αἰγιαλὸν ἐκοιμᾶτο διὰ τὸν κόπον· μετὰ μικρὸν δὲ ἐξαναστάς, ὡς ἐθεάσατο τὴν θάλασσαν, ἐμέμφετο αὐτῇ ὅτι γε δελεάζουσα τοὺς ἀνθρώπους τῇ πραότητι τῆς συνόψεως, ἡνίκα ἂν αὐτοὺς προσδέξηται, ἀπαγριουμένη διαφθείρει. Ἡ δὲ ὁμοιωθεῖσα γυναικὶ ἔφη πρὸς αὐτόν· « Ἀλλ’, ὦ οὗτος, μὴ ἐμὲ μέμφου, ἀλλὰ τοὺς ἀνέμους· ἐγὼ μὲν γὰρ φύσει τουαύτη εἰμὶ ὁποίαν καὶ νῦν με ὁρᾷς· οἱ δὲ αἰφνίδιόν με ἐπέρχονται καὶ κυματοῦσι καὶ ἐξαγριοῦσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς ἐπὶ τῶν ἀδικημάτων οὐ δεῖ τοὺς δρῶντας αἰτιᾶσθαι, ὅταν ἑτέροις ὑποτεταγμένοι ὦσι, τοὺς δὲ τούτοις ἐπιστατοῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 165 Pb 166 Pc 94 Ma 115 Mb 125.</p>
+          <bibl>Codd. Pa 165 Pb 166 Pc 94 Ma 115 Mb 125.</bibl>
           <p><milestone unit="traduction"/>Un naufragé, rejeté sur le rivage, s’était endormi de fatigue ; mais il ne tarda pas à s’éveiller, et, voyant la mer, il lui reprocha de séduire les hommes par son air tranquille ; puis, quand elle les a reçus sur ses eaux, de devenir sauvage et de les faire périr. La mer, ayant pris la forme d’une femme, lui dit : « Mais, mon ami, ce n’est pas à moi, c’est aux vents qu’il faut adresser tes reproches ; car moi, je suis naturellement telle que tu me vois à présent : ce sont les vents qui, tombant sur moi à l’improviste, me soulèvent et me rendent sauvage. »</p>
           <p><milestone unit="traduction"/>De même nous ne devons pas rendre responsable l’auteur d’une injustice, quand il agit sur les ordres d’autrui, mais bien ceux qui ont autorité sur lui.</p>
         </div>
@@ -6810,7 +6809,7 @@
           <l><milestone unit="recitvers"/>Ἐὰν δὲ βουληθῇς χωρὶς τούτων πλεῦσαι,</l>
           <l><milestone unit="recitvers"/>ἡμερωτέραν δή με τῆς γῆς εὑρήσεις. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι γαληνοὺς δεσπότας οἱ χαιρέκακοι παραφυσῶντες ἐπεγείρουσι πρὸς ὀργάς τε καὶ ζάλας.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 26.</p>
+          <bibl>Cod. Mb 26.</bibl>
         </div>
         <div>
           <head>Chambry 247.3</head>
@@ -6818,14 +6817,14 @@
           <pb ed="perry" n="P168"/>
           <p><milestone unit="recitprose"/>Ἰδὼν γεωργὸς ναῦν ἐν θαλάσσῃ χειμαζομένην καὶ κινδυνεύουσαν, εἶπεν· « Ὦ θάλασσα, στοιχεῖον ἀνηλεὲς καὶ τῶν ἀνθρώπων ἐχθρόν. » Ἡ δὲ θάλασσα γυναικείαν μορφὴν ἀναλαϐομένη ἔφη· « Τί μέμφῃ μοι, ἄνθρωπε, μάτην ; οὔκ εἰμι ἐγὼ αἰτία, ἀλλ’ οἱ ἐκταράσσοντές με ἄνεμοι· εἰ δὲ χωρὶς τούτων πλεύσεις, με ἡμερωτέραν τῆς γῆς εὑρήσεις ἐφ’ ἧς βαδίζεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καὶ γαληνοὺς καὶ πραεῖς δεσπότας οἱ χαιρέκακοι παραφυσῶντες πρὸς ζάλην καὶ ὀργὴν διεγείρουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 54 Bb 34.</p>
+          <bibl>Cod. Ba 54 Bb 34.</bibl>
         </div>
         <div>
           <head>Chambry 247.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P168"/>
           <p><milestone unit="recitprose"/>Γεωργὸς ἰδὼν ναῦν ἐν τῇ θαλάσσῃ χειμαζομένην καὶ κινδυνεύουσαν, τῇ θαλάσσῃ κατεμέμφετο καὶ ὡς στοιχείῳ ἀνημέρῳ καὶ ἀπανθρώπῳ. Ἡ δὲ θάλασσα ἐν γυναικείῳ σχήματι νυκτὸς ἐπιστᾶσα ἔφη· « Τί με μάτην, ὦ ἄνθρωπε, κακίζεις ; οὔκ εἰμι ἐγὼ αἰτία τῆς ταραχῆς ἣν ἑώρακας, ἀλλ’ οἱ ἐκταράσσοντές με ἄνεμοι· ἂν γὰρ χωρὶς τούτων πλεύσῃ μέ τις, καὶ ἡμερωτέραν εὑρήσει τῆς γῆς ἣν σύ βαδίζεις. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 27.</p>
+          <bibl>Cod. Bd 27.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-248">
@@ -6836,7 +6835,7 @@
           <pb ed="perry" n="P66"/>
           <p><milestone unit="recitprose"/>Δύο νεανίσκοι ἐν ταὐτῷ κρέας ὠνοῦντο. Καὶ δὴ τοῦ μαγείρου περισπασθέντος, ὁ ἕτερος ὑφελόμενος ἀκροκώλιον, εἰς τὸν τοῦ ἑτέρου κόλπον καθῆκεν. Ἐπιστραφέντος δὲ αὐτοῦ καὶ ἐπιζητοῦντος, αἰτιωμένου τε ἐκείνους, ὁ μὲν εἰληφὼς ὤμνυε μὴ ἔχειν, ὁ δὲ ἔχων μὴ εἰληφέναι. Καὶ ὁ μάγειρος αἰσθόμενος αὐτῶν τὴν κακοτεχνίαν, εἶπεν· « Ἀλλὰ κἂν ἐμὲ λάθητε ἐπιορκοῦντες, θεοὺς μέντοι γε οὐ λήσετε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ αὐτή ἐστιν ἡ ἀσέϐεια τῆς ἐπιορκίας, κἂν αὐτήν τις κατασοφίζηται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 65 Pb 66 Pe 33 Pf 30 Pg 43 Ph 32 Ma 47 Mb 37.</p>
+          <bibl>Codd. Pa 65 Pb 66 Pe 33 Pf 30 Pg 43 Ph 32 Ma 47 Mb 37.</bibl>
           <p><milestone unit="traduction"/>Deux jeunes garçons achetaient de la viande au même étal. Voyant le boucher occupé d’un autre côté, l’un d’eux déroba des abattis et les jeta dans le sein de l’autre. Le boucher, s’étant retourné et cherchant ces morceaux, accusa les deux garçons. Mais celui qui les avait pris jura qu’il ne les avait pas, et celui qui les avait, qu’il ne les avait pas pris. Devinant leur artifice, le boucher dit : « Vous pouvez m’échapper par un faux serment ; mais à coup sûr vous n’échapperez pas aux dieux. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’impiété du faux serment reste la même, quelque habileté qu’on mette à la sophistiquer.</p>
         </div>
@@ -6846,7 +6845,7 @@
           <pb ed="perry" n="P66"/>
           <p><milestone unit="recitprose"/>Δύο νεανίσκοι ἐν ταὐτῷ κρέας ὠνήσαντο. Καὶ δὴ τοῦ μαγείρου περισπασθέντος, εἷς ἐξ αὐτῶν ἀφελόμενος μέρος τι τοῦ κρέατος εἰς τὸν τοῦ ἑτέρου κόλπον καθῆκεν. Ἐπιστραφεὶς δὲ ὁ μάγειρος καὶ ἐπιζητῶν αὐτό, ὁ μὲν εἰληφὼς ὤμνυε μὴ ἔχειν, ὁ δὲ ἔχων, μὴ εἰληφέναι. Καὶ ὁ μάγειρος αἰσθόμενος τὴν κακοτεχνίαν αὐτῶν, ἔφη· « Ἀλλὰ κἂν ἐμὲ λάθητε, τῷ ἐπιορκουμένῳ θεῷ οὐκ ἀγνοηθήσεσθε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, κἂν ἀνθρώπους διακρουσώμεθα ἐπιορκοῦντες, ἀλλὰ θεὸν οὐδαμῶς· ἀλάθητον γὰρ τὸ θεῖον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 60 Cb 39 Cd 36 Ce 41 Cf 45 Ch 46 Mh 39 Mi 79.</p>
+          <bibl>Codd. Ca 60 Cb 39 Cd 36 Ce 41 Cf 45 Ch 46 Mh 39 Mi 79.</bibl>
         </div>
         <div>
           <head>Chambry 248.3</head>
@@ -6854,7 +6853,7 @@
           <pb ed="perry" n="P66"/>
           <p><milestone unit="recitprose"/>Δύο νεανίσκοι μαγείρῳ παρεκάθηντο. Καὶ δὴ τοῦ μαγείρου περί τι τῶν οἰκείων ἔργων ἀσχολουμένου, ἅτερος τούτων, μέρος τι τῶν κρεῶν ὑφελόμενος, εἰς τὸν θἀτέρου καθῆκε κόλπον. Ἐπιστραφέντος δὲ τοῦ μαγείρου καὶ τὸ κρέας ἐπιζητοῦντος, ὁ μὲν εἰληφὼς ὤμνυε μὴ ἔχειν, ὁ δὲ ἔχων μὴ εἰληφέναι. Ὁ δὲ μάγειρος, αἰσθόμενος τὴν κακουργίαν αὐτῶν, εἶπεν· « Ἀλλὰ κἂν ἐμὲ λάθητε, τόν γ’ ἐπιορκούμενον θεὸν οὔκουν λήσετε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, κἂν ἀνθρώπους ἐπιορκοῦντες λάθωμεν, ἀλλὰ τόν γε θεὸν οὐ λήσομεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 26 Lb 37 Lc 14 Ld 18 Le 37 Lf 26 Lg 14 Lh 16 Mc 38 Md 44 Me 44 Mf 39 Mg 46 Mj 43 Mk 42 Ml 48 Mm 56 Mn 18.</p>
+          <bibl>Codd. La 26 Lb 37 Lc 14 Ld 18 Le 37 Lf 26 Lg 14 Lh 16 Mc 38 Md 44 Me 44 Mf 39 Mg 46 Mj 43 Mk 42 Ml 48 Mm 56 Mn 18.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-249">
@@ -6865,7 +6864,7 @@
           <pb ed="perry" n="P169"/>
           <p><milestone unit="recitprose"/>Νέος ἄσωτος καταφαγὼν τὰ πατρῷα, ἱματίου αὐτῷ μόνου περιλειφθέντος, ὡς ἐθεάσατο χελιδόνα παρὰ καιρὸν ἐλθοῦσαν, οἰόμενος ἤδη θέρος εἶναι, ὡς μηκέτι δεόμενος τοῦ ἱματίου, καὶ τοῦτο φέρων ἀπημπόλησεν. Ὕστερον δὲ χειμῶνος ἐπιλαϐόντος καὶ σφοδροῦ τοῦ κρύους γενομένου, περιιών, ἐπειδὴ εἶδε τὴν χελιδόνα νεκρὰν ἐρριγωμένην, ἔφη πρὸς αὐτήν· « Ὦ αὕτη, σὺ κἀμὲ καὶ σὲ ἀπώλεσας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πάντα τὰ παρὰ καιρὸν δρώμενα ἐπισφαλῆ τυγχάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 166 Pc 95 Pg 106 Ma 116 Mb 126 Ca 123.</p>
+          <bibl>Codd. Pa 166 Pc 95 Pg 106 Ma 116 Mb 126 Ca 123.</bibl>
           <p><milestone unit="traduction"/>Un jeune prodigue, ayant mangé son patrimoine, ne possédait plus qu’un manteau. Il aperçut une hirondelle qui avait devancé la saison. Croyant le printemps venu, et qu’il n’avait plus besoin de manteau, il s’en alla le vendre aussi. Mais le mauvais temps étant survenu ensuite et l’atmosphère étant devenue très froide, il vit, en se promenant, l’hirondelle morte de froid. « Malheureuse, dit-il, tu nous as perdus, toi et moi du même coup. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que tout ce qu’on fait à contretemps est hasardeux.</p>
         </div>
@@ -6875,7 +6874,7 @@
           <pb ed="perry" n="P169"/>
           <p><milestone unit="recitprose"/>Νέος ἄσωτος καταφαγὼν τὰ πατρῷα, ἱματίου μόνου καταλειφθέντος αὐτῷ, εἶδε χελιδόνα παρὰ καιρὸν ἐλθοῦσαν καὶ θέρος εἶναι νομίσας, μηκέτι δεόμενος τοῦ ἱματίου, τοῦτο φέρων ἐπώλησε. Μετὰ μικρὸν δὲ χειμῶνος καὶ ψύχους σφοδροῦ γενομένου, ἐπειδὴ εἶδε τὴν χελιδόνα φερομένην ὑπὸ τῶν ὑδάτων νεκράν, ἔφη· « Ὦ αὕτη, σὺ κἀμὲ καὶ σεαυτὴν ἀπώλεσας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πᾶν τὸ παρὰ καιρὸν πραττόμενον ἐπικίνδυνόν ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 92 Cg 18 Cb 76 Ce 83 Cf 87 Mc 74 Ml 114.</p>
+          <bibl>Codd. Ch 92 Cg 18 Cb 76 Ce 83 Cf 87 Mc 74 Ml 114.</bibl>
         </div>
         <div>
           <head>Chambry 249.3</head>
@@ -6893,7 +6892,7 @@
           <l><milestone unit="epimythiumenvers"/>Ὁ λόγος παραινεῖ</l>
           <l><milestone unit="epimythiumenvers"/>πᾶσι μὴ δρᾶν τι πρᾶγμα παρὰ τὴν ὥραν·</l>
           <l><milestone unit="epimythiumenvers"/>εἰ γὰρ δράσειας, οὐ φεύξῃ τοῦ κινδύνου.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 91.</p>
+          <bibl>Cod. Cd 91.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-250">
@@ -6904,7 +6903,7 @@
           <pb ed="perry" n="P170"/>
           <p><milestone unit="recitprose"/>Νοσῶν τις καὶ ἐπερωτώμενος ὑπὸ τοῦ ἰατροῦ πῶς διετέθη, ἔλεγε πλέον τοῦ δέοντος ἱδρωκέναι. Ὁ δὲ ἔφη· « Ἀγαθὸν τοῦτο. » Ἐκ δευτέρου δὲ ἐρωτώμενος πῶς ἔχοι, ἔφη φρίκῃ συνεχόμενος διατετινάχθαι. Ὁ δέ· « Καὶ τοῦτο, ἔφη, ἀγαθόν. » Τὸ δὲ τρίτον ὡς παρεγένετο καὶ ἐπηρώτα αὐτὸν περὶ τῆς νόσου, διαρροίᾳ περιπεπτωκέναι ἔφασκε. Κἀκεῖνος « ἀγαθὸν καὶ τοῦτο » φήσας ἀπηλλάγη. Τῶν δὲ οἰκείων τινὸς παραγενομένου πρὸς αὐτὸν καὶ πυνθανομένου πῶς ἔχοι, ἔφη πρὸς αὐτόν· « Ἐγώ σοι ὑπὸ τῶν ἀγαθῶν ἀπόλωλα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ τῶν ἀνθρώπων ἐπὶ τούτοις ὑπὸ τῶν πέλας μακαρίζονται τῇ ἔξωθεν οἰήσει, ἐφ’ οἷς αὐτοὶ παρ’ ἑαυτοῖς τὰ μάλιστα δυσφοροῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 167 Pf 89 Pg 107 Ma 117 Mb 127 Me 115 Mf 97 Mj 106.</p>
+          <bibl>Codd. Pa 167 Pf 89 Pg 107 Ma 117 Mb 127 Me 115 Mf 97 Mj 106.</bibl>
           <p><milestone unit="traduction"/>Un malade, questionné sur son état par le médecin, répondit qu’il avait sué plus que de raison. « Cela va bien », dit le médecin. Questionné une seconde fois sur sa santé, il dit qu’il avait été pris de frisson et fortement secoué. « Cela va bien aussi », dit le médecin. Une troisième fois le médecin vint le voir, et le questionna sur sa maladie. Il répondit qu’il avait eu la diarrhée. « Cela va bien encore », dit le médecin, et il se retira. Un de ses parents étant venu le voir et lui demandant comment il allait : « Moi, répondit-il, je meurs à force d’aller bien. »</p>
           <p><milestone unit="traduction"/>Il en est souvent ainsi : nos voisins, n’en jugeant que par les dehors, nous estiment heureux pour des choses qui nous causent intérieurement le plus vif chagrin.</p>
         </div>
@@ -6914,7 +6913,7 @@
           <pb ed="perry" n="P170"/>
           <p><milestone unit="recitprose"/>Νοσῶν τις καὶ ὑπὸ τοῦ ἰατροῦ ἐπερωτώμενος πῶς διετέθης, ἔφη πλέον τοῦ δέοντος ἱδρωκέναι. Ὁ δὲ ἀγαθὸν τοῦτο εἶναι ἔφη. Ἐκ δευτέρου δὲ ἐρωτηθεὶς παρ’ αὐτοῦ πῶς ἔχεις, ἔφη· « Φρίκῃ συσχεθεὶς σφοδρῶς διετινάχθην. » Ὁ δὲ καὶ τοῦτο ἀγαθὸν φήσας εἶναι, ἐκ τρίτου ἐρώτησεν αὐτὸν πῶς διετέθης. Ὁ δὲ ἔφη· « Ὑδρείᾳ περιπέπτωκα. » Κἀκεῖνος πάλιν ἀγαθὸν τοῦτο ἔφησε. Μετὰ ταῦτα δὲ τῶν οἰκείων τινὸς ἐρωτήσαντος αὐτὸν πῶς ἔχεις, « Ἐγώ, ἄδελφε, εἶπεν, ὑπὸ τῶν ἀγαθῶν ἀπόλλυμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τινὲς τῶν ἀνθρώπων θέλουσι κατὰ χάριν λέγειν τισὶν ἃ μάλιστα αὐτοὺς βλάπτουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 126 Cb 77 Ce 84 Cf 89 Cg 19 Ch 94.</p>
+          <bibl>Codd. Ca 126 Cb 77 Ce 84 Cf 89 Cg 19 Ch 94.</bibl>
         </div>
         <div>
           <head>Chambry 250.3</head>
@@ -6922,7 +6921,7 @@
           <pb ed="perry" n="P170"/>
           <p><milestone unit="recitprose"/>Νοσῶν τις καὶ ὑπὸ τοῦ ἰατροῦ ἐρωτώμενος ὅπως διετέθη, πλέον εἶπε τοῦ δέοντος ἱδρωκέναι. Ὁ δὲ ἀγαθὸν ἔφη τοῦτ’ εἶναι. Ἐκ δευτέρου δὲ παρ’ αὐτοῦ πάλιν ἐρωτηθεὶς ὅπως ἔσχε, φρίκῃ συσχεθεὶς εἶπε σφοδρῶς διατετινάχθαι. Ὁ δὲ καὶ τοῦτ’ ἀγαθὸν ἔφησεν εἶναι. Ἐκ δὲ τρίτου αὖθις ἐρωτηθεὶς ὅπως διεγένετο εἶπεν ὑδέρῳ περιπεπτωκέναι. Ὁ δὲ καὶ τοῦτο πάλιν ἀγαθὸν εἶπεν εἶναι. Εἶτα τῶν οἰκείων τινὸς αὐτὸν ἐρωτήσαντος ὅπως ἔχει, « Ἐγώ, εἶπεν, ὦ οὗτος, ὑπὸ τῶν ἀγαθῶν ἀπόλλυμαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι μάλιστα τῶν ἀνθρώπων δυσχεραίνομεν τοὺς πρὸς χάριν ἀεὶ βουλομένους λέγειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 43 Lb 86 Ld 26 Le 86 Lf 43 Lh 42 Mc 75 Md 84 Mg 111 Ml 112 Mm 101 Mn 26.</p>
+          <bibl>Codd. La 43 Lb 86 Ld 26 Le 86 Lf 43 Lh 42 Mc 75 Md 84 Mg 111 Ml 112 Mm 101 Mn 26.</bibl>
         </div>
         <div>
           <head>Chambry 250.4</head>
@@ -6941,7 +6940,7 @@
           <l><milestone unit="recitvers"/>« Πῶς ἔχεις, &lt;ὦ&gt; ἄδελφε φίλε ; ῥωννύου, »</l>
           <l><milestone unit="recitvers"/>ὁδέ· « Ἀπόλλυμαι ἐν ἀγαθοῖς » ἔφη.</l>
           <p><milestone unit="epimythiumprose"/>Τοῦτο δηλοῖ ὅτι οὓς παραμυθέοντας ἔθος τυγχάνει ψευδεῖς τοὺς πάσχοντας παρηγορεῖν λόγοις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 92.</p>
+          <bibl>Cod. Cd 92.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-251">
@@ -6952,7 +6951,7 @@
           <pb ed="perry" n="P171"/>
           <p><milestone unit="recitprose"/>Νυκτερὶς καὶ βάτος καὶ αἴθυια κοινωνίαν πρὸς ἀλλήλας σπεισάμεναι ἐμπορεύεσθαι διέγνωσαν. Καὶ δὴ ἡ μὲν νυκτερὶς ἀργύριον δανεισαμένη εἰς μέσον κατέθηκεν, ἡ δὲ βάτος ἐσθῆτα ἐνεϐάλετο, ἡ δὲ αἴθυια χαλκὸν πριαμένη καὶ τοῦτον ἐνθεμένη ἔπλει. Χειμῶνος δὲ σφοδροῦ γενομένου καὶ τῆς νηὸς περιτραπείσης, πάντα ἀπολέσασαι αὐταὶ ἐπὶ τὴν γῆν διεσώθησαν. Καὶ ἡ μὲν αἴθυια ἀπ’ ἐκείνου τὸν χαλκὸν ζητοῦσα κατὰ τοῦ βυθοῦ δύνει, οἰομένη τὸν χαλκὸν εὑρήσειν· ἡ δὲ νυκτερὶς τοὺς δανειστὰς φοϐουμένη ἡμέρας μὲν οὐ φαίνεται, νυκτὸς δὲ ἐπὶ νομὴν ἔξεισιν· ἡ δὲ βάτος τὰς ἔσθητας ἐπιζητοῦσα τῶν παριόντων ἐπιλαμϐάνεται τῶν ἱματίων προσδοκῶσα τῶν ἰδίων τι ἐπιγνώσεσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι περὶ ταῦτα μᾶλλον σπουδάζομεν περὶ ἃ ἂν πρότερον πταίσωμεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 168 Pb 167 Pc 96 Pf 90 Mb 128 Me 116 Mf 98 Mj 107.</p>
+          <bibl>Codd. Pa 168 Pb 167 Pc 96 Pf 90 Mb 128 Me 116 Mf 98 Mj 107.</bibl>
         </div>
         <div>
           <head>Chambry 251.2</head>
@@ -6960,7 +6959,7 @@
           <pb ed="perry" n="P171"/>
           <p><milestone unit="recitprose"/>Νυκτερὶς καὶ βάτος καὶ αἴθυια πρὸς ἀλλήλας φιλίαν ποιήσασαι ἐμπορεύεσθαι ἔγνωσαν. Καὶ ἡ μὲν νυκτερὶς ἀργύριον δανεισαμένη εἰς τὸ μέσον τοῦτο κατέθηκεν· ἡ δὲ βάτος ἐσθῆτα ἐνεϐάλλετο· ἡ δὲ αἴθυια χαλκόν· καὶ εὐθέως ἀπέπλευσαν. Χειμῶνος δὲ σφοδροῦ γενομένου καὶ τῆς νεὼς περιτραπείσης, πάντα ἀπολέσασαι αὐταὶ ἐπὶ τὴν γῆν διεσώθησαν. Καὶ ἀπὸ τῶν τότε ἡ αἴθυια παρὰ τὸ χεῖλος τῆς θαλάσσης ἐνεδρεύει, μήπως ἡ θάλασσα τὸν χαλκὸν ἐξαγάγῃ· ἡ δὲ νυκτερὶς τοὺς δανειστὰς φοϐουμένη, ἡμέρας μὲν οὐ φαίνεται, νυκτὸς δὲ ἐπὶ νομὴν ἔξεισιν· ἡ δὲ βάτος τῶν ἐσθήτων ἐπιλαμϐάνεται τῶν παριόντων, ζητοῦσα τὸ ἴδιον ἱμάτιον ἐπιγνῶναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι περὶ ταῦτα μᾶλλον σπουδάζομεν περὶ ἃ &lt;ἂν&gt; πρότερον πταίσωμεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 124 Cf 88 Cg 17 Ch 93.</p>
+          <bibl>Codd. Ca 124 Cf 88 Cg 17 Ch 93.</bibl>
         </div>
         <div>
           <head>Chambry 251.3</head>
@@ -6968,7 +6967,7 @@
           <pb ed="perry" n="P171"/>
           <p><milestone unit="recitprose"/>Νυκτερὶς καὶ βάτος καὶ αἴθυια ἑταιρείαν ποιησάμεναι, ἐμπορικὸν διέγνωσαν βίον ζῆν. Ἡ μὲν οὖν νυκτερὶς ἀργύριον δανεισαμένη καθῆκεν εἰς τὸ μέσον, ἡ δὲ βάτος ἐσθῆτα μετ’ ἑαυτῆς ἔλαϐεν, ἡ δὲ αἴθυια τρίτη χαλκόν· καὶ ἀπέπλευσαν. Χειμῶνος δὲ σφοδροῦ γενομένου καὶ τῆς νεὼς περιτραπείσης, πάντα ἀπολέσασαι αὐταὶ ἐπὶ τὴν γῆν διεσώθησαν. Ἐξ ἐκείνου τοίνυν ἡ μὲν αἴθυια τοῖς αἰγιαλοῖς ἀεὶ παρεδρεύει, μή που τὸν χαλκὸν ἐκϐάλλῃ ἡ θάλαττα· ἡ δὲ νυκτερὶς τοὺς δανειστὰς φοϐουμένη, τῆς μὲν ἡμέρας οὐ φαίνεται, νύκτωρ δ’ ἐπὶ νομὴν ἔξεισιν· ἡ δὲ βάτος τῆς τῶν παριόντων ἐσθῆτος ἐπιλαμϐάνεται, εἴ που τὴν οἰκείαν ἐπιγνοίη ζητοῦσα.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι περὶ ἃ σπουδάζομεν, τούτοις ἐς ὕστερον περιπίπτομεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 42 Lb 85 Le 85 Lf 42 Lh 41 Ma 184 Md 83 Mg 110 Ml 111 Mm 100.</p>
+          <bibl>Codd. La 42 Lb 85 Le 85 Lf 42 Lh 41 Ma 184 Md 83 Mg 110 Ml 111 Mm 100.</bibl>
           <p><milestone unit="traduction"/>La chauve-souris, la ronce et la mouette s’associèrent ensemble dans l’intention de s’adonner au commerce. En conséquence la chauve-souris emprunta de l’argent pour le mettre dans la communauté ; la ronce prit avec elle de l’étoffe, et la troisième associée, la mouette, acheta du cuivre ; puis elles appareillèrent. Mais une violente tempête étant survenue, le vaisseau chavira, et toute la cargaison fut perdue ; elles ne sauvèrent que leurs personnes. Aussi depuis ce temps, la mouette est toujours aux aguets sur les rivages, pour voir si la mer ne rejettera pas son cuivre quelque part ; la chauve-souris, craignant ses créanciers, ne se montre pas de jour et ne sort pour pâturer que la nuit ; enfin la ronce accroche les habits des passants, cherchant à reconnaître son étoffe.</p>
           <p><milestone unit="traduction"/>Cette fable montre que nous revenons toujours aux choses où nous avons intérêt.</p>
         </div>
@@ -6992,7 +6991,7 @@
           <l><milestone unit="recitvers"/>ἡ αἴθυια δὲ τὴν θάλασσαν ἐντρέχει</l>
           <l><milestone unit="recitvers"/>δοκοῦσ’ ὧδε κἀκεῖσε χαλκοῦν εὑρήσειν.</l>
           <l><milestone unit="recitvers"/>Πᾶς ὅπερ ἀποϐάλλει, καὶ ζητεῖ τοῦτο.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 93.</p>
+          <bibl>Cod. Cd 93.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-252">
@@ -7003,7 +7002,7 @@
           <pb ed="perry" n="P172"/>
           <p><milestone unit="recitprose"/>Νυκτερὶς ἐπὶ τῆς γῆς πεσοῦσα ὑπὸ γαλῆς συνελήφθη· μέλλουσα δὲ ἀναιρεῖσθαι παρεκάλει περὶ τῆς σωτηρίας. Τῆς δὲ λεγούσης ὡς οὐ δύναται αὐτὴν ἀπολῦσαι, φύσει γὰρ πάντας πολεμεῖ πτηνούς, ἔφησεν αὑτὴν μὴ ὄρνεον εἶναι, ἀλλὰ μῦν, καὶ οὕτως ἀφείθη. Ὕστερον δὲ πεσοῦσα πάλιν καὶ συλληφθεῖσα ὑπὸ ἑτέρας γαλῆς ἐδεῖτο ὅπως μὴ θύσῃ αὐτήν. Τῆς δὲ εἰπούσης ἅπασι τοῖς μυσὶ διεχθραίνειν, ἔλεγεν ἑαυτὴν μὴ μῦν εἶναι, ἀλλὰ νυκτερίδα, καὶ πάλιν ἀπελύθη. Οὕτω τε συνέϐη αὐτῇ δὶς ἐναλλαξαμένῃ τὸ ὄνομα τῆς σωτηρίας περιγενέσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς δεῖ μὴ ἀεὶ τοῖς αὐτοῖς ἐπιμένειν λογιζομένους ὅτι οἱ τοῖς καιροῖς συμμετασχηματιζόμενοι πολλάκις καὶ τοὺς σφοδροὺς τῶν κινδύνων ἐκφεύγουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 169 Pc 97 Pf 91 Pg 108 Ma 118 Mb 129 Mj 108 Ca 125.</p>
+          <bibl>Codd. Pa 169 Pc 97 Pf 91 Pg 108 Ma 118 Mb 129 Mj 108 Ca 125.</bibl>
         </div>
         <div>
           <head>Chambry 252.2</head>
@@ -7011,7 +7010,7 @@
           <pb ed="perry" n="P172"/>
           <p><milestone unit="recitprose"/>Νυκτερὶς ἐπὶ γῆς πεσοῦσα ὑπὸ γαλῆς συνελήφθη, καὶ μέλλουσα ἀναιρεῖσθαι περὶ σωτηρίας ἐδεῖτο. Τῆς δὲ φαμένης μὴ δύνασθαι αὐτὴν ἀπολῦσαι, φύσει γὰρ πᾶσι τοῖς πτηνοῖς πολεμεῖν, αὐτὴ ἔλεγεν οὐκ ὄρνις, ἀλλὰ μῦς εἶναι, καὶ οὕτως ἀφείθη. Ὕστερον δὲ πάλιν πεσοῦσα καὶ ὑφ’ ἑτέρας συλληφθεῖσα γαλῆς μὴ βρωθῆναι ἐδεῖτο. Τῆς δὲ εἰπούσης ἅπασιν ἐχθραίνειν μυσίν, αὐτὴ μὴ μῦς, ἀλλὰ νυκτερὶς ἔλεγεν εἶναι, καὶ πάλιν ἀπελύθη. Καὶ οὕτω συνέϐη δὶς αὐτὴν ἀλλαξαμένην τὸ ὄνομα σωτηρίας τυχεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ καὶ ἡμᾶς μὴ τοῖς αὐτοῖς ἀεὶ ἐπιμένειν, λογιζομένους ὡς οἱ τοῖς καιροῖς συμμετασχηματιζόμενοι πολλάκις τοὺς κινδύνους ἐκφεύγουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 112 Lb 88 Le 88 Lf 113 Lh 44 Me 117 Mf 99 Mg 113 Ml 113.</p>
+          <bibl>Codd. La 112 Lb 88 Le 88 Lf 113 Lh 44 Me 117 Mf 99 Mg 113 Ml 113.</bibl>
           <p><milestone unit="traduction"/>Une chauve-souris, étant tombée à terre, fut prise par une belette. Se voyant sur le point d’être tuée, elle demanda la vie. La belette lui dit qu’elle ne pouvait la relâcher ; car elle était de son naturel ennemie de tous les oiseaux. La chauve-souris réplique qu’elle-même n’était pas un oiseau, mais une souris, et elle s’en tira par ce moyen. Dans la suite, étant tombée une seconde fois, elle fut prise par une autre belette, et la pria de ne point la manger. Celle-ci ayant répondu qu’elle détestait toutes les souris, la chauve-souris affirma qu’elle-même n’était pas une souris, mais une chauve-souris, et elle fut relâchée encore cette fois. Il arriva ainsi qu’à deux reprises, en changeant de nom, elle se sauva de la mort.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas s’en tenir toujours aux mêmes moyens, mais songer qu’en s’accomodant aux circonstances, on échappe souvent au danger.</p>
         </div>
@@ -7021,7 +7020,7 @@
         <head type="sub">Ξύλα καὶ ἐλαία — Les arbres et l’olivier.</head>
         <pb ed="perry" n="P262"/>
         <p><milestone unit="recitprose"/>Ξύλα ποτὲ ἐπορεύθη τοῦ χειροτονῆσαι ἐφ’ ἑαυτῶν βασιλέα καὶ εἶπαν τῇ ἐλαίᾳ· « Βασίλευσον ἐφ’ ἡμῶν. » Καὶ εἶπεν αὐτοῖς ἡ ἐλαία· « Ἀφεῖσα τὴν πιότητά μου ἣν ἐδόξασεν ἐν ἐμοὶ ὁ θεὸς καὶ οἱ ἄνθρωποι, πορευθῶ ἄρχειν τῶν ξύλων ; » Καὶ εἶπαν τὰ ξύλα τῇ συκῇ· « Δεῦρο, βασίλευσον ἐφ’ ἡμῶν. » Καὶ εἶπεν αὐτὴ ἡ συκῆ· « Ἀφεῖσα τὴν γλυκύτητά μου καὶ τὸ γέννημά μου τὸ ἀγαθόν, πορευθῶ τοῦ ἄρχειν τῶν ξύλων ; » Καὶ εἶπαν τὰ ξύλα πρὸς τὴν ῥάμνον· « Δεῦρο, βασίλευσον ἐφ’ ἡμῶν. » Καὶ εἶπεν ἡ ῥαμνος &lt;πρὸς&gt; τὰ ξύλα· « Εἰ ἐν ἀληθείᾳ ὑμεῖς χρίετέ με εἰς βασιλέα ἐφ’ ὑμῶν, δεῦτε ὑπόστητε ἐν τῇ σκέπῃ μου· καὶ εἰ μή, ἐξέλθοι πῦρ ἐκ τῆς ῥάμνου καὶ καταφάγοι τὰς κέδρους τοῦ Λιϐάνου. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 133.</p>
+        <bibl>Cod. Mb 133.</bibl>
         <p><milestone unit="traduction"/>Un jour les arbres se mirent en devoir d’élire un roi pour les commander, et ils dirent à l’olivier : « Règne sur nous. » Et l’olivier leur répondit : « Moi, que je renonce à la grasse liqueur si appréciée en moi par Dieu et par les hommes, pour aller régner sur les arbres ! » Et les arbres dirent au figuier : « Viens régner sur nous. » Et le figuier lui aussi répondit : « Moi, que je renonce à la douceur qui est en moi et à l’excellent fruit que je porte, pour aller régner sur les arbres ! » Et les arbres dirent à l’épine : « Viens régner sur nous. » Et l’épine répondit aux arbres : « Si vraiment vous m’oignez pour régner sur vous, venez vous mettre à l’abri sous moi ; sinon, qu’il sorte du feu de l’épine, et qu’il dévore les cèdres du Liban ! »</p>
       </div>
       <div type="poem" xml:id="chambry-254">
@@ -7032,7 +7031,7 @@
           <pb ed="perry" n="P173"/>
           <p><milestone unit="recitprose"/>Ξυλευόμενός τις παρά τινα ποταμὸν τὸν πέλεκυν ἀπέϐαλε· τοῦ δὲ ῥεύματος παρασύραντος αὐτόν, καθήμενος ἐπὶ τῆς ὄχθης ὠδύρετο, μέχρις οὗ ὁ Ἑρμῆς ἐλεήσας αὐτὸν ἧκε. Καὶ μαθὼν παρ’ αὐτοῦ τὴν αἰτίαν δι’ ἣν ἔκλαιε, τὸ μὲν πρῶτον καταϐὰς χρυσοῦν αὐτῷ πέλεκυν ἀνήνεγκε καὶ ἐπυνθάνετο εἰ οὗτος αὐτοῦ εἴη. Τοῦ δὲ εἰπόντος μὴ τοῦτον εἶναι, ἐκ δευτέρου ἀργυροῦν ἀνήνεγκε καὶ πάλιν ἀνηρώτα εἰ τοῦτον ἀπέϐαλεν. Ἀρνησαμένου δὲ αὐτοῦ, τὸ τρίτον τὴν ἰδίαν ἀξίνην ἀνεκόμισε. Τοῦ δὲ ἐπιγνόντος, ἀποδεξάμενος αὐτοῦ τὴν δικαιοσύνην πάσας αὐτῷ ἐχαρίσατο. Καὶ ὃς ἐπανελόμενος, ἐπειδὴ παρεγένετο πρὸς τοὺς ἑταίρους, τὰ γεγενημένα αὐτοῖς διηγήσατο. Τῶν δέ τις ἐποφθαλμιάσας ἐϐουλήθη καὶ αὐτὸς τῶν ἴσων περιγενέσθαι. Διόπερ ἀναλαϐὼν πέλεκυν παρεγένετο ἐπὶ τὸν αὐτὸν ποταμὸν καὶ ξυλευόμενος ἐπίτηδες τὴν ἀξίνην εἰς τὰς δίνας ἀφῆκε καθεζόμενός τε ἔκλαιεν. Ἑρμοῦ δὲ ἐπιφανέντος καὶ πυνθανομένου τί τὸ συμϐεϐηκὸς εἴη, ἔλεγε τὴν τοῦ πελέκεως ἀπώλειαν. Τοῦ δὲ χρυσοῦν αὐτῷ ἀνενεγκόντος καὶ διερωτῶντος εἰ τοῦτον ἀπολώλεκεν, ὑπὸ τοῦ κέρδους ὑποφθὰς ἔφασκεν αὐτὸν εἶναι. Καὶ ὁ θεὸς αὐτῷ οὐ μόνον οὐκ ἐχαρίσατο, ἀλλ’ οὐδὲ τὸν ἴδιον πέλεκυν ἀποκατέστησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι, ὅσον τοῖς δικαίοις τὸ θεῖον συναγωνίζεται, τοσοῦτον τοῖς ἀδίκοις ἐναντιοῦται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 171 Pb 168 Pc 99 Pf 92 Pg 109 Ma 119 Mb 132 Me 119 Mf 101 Mj 109.</p>
+          <bibl>Codd. Pa 171 Pb 168 Pc 99 Pf 92 Pg 109 Ma 119 Mb 132 Me 119 Mf 101 Mj 109.</bibl>
         </div>
         <div>
           <head>Chambry 254.2</head>
@@ -7040,7 +7039,7 @@
           <pb ed="perry" n="P173"/>
           <p><milestone unit="recitprose"/>Ξυλευόμενός τις παρά τινα ποταμὸν τὸν ἑαυτοῦ πέλεκυν ἀπεϐάλετο. Τοῦ δὲ ῥεύματος παρασύραντος αὐτόν, ὑπὸ πολλῆς συσχεθεὶς θλίψεως, καθήμενος παρὰ τὰς ὄχθας τοῦ ποταμοῦ ὠδύρετο. Ἑρμῆς δὲ ὁ τοῦ ποταμοῦ θεὸς ἐλεήσας αὐτὸν ἧκε μαθεῖν θέλων παρ’ αὐτοῦ τὴν αἰτίαν δι’ ἣν ἔκλαιε. Τοῦ δὲ εἰπόντος αὐτῷ, καταϐὰς ὁ Ἑρμῆς χρυσοῦν πέλεκυν ἀνήνεγκεν ἐκ τοῦ ποταμοῦ, καὶ ἐπυνθάνετο εἰ τοῦτον ἀπώλεσεν. Ἀρνησαμένου δὲ αὐτοῦ, ἐκ δευτέρου καταϐὰς ἀργυροῦν ἀνήνεγκεν. Ὁ δὲ πάλιν ἠρνήσατο κἀκεῖνον μὴ εἶναι αὐτοῦ. Καταϐὰς δὲ ἐκ τρίτου τὴν ἰδίαν ἀξίνην ἐκόμισεν· ἐπηρώτησε δὲ τοῦτον καὶ πάλιν, εἰ ταύτην ἀπώλεσεν· ὁ δὲ· « Ἀληθῶς ταύτην ἀπώλεσα, » εἶπεν. Ὁ δὲ Ἑρμῆς ἀποδεξάμενος αὐτοῦ τὴν δικαιοσύνην καὶ τὸ ἀληθὲς πάσας αὐτῷ ἐχαρίσατο. Παραγενόμενος οὖν πρὸς τοὺς ἑταίρους αὐτοῦ, διηγήσατο αὐτοῖς τὰ συμϐάντα αὐτῷ. Εἷς δέ τις ἐξ αὐτῶν τοῦτον ἐπιφθονήσας ἐϐουλήθη καὶ αὐτὸς τὸ ἴσον παραγενόμενος ἐκεῖσε διαπράξασθαι. Διόπερ ἀναλαϐὼν πέλεκυν, παρεγένετο ἐπὶ τὸν αὐτὸν ποταμὸν ξυλευσόμενος, καὶ ἐπίτηδες τὴν ἑαυτοῦ ἀξίνην ῥίψας ἐν τῷ ποταμῷ, ἐκαθέζετο κλαίων. Αὐτίκα οὖν τοῦ Ἑρμοῦ ἐπιφανέντος καὶ τὴν αἰτίαν τῶν θρήνων πυνθανομένου, ἔφη ὅτι πέλεκυν ἀπώλεσα ἐν τῷ ποταμῷ· ὅπερ ἀκούσας ὁ Ἑρμῆς, καταϐὰς χρυσοῦν πέλεκυν ἀνήγαγε. Καὶ δὴ φήσαντος αὐτοῦ εἰ τοῦτον ἀπώλεσεν, ἔφη μετὰ χαρᾶς· « Ναὶ ἀληθῶς οὗτός ἐστιν. » Ἰδὼν οὖν ἐκεῖνος τὴν ἀναίδειαν καὶ τὸ ψεῦσμα αὐτοῦ, οὐ μόνον τοῦτον οὐκ ἐδωρήσατο αὐτῷ, ἀλλ’ οὐδὲ τὸν ἴδιον ἀπέδωκε πέλεκυν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος διδάσκει ὅτι, ὅσον τοῖς δικαίοις συναγνωνίζεται τὸ θεῖον, τοσοῦτον τοῖς ἀδίκοις ἐναντιοῦται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 127 Cb 78 Ce 85 Cf 90 Cg 20 Ch 95 Mc 76.</p>
+          <bibl>Codd. Ca 127 Cb 78 Ce 85 Cf 90 Cg 20 Ch 95 Mc 76.</bibl>
         </div>
         <div>
           <head>Chambry 254.3</head>
@@ -7048,7 +7047,7 @@
           <pb ed="perry" n="P173"/>
           <p><milestone unit="recitprose"/>Ξυλευόμενός τις παρὰ ποταμῷ τὸν οἰκεῖον ἀπέϐαλε πέλεκυν. Ἀμηχανῶν τοίνυν παρὰ τὴν ὄχθην καθίσας ὠδύρετο. Ἑρμῆς δὲ μαθὼν τὴν αἰτίαν καὶ οἰκτείρας τὸν ἄνθρωπον, καταδὺς εἰς τὸν ποταμὸν χρυσοῦν ἀνήνεγκε πέλεκυν, καὶ εἰ οὗτός ἐστιν ὃν ἀπώλεσεν ἤρετο. Τοῦ δὲ μὴ τοῦτον εἶναι φαμένου, αὖθις καταϐὰς ἀργυροῦν ἀνεκόμισε. Τοῦ δὲ μηδὲ τοῦτον εἶναι τὸν οἰκεῖον εἰπόντος, ἐκ τρίτου καταϐὰς ἐκεῖνον τὸν οἰκεῖον ἀνήνεγκε. Τοῦ δὲ τοῦτον ἀληθῶς εἶναι τὸν ἀπολωλότα φαμένου, Ἑρμῆς ἀποδεξάμενος αὐτοῦ τὴν δικαιοσύνην, πάντας αὐτῷ ἐδωρήσατο. Ὁ δὲ παραγενόμενος πρὸς τοὺς ἑταίρους τὰ συμϐάντα αὐτοῖς διεξελήλυθεν· ὧν εἱς τις τὰ ἴσα διαπράξασθαι ἐϐουλεύσατο, καὶ παρὰ τὸν ποταμὸν ἐλθὼν καὶ τὴν οἰκείαν ἀξίνην ἐξεπίτηδες ἀφεὶς εἰς τὸ ῥεῦμα κλαίων ἐκάθητο. Ἐπιφανεὶς οὖν ὁ Ἑρμῆς κἀκείνῳ καὶ τὴν αἰτίαν μαθὼν τοῦ θρήνου, καταϐὰς ὁμοίως χρυσῆν ἀξίνην ἐξήνεγκε καὶ ἤρετο εἰ ταύτην ἀπέϐαλε. Τοῦ δὲ σὺν ἡδονῇ· « Ναὶ ἀληθῶς ἥδ’ ἐστί » φήσαντος, μισήσας ὁ θεὸς τὴν τοσαύτην ἀναίδειαν, οὐ μόνον ἐκείνην κατέσχεν, ἀλλ’ ουδὲ τὴν οἰκείαν ἀπέδωκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, ὅσον τοῖς δικαίοις τὸ θεῖον συναίρεται, τοσοῦτον τοῖς ἀδίκοις ἐναντιοῦται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 44 Lb 99 Lc 21 Le 89 Lf 44 Lg 21 Md 85 Mg 115 Mi 1 Ml 116 Mm 103.</p>
+          <bibl>Codd. La 44 Lb 99 Lc 21 Le 89 Lf 44 Lg 21 Md 85 Mg 115 Mi 1 Ml 116 Mm 103.</bibl>
           <p><milestone unit="traduction"/>Un homme qui coupait du bois au bord d’une rivière avait perdu sa cognée. Aussi, ne sachant que faire, il s’était assis sur la berge et pleurait. Hermès, ayant appris la cause de sa tristesse, le prit en pitié ; il plongea dans la rivière, en rapporta une cognée d’or et lui demanda si c’était celle qu’il avait perdue. L’homme lui ayant répondu que ce n’était pas celle-là, il plongea de nouveau et en rapporta une d’argent. L’homme ayant déclaré que celle-là non plus n’était pas la sienne, il plongea une troisième fois et lui rapporta sa propre cognée. L’homme affirma que c’était bien celle-là qu’il avait perdue. Alors Hermès, charmé de sa probité, les lui donna toutes les trois. Revenu près de ses camarades il leur conta son aventure. L’un d’eux se mit en tête d’en obtenir autant. Il se rendit au bord de la rivière et lança à dessein sa hache dans le courant, puis s’assit en pleurant. Alors Hermès lui apparut à lui aussi, et apprenant le sujet de ses pleurs, il plongea et lui rapporta aussi une cognée d’or, et lui demanda si c’était celle qu’il avait perdue. Et lui, tout joyeux, s’écria : « Oui, c’est bien elle. » Mais le dieu, ayant horreur de tant d’effronterie, non seulement garda la hache d’or, mais il ne lui rendit même pas la sienne.</p>
           <p><milestone unit="traduction"/>Cette fable montre que, autant la divinité est favorable aux honnêtes gens, autant elle est hostile aux malhonnêtes.</p>
         </div>
@@ -7088,7 +7087,7 @@
           <l><milestone unit="recitvers"/>Ἀναίδειαν οὖν ἐκπλαγεὶς τοῦ ἀνέρος</l>
           <l><milestone unit="recitvers"/>ῥίψας καὶ τοῦτον οὐδὲ διδοῖ τὸν ἄλλον.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι, ὅσον ὁ θεὸς εὐφραίνεται ἐπὶ τῷ δικαίῳ, τοσοῦτον πάλιν ἄχθεται ἐπὶ τῷ ἀδίκῳ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 94.</p>
+          <bibl>Cod. Cd 94.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-255">
@@ -7099,7 +7098,7 @@
           <pb ed="perry" n="P65"/>
           <p><milestone unit="recitprose"/>Δύο φίλοι τὴν αὐτὴν ὁδὸν ἐϐάδιζον. Ἄρκτου δὲ αὐτοῖς ἐπιφανείσης, ὁ μὲν ἕτερος φθάσας ἀνέϐη ἐπί τι δένδρον καὶ ἐνταῦθα ἐκρύπτετο, ὁ δὲ ἕτερος μέλλων περικατάληπτος γίνεσθαι, πεσὼν κατὰ τοῦ ἐδάφους τὸν νεκρὸν προσεποιεῖτο. Τῆς δὲ ἄρκτου προσενεγκούσης αὐτῷ τὸ ῥύγχος καὶ περιοσφραινομένης τὰς ἀναπνοὰς συνεῖχε· φασὶ γὰρ νεκροῦ μὴ ἅπτεσθαι τὸ ζῷον. Ὑποχωρησάσης δέ, ὁ ἀπὸ τοῦ δένδρου καταϐὰς ἐπυνθάνετο αὐτοῦ τί ἡ ἄρκτος πρὸς τὸ οὖς εἴρηκεν. Ὁ δὲ εἶπε· « Τοῦ λοιποῦ τοιούτοις μὴ συνοδοιπορεῖν φίλοις οἳ ἐν κινδύνοις οὐ παραμένουσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοὺς γνησίους τῶν φίλων αἱ συμφοραὶ δοκιμάζουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 64 Pb 65 Pc 32 Pe 32 Pg 42 Ma 46 Mb 36.</p>
+          <bibl>Codd. Pa 64 Pb 65 Pc 32 Pe 32 Pg 42 Ma 46 Mb 36.</bibl>
           <p><milestone unit="traduction"/>Deux amis cheminaient sur la même route. Un ours leur apparut soudain. L’un monta vite sur un arbre et s’y tint caché ; l’autre, sur le point d’être pris, se laissa tomber sur le sol et contrefit le mort. L’ours approcha de lui son museau et le flaira partout ; mais l’homme retenait sa respiration ; car on dit que l’ours ne touche pas à un cadavre. Quand l’ours se fut éloigné, l’homme qui était sur l’arbre descendit et demanda à l’autre ce que l’ours lui avait dit à l’oreille. « De ne plus voyager à l’avenir avec des amis qui se dérobent dans le danger », répondit l’autre.</p>
           <p><milestone unit="traduction"/>Cette fable montre que les amis véritables se reconnaissent à l’épreuve du malheur.</p>
         </div>
@@ -7109,7 +7108,7 @@
           <pb ed="perry" n="P65"/>
           <p><milestone unit="recitprose"/>Δύο φίλοι τὴν αὐτὴν ὁδὸν ἐϐάδιζον. Καὶ δὴ ἄρκτου αὐτοῖς συναντησάσης, ὁ μὲν εἷς φοϐηθεὶς ἐπί τι δένδρον ἀναϐὰς ἐκρύϐη ἐν αὐτῷ· ὁ δὲ ἕτερος περιγενέσθαι αὐτῆς μὴ δυνηθεὶς μόνος, ὡς εἶδεν αὑτὸν κυριευόμενον παρὰ τῆς ἄρκτου, πεσὼν ἐπὶ τὴν γῆν προσεποιεῖτο τεθνάναι. Ἐλθούσης δὲ αὐτῆς ἐπὶ τὴν κεφαλὴν αὐτοῦ ὠσφραίνετο διὰ τοῦ ῥύγχους τῶν ἀκοῶν αὐτοῦ καὶ τῶν φρενῶν. Ὁ δὲ τὰς ἀναπνοὰς αὑτοῦ ἐκράτει εὐτόνως. Ἡ δὲ ἄρκτος ὑπολαϐοῦσα νεκρὸν αὐτὸν ὑπάρχειν, ἀπῄει· φασὶ γὰρ ὅτι νεκροῦ ἡ ἄρκτος οὐχ ἅπτεται. Ἀπαλλαγείσης δὲ αὐτῆς, ὁ ἕτερος καταϐὰς ἀπὸ τοῦ δένδρου, ἐπυνθάνετο τί [ἂν] πρὸς τὸ οὖς ἐλάλει αὐτῷ ἡ ἄρκτος. Ὁ δὲ εἶπεν ὅτι « ἔφη πρός με ἡ ἄρκτος ὥστε ἀπὸ τοῦ νῦν τοιούτοις μὴ συνοδοιπορεῖν φίλοις οἳ ἐν κινδύνοις οὐ παραμένουσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς γνησίους τῶν φίλων αἱ συμφοραὶ δοκιμάζουσιν. Ἢ· Ἀπέχεσθαι χρὴ φίλων οἵτινες ἐν κινδύνοις οὐ βοηθοῦσιν οὐδὲ παραμένουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 57 Cb 38 Cd 35 Ce 40 Cf 44 Ch 45 Mc 37 Md 43 Mh 38 Mi 78 Ml 152 Mm 55 Mn 17 Ld 17.</p>
+          <bibl>Codd. Ca 57 Cb 38 Cd 35 Ce 40 Cf 44 Ch 45 Mc 37 Md 43 Mh 38 Mi 78 Ml 152 Mm 55 Mn 17 Ld 17.</bibl>
         </div>
         <div>
           <head>Chambry 255.3</head>
@@ -7117,7 +7116,7 @@
           <pb ed="perry" n="P65"/>
           <p><milestone unit="recitprose"/>Δύο φίλοι τὴν αὐτὴν ὁδὸν ἐϐάδιζον. Καὶ δὴ ἄρκτος αὐτοῖς συναντήσας τὸν μὲν ἕνα εἰς φυγὴν ἔτρεψεν· ὃς καὶ ἀναϐὰς ἐπὶ δένδρον ἐκρύϐη. Ὁ δὲ ἕτερος τοῦτο ποιῆσαι μὴ δυνηθείς, ὡς ἔγνω ἑαυτὸν μέλλοντα κυριευθῆναι ὑπὸ τῆς ἄρκτου, πεσὼν ἐπὶ τῆς γῆς προσεποιεῖτο τεθνάναι. Ἡ δὲ ἄρκτος ἐλθοῦσα ἐπ τὴν κεφαλὴν αὐτοῦ ὠσφραίνετο τήν τε ἀναπνοὴν αὐτοῦ καὶ τὰς φρένας καὶ τὴν ἀκοήν. Ὁ δὲ εὐτόνως κατεῖχε τὴν ἀναπνοὴν αὐτοῦ. Ἡ δὲ ἄρκτος ὑπολαϐοῦσα βεκρὸν αὐτὸν εἶναι ἀνεχώρησε· φασὶ γὰρ νεκροῦ μὴ ἅπτεσθαι τὴν ἄρκτον. Ὁ δὲ ἕτερος καταϐὰς ἀπὸ τοῦ δένδρου ἐπυνθάνετο τί πρὸς τὸ οὖς αὐτοῦ ἐλάλει ἡ ἄρκτος. Ὁ δὲ εἶπε· Τοῦτο ἔφη· ἀπὸ τοῦ νῦν τοιούτοις μὴ συνόδευε φίλοις.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ἀπέχεσθαι τῶν φίλων οἵτινες ἐν καιρῷ περιστάσεως οὐ περιμένουσι βοηθῆσαι τοῖς φίλοις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 41.</p>
+          <bibl>Cod. Mk 41.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-256">
@@ -7126,7 +7125,7 @@
         <pb ed="perry" n="P236"/>
         <p><milestone unit="recitprose"/>Πορευομένοις τισὶν ἐπὶ πρᾶξίν τινα κόραξ ὑπήντησε τὸν ἕτερον τῶν ὀφθαλμῶν πεπηρωμένος. Ἐπιστραφέντων δὲ αὐτῶν καί τινος ὑποστρέψαι παραινοῦντος, τουττο γὰρ σημαίνειν τὸν οἰωνόν, ἕτερος ὑποτυχὼν εἶπε· « Καὶ πῶς οὗτος ἡμῖν δύναται τὰ μέλλοντα μαντεύεσθαι, ὃς οὐδὲ τὴν ἰδίαν πήρωσιν προεῖδεν, ἵνα φυλάξηται ; »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ ἐν τοῖς ἰδίοις ἄϐουλοι καὶ εἰς τὰς τῶν πέλας συμϐουλίας ἀδόκιμοί εἰσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 212 Pf 120 Me 155.</p>
+        <bibl>Codd. Pa 212 Pf 120 Me 155.</bibl>
         <p><milestone unit="traduction"/>Des gens, qui voyageaient pour certaine affaire, rencontrèrent un corbeau qui avait perdu un œil. Ils tournèrent leurs regards vers lui, et l’un d’eux leur conseilla de rebrousser chemin ; c’était, à son avis, ce que voulait dire le présage. Mais un autre prenant la parole dit : « Comment cet oiseau pourrait-il nous prédire l’avenir, lui qui n’a même pas prévu, pour l’éviter, la perte de son œil ? »</p>
         <p><milestone unit="traduction"/>Pareillement les hommes qui sont aveugles sur leurs propres intérêts sont mal qualifiés pour conseiller leur prochain.</p>
       </div>
@@ -7138,7 +7137,7 @@
           <pb ed="perry" n="P67"/>
           <p><milestone unit="recitprose"/>Δύο ἐν ταὐτῷ ὡδοιπόρουν. Ἑτέρου δὲ πέλεκυν εὑρόντος, ὁ ἕτερος ἔλεγεν· « Εὑρήκαμεν. » Ὁ δὲ ἕτερος παρῄνει μὴ λέγειν « Εὑρήκαμεν, » ἀλλ’ « Εὕρηκας. » Μετὰ μικρὸν δὲ ἐπελθόντων αὐτοῖς τῶν ἀποϐεϐληκότων τὸν πέλεκυν, ὁ ἔχων αὐτὸν διωκόμενος ἔλεγε πρὸς τὸν συνοδοιπόρον· « Ἀπολώλαμεν. » Ἐκεῖνος δὲ ἔφη· « &lt;Μὴ ἀπολώλαμεν εἴπῃς&gt;, ἀλλ’ ἀπολώλα· οὐδὲ γὰρ, ὅτε τὸν πέλεκυν εὗρες, ἐμοὶ αὐτὸν ἀνεκοινώσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ μὴ μεταλαϐόντες τῶν εὐτυχημάτων οὐδὲ ἐν ταῖς συμφοραῖς βέϐαιοί εἰσι φίλοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 66 Pb 67 Pc 33 Pe 34 Pf 31 Ph 33 Mb 15 Me 46 Mf 41.</p>
+          <bibl>Codd. Pa 66 Pb 67 Pc 33 Pe 34 Pf 31 Ph 33 Mb 15 Me 46 Mf 41.</bibl>
           <p><milestone unit="traduction"/>Deux hommes voyageaient de compagnie. L’un d’eux ayant trouvé une hache, l’autre dit : « Nous avons trouvé une hache. – Ne dis pas, reprit le premier : nous avons trouvé, mais : tu as trouvé. » Quelques moments après, ils furent rejoints par ceux qui avaient perdu la hache, et celui qui l’avait, se voyant poursuivi, dit à son compagnon de route : « Nous sommes perdus. – Ne dis pas : nous sommes perdus, reprit celui-ci, mais : je suis perdu ; car, lorsque tu as trouvé la hache, tu ne m’as pas mis de moitié dans ta trouvaille. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que, si l’on n’a point de part aux heureux succès d’un ami, on ne lui est pas non plus fidèle dans le malheur.</p>
         </div>
@@ -7148,7 +7147,7 @@
           <pb ed="perry" n="P67"/>
           <p><milestone unit="recitprose"/>Δύο τινὲς κατὰ ταὐτὸν ὡδοιπόρουν, καὶ θἀτέρου πέλεκυν εὑρόντος, ἅτερος ὁ μὴ εὑρὼν παρῄνει αὐτῷ μὴ λέγειν· « Εὕρηκα, » ἀλλ’ « Εὑρήκαμεν. » Μετὰ μικρὸν δὲ ἐπέλθοντων αὐτοῖς τῶν τὸν πέλεκυν ἀποϐεϐληκότων, ὁ ἔχων αὐτὸν διωκόμενος πρὸς τὸν μὴ εὑρόντα συνοδοιπόρον ἔλεγεν· « Ἀπολώλαμεν. » Ὁ δὲ εἶπεν· « Ἀλόλωλα λέγε, οὐκ ἀπολώλαμεν· καὶ γὰρ καὶ ὅτε τὸν πέλεκυν εὗρες, εὕρηκα ἔλεγες, οὐχ εὑρήκαμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ μὴ μεταλαμϐάνοντες τῶν εὐτυχημάτων οὐδ’ ἐν ταῖς συμφοραῖς βέϐαιοί εἰσι φίλοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 87 Lb 39 Le 39 Lf 87 Md 140 Mg 54 Mi 114 Mj 45 Ml 50 Mm 141 Ce 39 Cf 42.</p>
+          <bibl>Codd. La 87 Lb 39 Le 39 Lf 87 Md 140 Mg 54 Mi 114 Mj 45 Ml 50 Mm 141 Ce 39 Cf 42.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-258">
@@ -7157,7 +7156,7 @@
         <pb ed="perry" n="P175"/>
         <p><milestone unit="recitprose"/>Ὁδοιπόροι θέρους ὥρᾳ περὶ μεσημϐρίαν ὑπὸ καύματος τρυχόμενοι, ὡς ἐθεάσαντο πλάτανον, ὑπὸ ταύτην καταντήσαντες καὶ ἐν τῇ σκιᾷ κατακλιθέντες ἀνεπαύοντο. Ἀναϐλέψαντες δὲ εἰς τὴν πλάτανον ἔλεγον πρὸς ἀλλήλους ὡς ἀνωφελές ἐστιν ἀνθρώποις τοῦτο ἄκαρπον τὸ δένδρον. Ἡ δὲ ὑποτυχοῦσα ἔφη· « Ὦ ἀχάριστοι, ἔτι τῆς ἐξ ἐμοῦ εὐεργεσίας ἀπολαύοντες, ἀχρείαν με καὶ ἄκαρπον ἀποκαλεῖτε. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων τινὲς ἀτυχεῖς εἰσιν ὡς καὶ εὐεργετοῦντες τοὺς πέλας ἐπὶ τῇ χρηστότητι ἀπιστεῖσθαι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 173 Pb 170 Pc 101 Pf 94 Pg 111 Ph 75 Ma 121 Mb 146 Me 121 Mf 102 Mj 111 Ca 129 Lb 99 Le 99 Lh 51.</p>
+        <bibl>Codd. Pa 173 Pb 170 Pc 101 Pf 94 Pg 111 Ph 75 Ma 121 Mb 146 Me 121 Mf 102 Mj 111 Ca 129 Lb 99 Le 99 Lh 51.</bibl>
         <p><milestone unit="traduction"/>En été, vers l’heure de midi, deux voyageurs, fatigués par l’ardeur du soleil, ayant aperçu un platane, se réfugièrent sous ses branches et, s’étendant à son ombre, se reposèrent. Or, ayant levé les yeux vers le platane, ils se dirent l’un à l’autre : « Voilà un arbre qui est stérile et inutile à l’homme. » Le platane prenant la parole : « Ingrats, dit-il, au moment même où vous jouissez de ma bienfaisance, vous me traitez d’inutile et de stérile. »</p>
         <p><milestone unit="traduction"/>Il en est ainsi chez les hommes : certains sont si malchanceux que, même en obligeant leurs voisins, ils ne peuvent faire croire à leur bienfaisance.</p>
       </div>
@@ -7169,7 +7168,7 @@
           <pb ed="perry" n="P177"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόροι κατά τινα αἰγιαλὸν ὁδεύοντες, ὡς ἦλθον ἐπί τινα σκοπιάν, ἐνθένδε θεασάμενοι φρύγανα πόρρωθεν ἐπιπλέοντα, ᾠήθησαν ναῦν εἶναι μεγάλην. Διὸ προσέμενον ὡς μέλλουσαν προσορμίζεσθαι. Ἐπεὶ δὲ ὑπὸ ἀνέμου φερόμενα τὰ φρύγανα μικρὸν προσεπέλαζον, ἀπεκαραδόκουν ὑπολαμϐάνοντες πλοῖον εἶναι οὐκέτι μέγα ὡς τὸ πρότερον. Ἐγγὺς δὲ παντελῶς ἐξενεχθέντα αὐτὰ ἰδόντες φρύγανα ὄντα, ἔφασαν πρὸς ἀλλήλους· « Τὸ μηδὲν ὂν ἡμεῖς μάτην προσεδεχόμεθα. »</p>
           <p><milestone unit="epimythiumprose"/>Οὑτω καὶ τῶν ἀνθρώπων ἔνιοι ἐξ ἀπροόπτου δοκοῦντες φοϐεροὶ εἶναι, ὅταν εἰς διάπειραν ἔλθωσιν, εὑρίσκονται οὐδενὸς ἄξιοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 175 Pb 172 Pc 103 Pf 95 Ma 123 Mb 147 Me 122 Mf 103 Mj 112.</p>
+          <bibl>Codd. Pa 175 Pb 172 Pc 103 Pf 95 Ma 123 Mb 147 Me 122 Mf 103 Mj 112.</bibl>
         </div>
         <div>
           <head>Chambry 259.2</head>
@@ -7177,7 +7176,7 @@
           <pb ed="perry" n="P177"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόροι κατά τινα αἰγιαλὸν ὁδεύοντες ἦλθον ἐπί τινα σκοπιάν. Κἀκεῖθεν θεασάμενοι φρύγανα πόρρωθεν ἐπιπλέοντα, ναῦν εἶναι μεγάλην ᾠήθησαν. Διὸ δὴ προσέμενον, ὡς μελλούσης αὐτῆς προσορμίζεσθαι. Ἐπεὶ δὲ ὑπὸ ἀνέμου φερόμενα τὰ φρύγανα ἐγγυτέρω ἐγένετο, οὐκέτι ναῦν, ἀλλὰ πλοῖον ἐδόκουν βλέπειν. Ἐξενεχθέντα δὲ αὐτὰ φρύγανα ὄντα ἰδόντες, πρὸς ἀλλήλους ἔφασαν ὡς ἄρα μάτην ἡμεῖς τὸ μηδὲν ὂν προσεδεχόμεθα.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν ἀνθρώπων ἔνιοι ἐξ ἀπροόπτου δοκοῦντες φοϐεροὶ εἶναι, ὅταν εἰς πεῖραν ἔλθωσιν, οὐδενὸς εὑρίσκονται ἄξιοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 114 Lb 100 Le 100 Lf 114 Lh 52 Mg 123 Ml 134.</p>
+          <bibl>Codd. La 114 Lb 100 Le 100 Lf 114 Lh 52 Mg 123 Ml 134.</bibl>
           <p><milestone unit="traduction"/>Des voyageurs, cheminant sur le bord de la mer, arrivèrent sur une hauteur. De là voyant flotter au loin des broussailles, ils les prirent pour un grand vaisseau de guerre ; aussi attendirent-ils, pensant qu’il allait aborder. Mais les broussailles poussées par le vent s’étant rapprochées, ils crurent voir, non plus un vaisseau de guerre, mais un vaisseau de charge. Une fois arrivées au rivage, ils virent que c’étaient des broussailles, et se dirent entre eux : « Comme nous étions sots d’attendre une chose qui n’était rien ! »</p>
           <p><milestone unit="traduction"/>Cette fable montre que certains hommes qui paraissent redoutables parce qu’ils sont inconnus, révèlent leur nullité à la première épreuve.</p>
         </div>
@@ -7188,7 +7187,7 @@
         <pb ed="perry" n="P355"/>
         <p><milestone unit="recitprose"/>Ὁδοιπορῶν τις ἐν ἐρήμῳ εὗρε γυναῖκα μόνην κατηφῆ ἑστῶσαν, καί φησιν αὐτῇ· « Τίς εἶ ; » Ἡ δὲ ἔφη· « Ἀλήθεια. – Καὶ διὰ ποίαν αἰτίαν τὴν πόλιν ἀφεῖσα τὴν ἐρημίαν οἰκεῖς ; » Ἡ δὲ εἶπεν· « Ὅτι τοῖς πάλαι καιροῖς παρ’ ὀλίγοις ἦν τὸ ψεῦδος· νῦν δὲ εἰς πάντας ἀνθρώπους ἐστίν, ἐάν τι ἀκούειν καὶ λέγειν θέλῃς. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι κάκιστος βίος καὶ πονηρὸς τοῖς ἀνθρώποις ἐστίν, ὅτε τὸ ψεῦδος προκρίνεται τῆς ἀληθείας.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 98.</p>
+        <bibl>Cod. Ba 98.</bibl>
         <p><milestone unit="traduction"/>Un voyageur qui passait dans un désert rencontra une femme solitaire qui tenait ses yeux baissés. « Qui es-tu ? » demanda-t-il. « La Vérité », répondit-elle. « Et pour quel motif as-tu quitté la ville et habites-tu le désert ? » Elle répondit : « Parce que, dans les temps anciens, le mensonge ne se rencontrait que chez un petit nombre d’hommes ; maintenant il est chez tous, quoi qu’on entende et quoi qu’on dise. »</p>
         <p><milestone unit="traduction"/>La vie devient mauvaise et pénible pour les hommes, lorsque le mensonge prévaut sur la vérité.</p>
       </div>
@@ -7200,7 +7199,7 @@
           <pb ed="perry" n="P178"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόρος πολλὴν ὁδὸν ἀνύων ηὔξατο, ἐὰν εὕρῃ τι, τούτου τὸ ἥμισυ τῷ Ἑρμῇ ἀναθήσειν. Περιτυχὼν δὲ πήρᾳ, ἐν ᾗ ἀμύγδαλά τε ἦν καὶ φοίνικες, ταῦτα ἀνείλατο οἰόμενος ἀργύριον εἶναι. Ἐκτινάξας δέ, ὡς εὗρε τὰ ἐνόντα, ταῦτα καταφαγὼν καὶ λαϐὼν τῶν τε ἀμυγδάλων τὰ κελύφη καὶ τῶν φοινίκων τὰ ὀστᾶ, ταῦτα ἐπί τινος βωμοῦ ἔθηκεν, εἰπών· « Ἀπέχεις, ὦ Ἑρμῆ, τὴν εὐχήν· καὶ γὰρ τὰ ἐντὸς ὧν εὗρον καὶ τὰ ἐκτὸς πρὸς σὲ διανενέμημαι. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα φιλάργυρον διὰ πλεονεξίαν καὶ θεοὺς κατασοφιζόμενον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 176 Pb 173 Pc 104 Pf 96 Pg 113 Mb 148 Me 123.</p>
+          <bibl>Codd. Pa 176 Pb 173 Pc 104 Pf 96 Pg 113 Mb 148 Me 123.</bibl>
           <p><milestone unit="traduction"/>Un voyageur, qui avait de longs trajets à faire, fit vœu, s’il trouvait quelque chose, d’en consacrer la moitié à Hermès. Or il trouva une besace où il y avait des amandes et des dattes. Il la ramassa, s’imaginant que c’était de l’argent, la secoua, et, voyant ce qu’elle renfermait, le mangea ; puis, prenant les coquilles des amandes et les noyaux des dattes, il les plaça sur un autel en disant : « Je suis quitte, ô Hermès, de mon vœu ; car j’ai partagé avec toi le dehors et le dedans de ce que j’ai trouvé. »</p>
           <p><milestone unit="traduction"/>Cette fable s’applique à l’avare qui, par cupidité, ruse même avec les dieux.</p>
         </div>
@@ -7210,7 +7209,7 @@
           <pb ed="perry" n="P178"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόρος πολλὴν ἀνύων ὁδὸν ηὔξατο λέγων ὅτι, « ὦ Ἑρμῆ, ἐὰν εὕρω τι, σοὶ τὸ ἥμισυ ἀναθήσω. » Περιτυχὼν δὲ πήρᾳ, ἐν ᾗ ἀμύγδαλα ἦσαν καὶ φοίνικες, ταύτην ἀνείλετο, οἰόμενος ἀργύριον εἶναι. Ἐκτινάξας δὲ εὗρε τὰ ἐνόντα. Καταφαγὼν δὲ ταῦτα καὶ λαϐὼν τῶν ἀμυγδάλων τὰ λέπη καὶ τῶν φοινίκων τὰ ὀστᾶ, ἐπί τινος βωμοῦ ἔθηκεν εἰπών· « Ἀπέχεις, ὦ Ἑρμῆ, τὴν εὐχήν· καὶ γὰρ τὰ ἐντὸς ὧν εὗρον καὶ τὰ ἐκτὸς πρὸς σὲ ἀνέθηκα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος πρὸς ἄνδρα φιλάργυρον, τὸν καὶ θεοὺς διὰ πλεονεξίαν κατασοφιζόμενον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 156 Cb 86 Ce 88 Cf 93 Cg 31 Ch 106.</p>
+          <bibl>Codd. Ca 156 Cb 86 Ce 88 Cf 93 Cg 31 Ch 106.</bibl>
         </div>
         <div>
           <head>Chambry 261.3</head>
@@ -7218,7 +7217,7 @@
           <pb ed="perry" n="P178"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόρος πολλὴν ἀνύσας ὁδὸν ηὔξατο, εἰ ἄρα εὑρήσει τι, τὸ ἥμισυ τούτου τῷ Ἑρμῇ ἀναθήσειν. Περιτυχὼν δὲ πήρᾳ μεστῇ φοινίκων καὶ ἀμυγδάλων, καὶ ταύτην ἀνελόμενος, ἐκείνους μὲν ἔφαγε, τὰ δὲ τῶν φοινίκων ὀστᾶ καὶ τὰ τῶν ἀμυγδάλων κελύφη ἐπί τινος ἀνέθηκε βωμοῦ, φήσας· « Ἀπέχεις, ὦ Ἑρμῆ, τὴν εὐχήν· τοῦ γὰρ εὑρεθέντος τὰ ἐκτὸς καὶ ἐντὸς πρὸς σὲ διανενέμημαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρα φιλάργυρον καὶ τοὺς θεοὺς διὰ πλεονεξίαν κατασοφιζόμενον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 47 Lb 93 Ld 29 Le 93 Lf 47 Mc 86 Md 96 Mg 118 Mi 12 Ml 119 Mm 114 Mn 29.</p>
+          <bibl>Codd. La 47 Lb 93 Ld 29 Le 93 Lf 47 Mc 86 Md 96 Mg 118 Mi 12 Ml 119 Mm 114 Mn 29.</bibl>
         </div>
         <div>
           <head>Chambry 261.4</head>
@@ -7238,7 +7237,7 @@
           <l><milestone unit="recitvers"/>Λοιπὸν τὴν ὑπόσχεσιν Διὶ ἐπλήρου,</l>
           <l><milestone unit="recitvers"/>τὰ ἐντὸς καὶ ἔξωθεν τῷ βωμῷ θύων.</l>
           <p><milestone unit="epimythiumprose"/>Τοῦτο δ’ ὁ λόγος λέγει ὅτι φιλάργυροι σοφίζονται τὸ θεῖον χάριν φιλαργυρίας, δευτέρας λύσσης, διὰ πλεονεξίαν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 100.</p>
+          <bibl>Cod. Cd 100.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-262">
@@ -7249,7 +7248,7 @@
           <pb ed="perry" n="P174"/>
           <p><milestone unit="recitprose"/>Ὁδοιπόρος πολλὴν ὁδὸν διανύσας, ἐπειδὴ κόπῳ συνείχετο, πεσὼν παρά τι φρέαρ ἐκοιμᾶτο. Μέλλοντος δὲ αὐτοῦ ὅσον οὔπω καταπίπτειν, ἡ Τύχη ἐπιστᾶσα καὶ διεγείρασα αὐτὸν εἶπεν· « Ὦ οὗτος, εἴγε ἐπεπτώκεις, οὐκ ἂν τὴν σεαυτοῦ ἀϐουλίαν, ἀλλ’ ἐμὲ ᾐτιῶ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ τῶν ἀνθρώπων δι’ ἑαυτοὺς δυστυχήσαντες τοὺς θεοὺς αἰτιῶνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 172 Pb 169 Pc 100 Pg 110 Ma 120 Mb 145.</p>
+          <bibl>Codd. Pa 172 Pb 169 Pc 100 Pg 110 Ma 120 Mb 145.</bibl>
           <p><milestone unit="traduction"/>Un voyageur, ayant fait une longue route, et se trouvant recru de fatigue, se laissa tomber sur le bord d’un puits et s’endormit. Il allait à coup sûr tomber dedans, quand la Fortune, s’étant approchée de lui, l’éveilla et lui dit : « Hé, l’ami ! si tu étais tombé, ce n’est pas ton imprudence, c’est moi que tu en aurais accusée. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que beaucoup de gens, tombés dans le malheur par leur faute, en accusent les dieux.</p>
         </div>
@@ -7259,7 +7258,7 @@
           <pb ed="perry" n="P174"/>
           <p><milestone unit="recitprose"/>Ἐγγὺς φρέατος παῖς τις ἐκοιμᾶτο. Ἐπιστᾶσα δὲ αὐτῷ ἡ Τύχη ἐϐόα· « Ἀνάστα καὶ ἄπελθε ἐντεῦθεν, μή πως κάτωθεν τοῦ φρέατος πέσῃς, καὶ ἐμὲ τὴν Τύχην καταμέμψωνται πάντες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις σφαλλόμενοι καὶ πράττοντες κακῶς περιπίπτομεν κινδύνοις καὶ μεμφόμεθα τὴν τύχην.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 62 Cb 43 Cd 40 Ce 45 Cf 49 Ch 50 Ma 165 Mc 42 Md 48 Mg 59 Mh 43 Mi 83 Mk 46 Ml 68 Mm 61.</p>
+          <bibl>Codd. Ca 62 Cb 43 Cd 40 Ce 45 Cf 49 Ch 50 Ma 165 Mc 42 Md 48 Mg 59 Mh 43 Mi 83 Mk 46 Ml 68 Mm 61.</bibl>
         </div>
         <div>
           <head>Chambry 262.3</head>
@@ -7271,7 +7270,7 @@
           <l><milestone unit="recitvers"/>μήπως, σοῦ τῷ φρέατι προσπεπτωκότος,</l>
           <l><milestone unit="recitvers"/>ἐμὲ τὴν Τύχην καταμέμψωνται πάντες. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις σφαλλόμενοι πράττοντες κακῶς περιπίπτομεν κινδύνοις καὶ μεμφόμεθα τύχην.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 178.</p>
+          <bibl>Cod. Mb 178.</bibl>
         </div>
         <div>
           <head>Chambry 262.4</head>
@@ -7279,7 +7278,7 @@
           <pb ed="perry" n="P174"/>
           <p><milestone unit="recitprose"/>Ἐγγὺς φρέατός τις ἐκοιμᾶτο. Ἡ δὲ Τύχη ἐπιστᾶσα αὐτῷ εἶπεν· « Ἔγειραι καὶ ἀλλαχοῦ κοιμήθητι μή πως, ἐν τῷ φρέατι σοῦ πεσόντος, ἐμὲ τὴν Τύχην ἅπαντες καταμέμψωνται. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις σφαλλόμενοι καὶ κακῶς πράσσοντες κινδύνοις περιπεσόντες εἱμαρμένην καὶ τύχην καταμεμφόμεθα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 33 Bb 22 Mg 59.</p>
+          <bibl>Codd. Ba 33 Bb 22 Mg 59.</bibl>
         </div>
         <div>
           <head>Chambry 262.5</head>
@@ -7287,14 +7286,14 @@
           <pb ed="perry" n="P174"/>
           <p><milestone unit="recitprose"/>Ἐν φρέατι τινὶ κοιμωμένου τινός, ἡ Τύχη ἐπιστᾶσα αὐτῷ εἴρηκεν· « Ἔγειραι, κοιμήθητι ἀλλαχόσε, μή πως, σοῦ κρημνισθέντος, οἱ σοῦ προσγενεῖς ἐμοὶ τὴν μέμψιν ἐπάξωσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις οἱ ἄνθρωποι σφαλλόμενοι οὐχ ἑαυτοῖς, ἀλλὰ μᾶλλον τῇ Τύχῃ τὸν μῶμον προσάγουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 26.</p>
+          <bibl>Cod. Bc 26.</bibl>
         </div>
         <div>
           <head>Chambry 262.6</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P174"/>
           <p><milestone unit="recitprose"/>Φρέατος ἔγγιστα καὶ παρὰ τὸ χεῖλος αὐτοῦ τις ἄνθρωπος πεσὼν ὕπνωσεν. Ἡ δὲ Τύχη ἐπιστᾶσα ἔφη αὐτῷ· « Ἐγέρθητι καὶ ἀλλαχοῦ κοιμήθητι, ἄνθρωπε, μή πως, πεσόντος σοῦ ἐν τῷ φρέατι καὶ ἀποπνιγέντος, ἐμοὶ τῇ Τύχῃ οἱ ἄνθρωποι μέμψωνται. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 16.</p>
+          <bibl>Cod. Bd 16.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-263">
@@ -7303,7 +7302,7 @@
         <pb ed="perry" n="P185"/>
         <p><milestone unit="recitprose"/>Ὄνοι ποτὲ ἀχθόμενοι ἐπὶ τῷ συνεχῶς ἀχθοφορεῖν καὶ ταλαιπωρεῖν πρέσϐεις ἔπεμψαν πρὸς τὸν Δία, λύσιν τινὰ αἰτούμενοι τῶν πόνων. Ὁ δὲ αὐτοῖς ἐπιδεῖξαι βουλόμενος ὅτι τοῦτο ἀδύνατόν ἐστιν, ἔφη τότε αὐτοὺς ἀπαλλαγήσεσθαι τῆς κακοπαθείας, ὅταν οὐροῦντες ποταμὸν ποιήσωσι. Κἀκεῖνοι αὐτὸν ἀληθεύειν ὑπολαϐόντες ἀπ’ ἐκείνου καὶ μέχρι νῦν ἔνθα ἂν ἀλλήλων οὖρον ἴδωσιν, ἐνταῦθα καὶ αὐτοὶ περιιστάμενοι οὐροῦσιν.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὸ ἑκάστῳ πεπρωμένον ἀθεράπευτόν ἐστι.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 184 Pb 181 Pd 38 Mb 158 Ca 138 La 116 Lb 102 Le 102 Lf 116 Me 131 Mf 109 Mg 125 Mj 123 Ml 128.</p>
+        <bibl>Codd. La 184 Pb 181 Pd 38 Mb 158 Ca 138 La 116 Lb 102 Le 102 Lf 116 Me 131 Mf 109 Mg 125 Mj 123 Ml 128.</bibl>
         <p><milestone unit="traduction"/>Un jour, les ânes excédés d’avoir toujours des fardeaux à porter et des fatigues à souffrir, envoyèrent des messagers auprès de Zeus, pour demander qu’il mît un terme à leurs travaux. Zeus, voulant leur démonter que la chose était impossible, leur dit qu’ils seraient délivrés de leur misère, quand ils auraient, en pissant, formé une rivière. Les ânes prirent au sérieux cette réponse, et depuis ce temps jusqu’à nos jours, quand ils voient quelque part de l’urine d’âne, ils s’arrêtent tout autour, eux aussi, pour pisser.</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’on ne peut rien changer à sa destinée.</p>
       </div>
@@ -7313,7 +7312,7 @@
         <pb ed="perry" n="P237"/>
         <p><milestone unit="recitprose"/>Ὄνον τις ἀγοράσαι μέλλων ἐπὶ πείρᾳ αὐτὸν ἔλαϐε· καὶ εἰσαγαγὼν εἰς τοὺς ἰδίους ἐπὶ τῆς φάτνης αὐτὸν ἔστησεν. Ὁ δὲ καταλιπὼν τοὺς ἄλλους παρὰ τῷ ἀργοτάτῳ καὶ ἀδηφάγῳ ἔστη. Καὶ ὡς οὐδὲν ἐποίει, δήσας καὶ ἀπαγαγὼν τῷ δεσπότῃ αὐτὸν ἀπέδωκε. Τοῦ δὲ διερωτῶντος εἰ οὕτως ἀξίαν αὐτοῦ τὴν δοκιμασίαν ἐποιήσατο, ὑποτυχὼν εἶπεν· « Ἀλλ’ ἔγωγε οὐδὲν ἐπιδέομαι πείρας· οἶδα γὰρ ὅτι τοιοῦτός ἐστιν ὁποῖον ἐξ ἁπάντων τὸν συνήθη ἐπελέξατο. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοιοῦτος εἶναί τις ὑπολαμϐάνεται ὁποίοις ἂν ἥδηται τοῖς ἑταίροις.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 188 Pf 101 Mb 162 Me 128.</p>
+        <bibl>Codd. Pa 188 Pf 101 Mb 162 Me 128.</bibl>
         <p><milestone unit="traduction"/>Un homme qui avait dessein d’acheter un âne, le prit à l’essai, et l’ayant amené parmi ses ânes à lui, il le plaça devant le râtelier. Or l’âne, délaissant tous les autres, alla se mettre près du plus paresseux et du plus glouton. Comme il ne faisait rien, l’homme lui passa un licol, l’emmena et le rendit à son propriétaire. Celui-ci lui demandant si l’épreuve qu’il avait faite ainsi était probante, il répondit : « Moi, je n’ai nul besoin d’une autre épreuve : je suis sûr qu’il est tel que le camarade qu’il a choisi entre tous. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’on nous juge pareils à ceux dont nous aimons la compagnie.</p>
       </div>
@@ -7323,7 +7322,7 @@
         <pb ed="perry" n="P183"/>
         <p><milestone unit="recitprose"/>Ὄνος ἄγριος ὄνον ἥμερον θεασάμενος ἔν τινι εὐηλίῳ τόπῳ προσελθὼν ἐμακάριζεν αὐτὸν ἐπὶ τῇ εὐεξίᾳ τοῦ σώματος καὶ τῇ τῆς τροφῆς ἀπολαύσει. Ὕστερον δὲ ἰδὼν αὐτὸν ἀχθοφοροῦντα καὶ τὸν ὀνηλάτην ὀπίσω ἑπόμενον καὶ ῥοπάλῳ παίοντα εἶπεν· « Ἀλλ’ ἔγωγε οὐκέτι σε εὐδαιμονίζω· ὁρῶ γὰρ ὅτι οὐκ ἄνευ κακῶν μεγάλων τὴν ἀφθονίαν ἔχεις. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οὐκ ἔστι ζηλωτὰ τὰ μετὰ κινδύνων καὶ ταλαιπωριῶν περιγινόμενα κέρδη.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 182 Pb 179 Pf 99 Pg 117 Mb 155 Me 126 Mf 106 Ca 136 La 115 Lb 101 Le 101 Lf 115 Lh 53 Mg 124 Mj 122 Ml 126.</p>
+        <bibl>Codd. Pa 182 Pb 179 Pf 99 Pg 117 Mb 155 Me 126 Mf 106 Ca 136 La 115 Lb 101 Le 101 Lf 115 Lh 53 Mg 124 Mj 122 Ml 126.</bibl>
         <p><milestone unit="traduction"/>Un âne sauvage ayant vu un âne domestique dans un endroit bien exposé au soleil, s’approcha pour le féliciter de son embonpoint et de la pâture dont il jouissait. Mais dans la suite l’ayant vu chargé d’un fardeau et suivi de l’ânier qui le frappait avec un gourdin, il s’écria : « Oh ! je ne te félicite plus ; car je vois que c’est au prix de grands maux que tu jouis de ton abondance. »</p>
         <p><milestone unit="traduction"/>C’est ainsi qu’il n’y a rien d’enviable dans les avantages qu’accompagnent les dangers et les souffrances.</p>
       </div>
@@ -7335,7 +7334,7 @@
           <pb ed="perry" n="P180"/>
           <p><milestone unit="recitprose"/>Ὄνος ἅλας ἔχων ποταμὸν διέϐαινεν. Ὀλισθήσας δέ, ὡς κατέπεσεν εἰς τὸ ὕδωρ, ἐκτακέντος τοῦ ἅλατος, κουφότερος ἐξανέστη. Ἡσθεὶς δὲ ἐπὶ τούτῳ, ἐπειδὴ ὕστερόν ποτε σπόγγους ἐμπεφορτισμένος κατά τινα ποταμὸν ἐγένετο, ᾠήθη ὅτι, ἐὰν πάλιν πέσῃ, ἐλαφρότερος διεγερθήσεται, καὶ δὴ ἑκὼν ὤλισθε. Συνέϐη δὲ αὐτῷ, τῶν σπόγγων ἀνασπασάντων τὸ ὕδωρ, μὴ δυνάμενον ἐξαναστῆναι ἐνταῦθα ἀποπνιγῆναι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἔνιοι διὰ τὰς ἰδίας ἐπινοίας λανθάνουσιν εἰς συμφορὰς ἐνσειόμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 179 Pb 176 Pg 115 Ma 124 Mb 152.</p>
+          <bibl>Codd. Pa 179 Pb 176 Pg 115 Ma 124 Mb 152.</bibl>
           <p><milestone unit="traduction"/>Un âne portant du sel traversait une rivière ; il glissa et tomba dans l’eau. Alors le sel se fondit, et il se releva plus léger, et fut enchanté de l’accident. Une autre fois, comme il arrivait au bord d’une rivière avec une charge d’éponges, il crut que, s’il se laissait tomber encore, il se relèverait plus léger, et il fit exprès de glisser. Mais il advint que les éponges ayant pompé l’eau, il ne put se relever et périt noyé.</p>
           <p><milestone unit="traduction"/>Ainsi parfois les hommes ne se doutent pas que ce sont leurs propres ruses qui les précipitent dans le malheur.</p>
         </div>
@@ -7363,7 +7362,7 @@
           <l><milestone unit="recitvers"/>καὶ παραυτίκα κεκλυσμένων τῶν σπόγγων,</l>
           <l><milestone unit="recitvers"/>ἤγετο ὄνος διπλοῦν βάρος βαστάζων.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλάκις ἐν ᾧ τις εὐτύχησεν, ἐν αὐτῷ καὶ πίπτει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ca 122.</p>
+          <bibl>Cod. Ca 122.</bibl>
         </div>
         <div>
           <head>Chambry 266.3</head>
@@ -7371,7 +7370,7 @@
           <pb ed="perry" n="P180"/>
           <p><milestone unit="recitprose"/>Μικρέμπορός τις ὄνον ἔχων εὐώνους ἅλας ἠγόρασε καὶ σφοδρῶς τὸν ὄνον ἐφόρτωσεν. Ὁ δὲ ὄνος ἄκων ὀλισθήσας εἰς ὕδωρ ἔπεσε, καὶ, λυθέντων τῶν ἁλῶν, ἠλαφρύνθη, εὐκόλως δὲ ἠγέρθη καὶ περιεπάτει ἀκόπως. Ὁ δὲ ἔμπορος πάλιν ἑτέρους ἦλθεν ἀγοράσων καὶ πλεῖον ἢ πρότερον τὸν ὄνον φορτώσας ἦγεν. Ὁ δὲ πάλιν ἑκὼν εἰς τὸ ῥεῖθρον πεσὼν ἠλαφρύνθη. Ὁ δὲ ἔμπορος τέχνην ἑτέραν νοήσας σπόγγους ὠνησάμενος πεφορτώκεν τὸν ὄνον. Ὁ δὲ ὄνος, ὡς προσῆλθε τῷ ῥείθρῳ, ἑκὼν κατέπεσε· τῶν δὲ σπόγγων διαϐραχέντων, βάρος διπλοῦν ἦγε βαστάζων.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις ἐν ᾧ τις εὐτύχησεν, ἐν αὐτῷ καὶ πίπτει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 92 Bb 59.</p>
+          <bibl>Codd. Ba 92 Bb 59.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-267">
@@ -7382,7 +7381,7 @@
           <pb ed="perry" n="P182"/>
           <p><milestone unit="recitprose"/>Ὄνῳ τις ἐπιθεὶς ἄγαλμα ἤλαυνεν εἰς ἄστυ. Τῶν δὲ συναντώντων προσκυνούντων τὸ ἄγαλμα, ὁ ὄνος ὑπολαϐὼν ὅτι αὐτὸν προσκυνοῦσιν, ἀναπτερωθεὶς ὠγκᾶτό τε καὶ οὐκέτι περαιτέρω προϊέναι ἐϐούλετο. Καὶ ὁ ὀνηλάτης αἰσθόμενος τὸ γεγονὸς τῷ ῥοπάλῳ αὐτὸν παίων ἔφη· « Ὦ κακὴ κεφαλή, ἔτι καὶ τοῦτο λοιπὸν ἦν ὄνον ὑπ’ ἀνθρώπων προσκυνεῖσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ τοῖς ἀλλοτρίοις ἀγαθοῖς ἐπαλαζονευόμενοι παρὰ τοῖς εἰδόσιν αὐτοὺς γέλωτα ὀφλισκάνουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 181 Pb 178 Pg 116 Mb 154 Ca 135.</p>
+          <bibl>Codd. Pa 181 Pb 178 Pg 116 Mb 154 Ca 135.</bibl>
           <p><milestone unit="traduction"/>Un homme, ayant mis une statue de dieu sur le dos d’un âne, le conduisait à la ville. Comme les passants se prosternaient devant la statue, l’âne, s’imaginant que c’était lui qu’on adorait, ne se tint plus d’orgueil ; il se mit à braire et il refusa d’avancer. L’ânier, devinant sa pensée, lui dit en le frappant de son gourdin : « Pauvre cervelle ! il ne manquait plus que cela, de voir un âne adoré des hommes. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ceux qui font vanité des avantages d’autrui prêtent à rire à ceux qui les connaissent.</p>
         </div>
@@ -7392,7 +7391,7 @@
           <pb ed="perry" n="P182"/>
           <p><milestone unit="recitprose"/>Ὄνῳ τις ἐπιθεὶς ξόανον ἦγε· πολλοὶ δὲ προσεκύνουν τῶν συναντώντων. Ὁ δὲ ὄνος τυφωθείς, νομίζων αὐτὸν προσκυνεῖν τοὺς ἀγροίκους, σκιρτῶν ἤμελλε τὸν θεὸν ῥίψειν. Ἀλλὰ τοῦτον ξύλοις παίων ὁ δεσπότης εἶπεν· « Ὄνος εἶ θεὸν φέρων, ἀλλ’ οὐ θεοῖς ὑπάρχεις ὁμότιμος. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] κτηνώδεις ἄνδρας, τοὺς τυφωμένους ἐπ’ ἀλλοτρίαις δόξαις ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 109 Bb 65.</p>
+          <bibl>Codd. Ba 109 Bb 65.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-268">
@@ -7401,7 +7400,7 @@
         <pb ed="perry" n="P188"/>
         <p><milestone unit="recitprose"/>Ὄνος ἐνδυσάμενος λέοντος δορὰν περιῄει ἐκφοϐῶν τὰ ἄλογα ζῷα. Καὶ δὴ θεασάμενος ἀλώπεκα ἐπειρᾶτο καὶ ταύτην δεδίττεσθαι. Ἡ δὲ (ἐτύγχανε γὰρ αὐτοῦ φθεγξαμένου προακηκουῖα) ἔφη πρὸς τὸν ὄνον· « Ἀλλ’ εὖ ἴσθι ὡς καὶ ἐγὼ ἄν σε ἐφοϐήθην, εἰ μὴ ὀγκωμένου ἤκουσα. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀπαιδεύτων τοῖς ἔξωθεν τύφοις δοκοῦντές τινες εἶναι ὑπὸ τῆς ἰδίας γλωσσαλγίας ἐλέγχονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 187 Pb 184 Ma 126 Mb 161 Me 132 Mf 110 Ca 141 La 117 Lb 103 Lc 30 Le 103 Lf 117 Lg 30 Lh 54 Mg 126 Mj 124 Ml 125.</p>
+        <bibl>Codd. Pa 187 Pb 184 Ma 126 Mb 161 Me 132 Mf 110 Ca 141 La 117 Lb 103 Lc 30 Le 103 Lf 117 Lg 30 Lh 54 Mg 126 Mj 124 Ml 125.</bibl>
         <p><milestone unit="traduction"/>Un âne, ayant revêtu une peau de lion, faisait le tour du pays, effrayant les animaux. Il aperçut un renard et voulut l’effrayer aussi. Mais le renard, qui avait justement entendu sa voix auparavant, lui dit : « N’en doute pas, tu m’aurais fait peur à moi aussi, si je ne t’avais pas entendu braire. »</p>
         <p><milestone unit="traduction"/>C’est ainsi que des gens sans éducation, qui, par leurs dehors fastueux, paraissent être quelque chose, se trahissent par leur démangeaison de parler.</p>
       </div>
@@ -7424,7 +7423,7 @@
           <l><milestone unit="recitvers"/>Ὡς οὖν ἑώρα τοῦτον ευθὺς ὁ ὄνος,</l>
           <l><milestone unit="recitvers"/>μετεϐάλλετο καὶ τὸν ἵππον ἠλέει.</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς πλουσίους καὶ ἄρχοντας οὐ δεῖ ζηλοῦν, ἀλλὰ τὸν κατ’ ἐκείνων φθόνον καὶ κίνδυνον ἀναλογιζομένους ἀγαπᾶν χρὴ τὴν πενίαν, ἡσυχίας μητέρα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 24 Ch 99 Ca 151 Ce 90 Cf 95 Mb 150 Mc 79.</p>
+          <bibl>Codd. Cg 24 Ch 99 Ca 151 Ce 90 Cf 95 Mb 150 Mc 79.</bibl>
         </div>
         <div>
           <head>Chambry 269.2</head>
@@ -7432,7 +7431,7 @@
           <pb ed="perry" n="P357"/>
           <p><milestone unit="recitprose"/>Ὄνος ἵππον ἐμακάριζεν, ὡς ἀφθόνως τρεφόμενον καὶ ἐπιμελῶς, αὐτὸς μηδ’ ἀχύρων ἅλις ἔχων, καὶ ταῦτα πλεῖστα ταλαιπωρῶν. Ἐπεὶ δὲ καιρὸς ἐπέστη πολέμου, καὶ ὁ στρατιώτης ἔνοπλος ἀνέϐη τὸν ἵππον, πανταχόσε τοῦτον ἐλαύνων, καὶ δὴ καὶ μέσον τῶν πολεμίων εἰσήλασε, καὶ ὁ ἵππος πληγεὶς ἔκειτο. Ταῦτα ἑωρακὼς ὁ ὄνος τὸν ἵππον μεταϐαλλόμενος ἐταλάνιζεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τοὺς ἄρχοντας καὶ πλουσίους ζηλοῦν, ἀλλὰ τὸν κατ’ ἐκείνων φθόνον καὶ τὸν κίνδυνον ἀναλογιζομένους τὴν πενίαν ἀγαπᾶν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 58 Lb 96 Lc 38 Le 96 Lf 58 Lg 38 Lh 48 Md 116 Me 135 Mf 113 Mg 120 Mi 32 Mj 119 Ml 133 Mm 115.</p>
+          <bibl>Codd. La 58 Lb 96 Lc 38 Le 96 Lf 58 Lg 38 Lh 48 Md 116 Me 135 Mf 113 Mg 120 Mi 32 Mj 119 Ml 133 Mm 115.</bibl>
           <p><milestone unit="traduction"/>L’âne trouvait le cheval heureux d’être nourri dans l’abondance et d’être bien soigné, tandis que lui n’avait même pas de paille en suffisance, alors qu’il était soumis à tant de travaux. Mais vint le temps de la guerre : le cheval dut porter un cavalier armé de pied en cap, et celui-ci le poussa dans tous les sens et le lança même au milieu des ennemis, où le cheval criblé de coups s’abattit. En voyant cela, l’âne changea d’avis et plaignit le cheval.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas envier les chefs ni les riches, mais penser à l’envie et aux dangers où ils sont en butte, et se résigner à la pauvreté.</p>
         </div>
@@ -7442,7 +7441,7 @@
           <pb ed="perry" n="P357"/>
           <p><milestone unit="recitprose"/>Ὄνος τὸν ἵππον ἐμακάριζε διὰ τὴν τροφὴν καὶ τὴν θεραπείαν· ἑαυτὸν δὲ ἐταλάνιζε καὶ τὴν ἑαυτοῦ τύχην, ὅτι ἀχθοφορεῖ καὶ ὀλίγη αὐτῷ ἐστιν ἡ τροφή, ὁ δὲ ἵππος κεκοσμημένος τῷ χαλινῷ καὶ προμετωπιδίοις, καὶ κοῦφος αὐτῷ ὁ δρόμος. Ταῦτα τοῦ ὄνου λογιζομένου, ἐπέστη πολέμου καιρός· καὶ ὁ στρατιώτης μετὰ τῶν ὅπλων ἐπέϐη τοῦ ἵππου, καὶ μέσον τῶν πολεμίων εἰσίει· καὶ ὁ ἵππος μέσος τοῖς ξίφεσιν ἔκειτο τραυματίας καὶ ψυχορραγῶν. Μετεϐάλλετο δὲ τὴν γνώμην ὁ ὄνος καὶ τὸν ἵππον ἠλέησεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς πλουσίους καὶ τοὺς ἐν ταῖς ἀρχαῖς οὐ δεῖ ζηλοῦν, ἀλλὰ τὸν κατ’ ἐκείνους φθόνον καὶ κίνδυνον λογισαμένους ἀγαπᾶν πενίαν, ἡσυχίας μητέρα.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 103.</p>
+          <bibl>Cod. Ba 103.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-270">
@@ -7453,7 +7452,7 @@
           <pb ed="perry" n="P82"/>
           <p><milestone unit="recitprose"/>Ἔν τινι ἐπαύλει ὄνος καὶ ἀλεκτρυὼν ἦσαν. Λέων δὲ λιμώττων, ὡς ἐθεάσατο τὸν ὄνον, οἷός τε ἦν εἰσελθὼν καταθοινήσασθαι. Παρὰ δὲ τὸν ψόφον τοῦ ἀλεκτρυόνος φθεγξαμένου καταπτήξας (φασὶ γὰρ πτύρεσθαι τοὺς λέοντας πρὸς τὰς τῶν ἀλεκτρυόνων φωνάς) εἰς φύγην ἐτράπη. Καὶ ὁ ὄνος ἀναπτερωθεὶς κατ’ αὐτοῦ, εἴγε ἀλεκτρυόνα ἐφοϐήθη, ἐξῆλθεν ὡς ἀποδιώξων αὐτόν. Ὁ δέ, ὡς μακρὰν ἐγένετο, κατέφαγεν αὐτόν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ἔνιοι ταπεινουμένους τοὺς αὑτῶν ἐχθροὺς ὁρῶντες καὶ διὰ τοῦτο καταθρασυνόμενοι λανθάνουσιν ὑπ’ αὐτῶν ἀναλισκόμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 79 Pb 83 Pf 41 Pg 53 Ph 43 Ma 62 Mb 48 Me 61 Mf 55 Ca 70.</p>
+          <bibl>Codd. Pa 79 Pb 83 Pf 41 Pg 53 Ph 43 Ma 62 Mb 48 Me 61 Mf 55 Ca 70.</bibl>
         </div>
         <div>
           <head>Chambry 270.2</head>
@@ -7461,7 +7460,7 @@
           <pb ed="perry" n="P82"/>
           <p><milestone unit="recitprose"/>Ἔν τινι ἐπαύλει ὄνος καὶ ἀλέκτωρ ἦσαν. Λέων δὲ λιμώττων, ὡς ἐθεάσατο τὸν ὄνον, οἷός τε ἦν εἰσελθὼν καταθοινήσασθαι. Καὶ τοῦ ἀλέκτορος φθεγξαμένου πρὸς τὸν λέοντα, ὅτι τὰς φωνὰς τῶν ἀλεκτρυόνων τοὺς λέοντας ἀκούοντάς φασι πτύρεσθαι, τοῦ δὲ λέοντος προσποιουμένου εἰς φυγὴν τραπῆναι, ὁ ὄνος καταπηδήσας κατὰ τοῦ λέοντος ἐξῆλθεν ὡς ἀποδιώξων αὐτόν. Ὡς δὲ μακρὰν ἐγένετο ὀπίσω αὐτοῦ, ἐπιστραφεὶς ὁ λέων κατέφαγεν αὐτόν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως καὶ οἱ τῶν ἀνθρώπων παῖδες τεταπεινωμένους τοὺς ἐχθροὺς ὁρῶντες καὶ αὐτοὶ θρασυνόμενοι λανθάνονται ὑπ’ αὐτῶν ἁλισκόμενοι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pe 47.</p>
+          <bibl>Cod. Pe 47.</bibl>
         </div>
         <div>
           <head>Chambry 270.3</head>
@@ -7469,7 +7468,7 @@
           <pb ed="perry" n="P82"/>
           <p><milestone unit="recitprose"/>Ὄνῳ ποτὲ ἀλεκτρυὼν συνεϐόσκετο. Λέοντος δ’ ἐπελθόντος τῷ ὄνῳ, ὁ ἀλεκτρυὼν ἐφώνησε· καὶ ὁ μὲν λέων (φασὶ γὰρ τοῦτον τὴν τοῦ ἀλεκτρυόνος φωνὴν φοϐεῖσθαι) ἔφυγεν. Ὁ δ’ ὄνος, νομίσας δι’ αὑτὸν πεφευγέναι, ἐπέδραμεν εὐθὺς τῷ λέοντι. Ὡς δὲ πόρρω τοῦτον ἐδίωξεν, ἔνθα μηκέτι ἡ τοῦ ἀλεκτρυόνος ἐφικνεῖτο φωνή, στραφεὶς ὁ λέων τοῦτον κατεθοινήσατο. Ὁ δὲ θνῄσκων ἐϐόα· « Ἄθλιος ἐγὼ καὶ ἀνόητος· πολεμιστῶν γὰρ μὴ ὢν γονέων, τίνος χάριν εἰς πόλεμον ἐξωρμήθην ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ τῶν ἀνθρώπων ταπεινουμένοις ἐπίτηδες τοῖς ἐχθροῖς ἐπιτίθενται, καὶ οὕτως ὑπ’ ἐκείνων ἀπόλλυνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 66 Lb 97 Lc 47 Le 97 Lf 66 Lg 47 Lh 49 Md 120 Me 134 Mf 112 Mg 121 Mi 94 Mj 120 Ml 135 Mm 116.</p>
+          <bibl>Codd. La 66 Lb 97 Lc 47 Le 97 Lf 66 Lg 47 Lh 49 Md 120 Me 134 Mf 112 Mg 121 Mi 94 Mj 120 Ml 135 Mm 116.</bibl>
           <p><milestone unit="traduction"/>Un coq paissait un jour en compagnie d’un âne. Comme un lion marchait sur l’âne, le coq poussa un cri, et le lion (on dit en effet qu’il a peur de la voix du coq) prit la fuite. L’âne, s’imaginant que, si le lion fuyait, c’était à cause de lui, n’hésita pas à lui courir sus. Quand il l’eut poursuivi jusqu’à une distance où la voix du coq n’arrivait plus, le lion se retourna et le dévora. Et lui disait en mourant : « Malheureux et insensé que je suis ! n’étant pas né de parents guerriers, pourquoi suis-je parti en guerre ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent on attaque un ennemi qui se fait petit à dessein et qu’on se fait ainsi tuer par lui.</p>
         </div>
@@ -7480,7 +7479,7 @@
         <pb ed="perry" n="P191"/>
         <p><milestone unit="recitprose"/>Ὄνος καὶ ἀλώπηξ κοινωνίαν συνθέμενοι πρὸς ἀλλήλους ἐξῆλθον ἐπὶ ἄγραν. Λέοντος δὲ περιτυχόντος αὐτοῖς, ἡ ἀλώπηξ ὁρῶσα τὸν ἐπηρτημένον κίνδυνον, προσελθοῦσα τῷ λέοντι, ὑπέσχετο παραδώσειν αὐτῷ τὸν ὄνον, ἐὰν αὐτῇ τὸ ἀκίνδυνον ἐπαγγείληται. Τοῦ δὲ αὐτὴν ἀπολύσειν φήσαντος, προσαγαγοῦσα τὸν ὄνον εἴς τινα πάγην ἐμπεσεῖν παρεσκεύασε. Καὶ ὁ λέων ὁρῶν ἐκεῖνον φεύγειν μὴ δυνάμενον, πρῶτον τὴν ἀλώπεκα συνέλαϐεν, εἶθ’ οὕτως ἐπὶ τὸν ὄνον ἐτράπη.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοῖς κοινωνοῖς ἐπιϐουλεύοντες λανθάνουσι πολλάκις καὶ ἑαυτοὺς συναπολλύντες.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 191 Pb 187 Pc 105 Pf 103 Pg 120 Mb 166 Me 130 Ca 144 La 120 Lb 106 Le 106 Lf 120 Lh 57 Mg 129 Mj 127 Ml 130.</p>
+        <bibl>Codd. Pa 191 Pb 187 Pc 105 Pf 103 Pg 120 Mb 166 Me 130 Ca 144 La 120 Lb 106 Le 106 Lf 120 Lh 57 Mg 129 Mj 127 Ml 130.</bibl>
         <p><milestone unit="traduction"/>Un âne et un renard, ayant lié société, sortirent pour chasser. Un lion se trouva sur leur chemin. Voyant le danger suspendu sur eux, le renard s’approcha du lion et s’engagea à lui livrer l’âne, si’l lui promettait la sûreté. Le lion ayant déclaré qu’il le laisserait aller, le renard amena l’âne dans un piège où il le fit tomber. Le lion, voyant que l’âne ne pouvait s’échapper, saisit d’abord le renard, et se tourna ensuite vers l’âne.</p>
         <p><milestone unit="traduction"/>Pareillement ceux qui tendent des pièges à leurs associés se perdent souvent inconsciemment avec leurs victimes.</p>
       </div>
@@ -7490,7 +7489,7 @@
         <pb ed="perry" n="P189"/>
         <p><milestone unit="recitprose"/>Ὄνος ξύλων γόμον φέρων λίμνην διέϐαινεν· ὀλισθὼν δέ, ὡς κατέπεσεν, ἐξαναστῆναι μὴ δυνάμενος ὠδύρετό τε καὶ ἔστενεν. Οἱ δὲ ἐν τῇ λίμνῃ βάτραχοι ἀκούσαντες αὐτοῦ τῶν στεναγμῶν ἔφασαν· « Ὦ οὗτος, καὶ τί ἂν ἐποίησας, εἰ τοσοῦτον ἐνταῦθα χρόνον διέτριϐες ὅσον ἡμεῖς, ὅτε πρὸς ὀλίγον πεσὼν οὕτως ὀδύρῃ ; »</p>
         <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα ῥᾴθυμον ἐπ’ ἐλαχίστοις πόνοις δυσφοροῦντα, αὐτὸς τοὺς πλείονας ῥᾳδίως ὑφιστάμενος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 189 Pb 185 Pg 119 Mb 163 Ca 142 La 118 Lb 104 Le 104 Lf 118 Lh 55 Me 133 Mf 111 Mg 127 Mj 125 Ml 127.</p>
+        <bibl>Codd. Pa 189 Pb 185 Pg 119 Mb 163 Ca 142 La 118 Lb 104 Le 104 Lf 118 Lh 55 Me 133 Mf 111 Mg 127 Mj 125 Ml 127.</bibl>
         <p><milestone unit="traduction"/>Un âne portant une charge de bois traversait un marais. Il glissa et tomba, et, ne pouvant se relever, il se mit à gémir et à se lamenter. Les grenouilles du marais, ayant entendu ses gémissements, lui dirent : « Hé, l’ami ! qu’aurais-tu fait, si tu étais resté ici aussi longtemps que nous, toi qui, tombé ici pour un moment, pousses de pareils soupirs ? »</p>
         <p><milestone unit="traduction"/>Nous pourrions appliquer cette fable à un homme efféminé qui s’impatiente des moindres peines, alors que nous-mêmes, nous supportons facilement des maux plus grands.</p>
       </div>
@@ -7500,7 +7499,7 @@
         <pb ed="perry" n="P263"/>
         <p><milestone unit="recitprose"/>Ὄνος καὶ ἡμίονος ἐν ταὐτῷ ἐϐάδιζον. Καὶ δὴ ὁ ὄνος ὁρῶν τοὺς ἀμφοῖν γόμους ἴσους ὄντας ἠγανάκτει καὶ ἐσχετλίαζεν, εἴγε διπλασίονος τροφῆς ἠξιωμένη ἡ ἡμίονος οὐδὲν περιττότερον βαστάζει. Μικρὸν δὲ αὐτῶν τῆς ὁδοῦ προϊόντων, ὁ ὀνηλάτης ὁρῶν τὸν ὄνον ἀντέχειν μὴ δυνάμενον, ἀφελόμενος αὐτοῦ τὸ φορτίον τῇ ἡμιόνῳ ἐπέθηκεν. Ἔτι δὲ αὐτῶν πόρρω προϐαινόντων, ὁρῶν ἔτι μᾶλλον ἀποκάμνοντα, πάλιν ἀπὸ τοῦ γόμου μετετίθει, μέχρι τὰ πάντα λαϐὼν καὶ ἀφελόμενος ἀπ’ αὐτοῦ τῇ ἡμιόνῳ ἐπέθηκε. Καὶ τότε ἐκείνη ἀποϐλέψασα εἰς τὸν ὄνον εἶπεν· « Ὦ οὗτος, ἆρά σοι οὐ δοκῶ δικαίως τῆς διπλῆς τροφῆς ἀξιωθῆναι ; »</p>
         <p><milestone unit="epimythiumprose"/>Ἀτὰρ οὖν καὶ ἡμᾶς προσήκει μὴ ἀπὸ τῆς ἀρχῆς, ἀλλ’ ἀπὸ τοῦ τέλους τὴν ἑκάστου δοκιμάζειν διάθεσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 192 Mb 167.</p>
+        <bibl>Codd. Pa 192 Mb 167.</bibl>
         <p><milestone unit="traduction"/>Un âne et un mulet cheminaient ensemble. Or l’âne, voyant que leurs charges à tous deux étaient égales, s’indignait et se plaignait que le mulet, jugé digne d’une double ration, ne portât pas plus que lui. Mais, quand ils eurent fait un peu de chemin, l’ânier s’apercevant que l’âne n’en pouvait plus, lui ôta une partie de sa charge et la mit et la mit sur le mulet. Quand ils eurent fait encore un bout de chemin, voyant l’âne encore plus épuisé, il lui retira une autre partie de sa charge, et enfin prenant le reste, il l’ôta à l’âne et le fit passer sur le mulet. Alors celui-ci tournant les yeux vers son camarade lui dit : « Eh bien ! mon ami, ne trouves-tu pas juste qu’on m’honore d’une double ration ? »</p>
         <p><milestone unit="traduction"/>Nous aussi, ce n’est point par le commencement, mais par la fin que nous devons juger de la condition de chacun.</p>
       </div>
@@ -7512,7 +7511,7 @@
           <pb ed="perry" n="P179"/>
           <p><milestone unit="recitprose"/>Ὄνος κηπουρῷ δουλεύων, ἐπειδὴ ὀλίγα μὲν ἤσθιε, πολλὰ δὲ ἐκακοπάθει, ηὔξατο τῷ Διὶ ὅπως τοῦ κηπουροῦ αὐτὸν ἀπαλλάξας ἑτέρῳ δεσπότῃ ἐγχειρίσῃ. Ὁ δὲ Ἑρμῆν πέμψας ἐκέλευσε κεραμεῖ αὐτὸν πωλῆσαι. Πάλιν δὲ αὐτοῦ δυσφοροῦντος, ἐπειδὴ καὶ πολλῷ πλείονα ἀχθοφορεῖν ἠναγκάζετο, καὶ τὸν Δία ἐπικαλουμένου, τὸ τελευταῖον ὁ Ζεὺς παρεσκεύασεν αὐτὸν βυρσοδέψῃ πραθῆναι. Καὶ ὁ ὄνος ἰδὼν τὰ ὑπὸ τοῦ δεσπότου πραττόμενα, ἔφη· « Ἀλλ’ ἔμοιγε αἱρετώτερον ἦν παρὰ τοῖς προτέροις δεσπόταις ἀχθοφοροῦντα λιμώττειν ἢ ἐνταῦθα παραγενέσθαι, ὅπου, ἐὰν ἀποθάνω, οὐδὲ ταφῆς ἀξιωθήσομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τότε μάλιστα τοὺς πρώτους δεσπότας οἱ οἰκέται ποθοῦσιν, ὅταν καὶ ἑτέρων πεῖραν λάϐωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 178 Pb 175 Pd 37 Pf 98 Pg 114 Mb 151 Me 125 Mf 105.</p>
+          <bibl>Codd. Pa 178 Pb 175 Pd 37 Pf 98 Pg 114 Mb 151 Me 125 Mf 105.</bibl>
         </div>
         <div>
           <head>Chambry 274.2</head>
@@ -7520,7 +7519,7 @@
           <pb ed="perry" n="P179"/>
           <p><milestone unit="recitprose"/>Ὄνος κηπωρῷ δουλεύων, ἐπειδὴ ὀλίγα μὲν ἤσθιε, πολλὰ δὲ ἐκακοπάθει, ηὔξατο τῷ Διὶ ὅπως τοῦ κηπωροῦ αὐτὸν ἀπαλλάξει, καὶ ἑτέρῳ δεσπότῃ αὐτὸν ἐκδώσει. Ὁ δὲ Ζεὺς ἐκέλευσεν εἰς κεραμέα πωλῆσαι. Πάλιν δὲ αὐτοῦ δυσφοροῦντος, ἐπειδὴ πολὺ πλέον ἀχθοφορεῖν ἠναγκάζετο ἐν τῷ πηλῷ καὶ τῇ πλινθείᾳ, πάλιν τὸν Δία παρεκάλει. Ὁ δὲ Ζεὺς παρεσκεύασε πραθῆναι αὐτὸν εἰς βυρσοδέψην. Ὁ δὲ ὄνος εἰς χείρονα δεσπότην ἐμπεσὼν καὶ ὁρῶν τὰ παρ’ αὐτοῦ πραττόμενα ἔφη μετὰ στεναγμοῦ· « Οὐαί μοι τῷ τάλανι· αἱρετώτερον ἦν μοι παρ’ ἐκείνοις τοῖς δεσπόταις εἶναι, ἐπεὶ οὗτος, ὡς ὁρῶ, καὶ τὸ δέρμα μου μέλλει ἀνελεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι μάλιστα τοὺς πρώτους δεσπότας τότε ποθοῦσιν οἱ οἰκέται, ὅταν πεῖραν λάϐωσιν ἑτέρων.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 132 Cb 79 Ce 86 Cf 91 Cg 21 Ch 96 Mc 77.</p>
+          <bibl>Codd. Ca 132 Cb 79 Ce 86 Cf 91 Cg 21 Ch 96 Mc 77.</bibl>
         </div>
         <div>
           <head>Chambry 274.3</head>
@@ -7528,7 +7527,7 @@
           <pb ed="perry" n="P179"/>
           <p><milestone unit="recitprose"/>Ὄνος ὑπηρετούμενος κηπωρῷ, ἐπειδὴ ὀλίγα μὲν ἤσθιε, πλεῖστα δ’ ἐμόχθει, ηὔξατο τῷ Διὶ ὥστε τοῦ κηπωροῦ ἀπαλλαγεὶς ἑτέρῳ ἀπεμποληθῆναι δεσπότῃ. Τοῦ δὲ Διὸς ἐπακούσαντος καὶ κελεύσαντος αὐτὸν κεραμεῖ πραθῆναι, πάλιν ἐδυσφόρει, πλέον ἢ πρότερον ἀχθοφορῶν καὶ τόν τε πηλὸν καὶ τοὺς κεράμους κομίζων. Πάλιν οὖν ἀμεῖψαι τὸν δεσπότην ἱκέτευε, καὶ βυρσοδέψῃ ἀπεμπολεῖται. Εἰς χείρονα τοίνυν τῶν προτέρων δεσπότην ἐμπεσὼν καὶ ὁρῶν τὰ παρ’ αὐτοῦ πραττόμενα, μετὰ στεναγμῶν ἔφη· « Οἴμοι τῷ ταλαιπωρῷ, βέλτιον ἦν μοι παρὰ τοῖς προτέροις δεσπόταις μένειν· οὗτος γάρ, ὡς ὁρῶ, καὶ τὸ δέρμα μου κατεργάσεται. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τότε μάλιστα τοὺς προτέρους δεσπότας οἱ οἰκέται ποθοῦσιν, ὅταν τῶν δευτέρων λάϐωσι πεῖραν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 45 Lb 91 Lc 46 Le 91 Lf 45 Lg 46 Lh 46 Md 94 Mg 116 Mi 10 Mj 115 Ml 121 Mm 112.</p>
+          <bibl>Codd. La 45 Lb 91 Lc 46 Le 91 Lf 45 Lg 46 Lh 46 Md 94 Mg 116 Mi 10 Mj 115 Ml 121 Mm 112.</bibl>
           <p><milestone unit="traduction"/>Un âne était au service d’un jardinier. Comme il mangeait peu, tout en travaillant beaucoup, il pria Jupiter de le délivrer du jardinier et de le faire vendre à un autre maître. Zeus l’exauça et le fit vendre à un potier. Mais il fut de nouveau mécontent, parce qu’on le chargeait davantage et qu’on lui faisait porter l’argile et la poterie. Aussi demanda-t-il encore une fois à changer de maître, et il fut vendu à un corroyeur. Il tomba ainsi sur un maître pire que les autres. En voyant quel métier faisait ce maître, il dit en soupirant : « Hélas ! malheureux que je suis ! j’aurais mieux fait de rester chez mes premiers maîtres ; car celui-ci, à ce que je vois, tannera aussi ma peau.</p>
         </div>
         <div>
@@ -7552,7 +7551,7 @@
           <l><milestone unit="recitvers"/>ὁρῶ γὰρ τοῦτον δεψήσειν μου τὸ δέρμα. »</l>
           <l><milestone unit="recitvers"/>Ποθοῦσι δεσπότας οἱ οἰκέται τοὺς πρώτους,</l>
           <l><milestone unit="recitvers"/>ὅταν πεῖραν καὶ δοκιμὴν λάϐωσι τῶν μετὰ ταῦτα.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 95.</p>
+          <bibl>Cod. Cd 95.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-275">
@@ -7561,7 +7560,7 @@
         <pb ed="perry" n="P190"/>
         <p><milestone unit="recitprose"/>Ὄνος ἡλκωμένος τὸν νῶτον ἔν τινι λειμῶνι ἐνέμετο. Κόρακος δὲ ἐπικαθίσαντος αὐτῷ καὶ τὸ ἕλκος κρούοντος, ὁ ὄνος ἀλγῶν ὠγκᾶτό τε καὶ ἐσκίρτα. Τοῦ δὲ ὀνηλάτου πόρρωθεν ἑστῶτος καὶ γελῶντος, λύκος παριὼν ἐθεάσατο καὶ πρὸς ἑαυτὸν ἔφη· « Ἄθλιοι ἡμεῖς, οἵ, κἂν αὐτὸ μόνον ὀφθῶμεν, διωκόμεθα, τούτους δὲ καὶ προσιόντας προσγελῶσιν. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ κακοῦργοι τῶν ἀνθρώπων καὶ ἐξ αὐτῶν τῶν προσώπων καὶ ἐξ ἀπροόπτου δῆλοί εἰσιν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 190 Pb 186 Pf 102 Mb 164 Me 129 Mf 108 Ca 143 La 119 Lb 105 Le 105 Lf 119 Lh 56 Mg 128 Mj 126 Ml 129.</p>
+        <bibl>Codd. Pa 190 Pb 186 Pf 102 Mb 164 Me 129 Mf 108 Ca 143 La 119 Lb 105 Le 105 Lf 119 Lh 56 Mg 128 Mj 126 Ml 129.</bibl>
         <p><milestone unit="traduction"/>Un âne, qui avait une plaie au dos, paissait dans une prairie. Un corbeau se posa sur lui et piqua sa plaie à coups de bec. L’âne sous l’impression de la douleur se mit à braire et à sauter. L’ânier, qui était à quelque distance, éclata de rire. Un loup qui passait le vit et se dit à lui-même : « Malheureux que nous sommes ! il suffit qu’on nous aperçoive, pour qu’on nous donne la chasse ; mais que ceux-ci osent s’approcher, on leur fait risette. »</p>
         <p><milestone unit="traduction"/>Cette fable fait voir que les gens malfaisants se reconnaissent à leur mine même et à première vue.</p>
       </div>
@@ -7573,7 +7572,7 @@
           <pb ed="perry" n="P91"/>
           <p><milestone unit="recitprose"/>Ἔχων τις κύνα Μελιταῖον καὶ ὄνον διετέλει ἀεὶ τῷ κυνὶ προσπαίζων· καὶ δή, εἴ ποτε ἔξω ἐδείπνει, διεκόμιζέ τι αὐτῷ, καὶ προσιόντι καὶ σαίνοντι παρέϐαλλεν. Ὁ δὲ ὄνος φθονήσας προσέδραμε καὶ σκιρτῶν ἐλάκτιζεν αὐτόν. Καὶ ὃς ἀγανακτήσας ἐκέλευσε παίοντας αὐτὸν ἀπαγαγεῖν καὶ τῇ φάτνῃ προσδῆσαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ πάντες πρὸς πάντα πεφύκασιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 87 Pb 92 Pc 47 Pe 54 Ma 67.</p>
+          <bibl>Codd. Pa 87 Pb 92 Pc 47 Pe 54 Ma 67.</bibl>
           <p><milestone unit="traduction"/>Un homme qui avait un chien de Malte et un âne jouait constamment avec le chien. Allait-il dîner dehors, il lui rapportait quelque friandise, et, quand le chien s’approchait la queue frétillante, il la lui jetait. Jaloux, l’âne accourut vers le maître, et se mettant à gambader, il l’atteignit d’un coup de pied. Le maître en colère le fit reconduire à coups de bâton et attacher au râtelier.</p>
           <p><milestone unit="traduction"/>Cette fable montre que tous ne sont pas faits pour les mêmes choses.</p>
         </div>
@@ -7606,7 +7605,7 @@
           <l><milestone unit="recitvers"/>τί γὰρ παρ’ οὐρηέσι οὐκ ἐπολεύμην,</l>
           <l><milestone unit="recitvers"/>βαιῷ δ’ ὁ μέλεος κυνὶ παρισούμην ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ πάντες πρὸς πάντα ἴσοι πεφύκασι, κἂν φθόνῳ ἀλαζονεύωνται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 138.</p>
+          <bibl>Cod. Mb 138.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-277">
@@ -7614,7 +7613,7 @@
         <head type="sub">Ὄνος καὶ κύων συνοδοιποροῦντες — L’âne et le chien voyageant de compagnie.</head>
         <pb ed="perry" n="P264"/>
         <p><milestone unit="recitprose"/>Ὄνος καὶ κύων ἐν ταὐτῷ ὡδοιπόρουν. Εὑρόντες δὲ ἐπὶ γῆς ἐσφραγισμένον γραμμάτιον, ὁ ὄνος λαϐὼν καὶ ἀναρρήξας τὴν σφραγῖδα καὶ ἀναπτύξας, διεξῄει εἰς ἐπήκοον τοῦ κυνός. Περὶ βοσκημάτων δὲ ἐτύγχανε τὰ γράμματα χόρτου τε, φημί, καὶ κριθῆς καὶ ἀχύρου. Ἀηδῶς οὖν ὁ κύων, τοῦ ὄνου ταῦτα διεξιόντος, διέκειτο· ἔνθεν δὴ καὶ ἔφησε τῷ ὄνῳ· « Ὑπόϐαθι, φίλτατε, μικρόν, μή τι καὶ περὶ κρεῶν καὶ ὀστέων εὕρῃς διαλαμϐάνων. » Ὁ δὲ ὄνος ἅπαν τὸ γραμμάτιον διεξελθὼν καὶ μηδὲν εὑρηκὼς ὧν ὁ κύων ἐζήτει, ἀντέφησεν αὖθις ὁ κύων· « Βάλε κατὰ γῆς, ὡς ἀδόκιμον πάντη, φίλε, τυγχάνον. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 173.</p>
+        <bibl>Cod. Mb 173.</bibl>
         <p><milestone unit="traduction"/>Un âne et un chien faisaient route ensemble. Ils trouvèrent à terre une lettre cachetée. L’âne la ramassa, rompit le sceau, l’ouvrit et la lut de manière à être entendu du chien. Il y était question de pâture, je veux dire de foi, d’orge et de paille. Le chien s’ennuyait pendant la lecture de l’âne ; aussi lui dit-il : « Descends de quelques lignes, très cher ; peut-être trouveras-tu dans la suite quelque chose qui se rapporte à la viande et aux os. » L’âne ayant parcouru tout l’écrit, sans rien trouver de ce que le chien cherchait, celui-ci reprit la parole : « Jette ce papier à terre, ami ; car il est tout à fait insignifiant. »</p>
       </div>
       <div type="poem" xml:id="chambry-278">
@@ -7625,7 +7624,7 @@
           <pb ed="perry" n="P186"/>
           <p><milestone unit="recitprose"/>Ὄνος ὑπὸ ὀνηλάτου ἀγόμενος, ὡς μικρὸν τῆς ὁδοῦ προῆλθεν, ἀφεὶς τὴν λείαν ἀτραπὸν διὰ κρημνῶν ἐφέρετο. Μέλλοντος δὲ αὐτοῦ κατακρημνίζεσθαι, ὁ ὀνηλάτης ἐπιλαϐόμενος τῆς οὐρᾶς, ἐπειρᾶτο μεταπεριάγειν αὐτόν. Τοῦ δὲ εὐτόνως ἀντιπίπτοντος, ἀφεὶς αὐτὸν ἔφη· « Νίκα· κακὴν γὰρ νίκην νικᾷς. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα φιλόνεικον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 185 Pb 182 Mb 159 Ca 139.</p>
+          <bibl>Codd. Pa 185 Pb 182 Mb 159 Ca 139.</bibl>
           <p><milestone unit="traduction"/>Un âne conduit par un ânier, après avoir fait un peu de chemin, quitta la route unie et prit à travers des lieux escarpés. Comme il allait tomber dans un précipice, l’ânier, le saisissant par la queue, essaya de le faire retourner ; mais comme l’âne tirait vigoureusement en sens inverse, l’ânier le lâcha et dit : « Je te cède la victoire : car c’est une mauvaise victoire que tu remportes. »</p>
           <p><milestone unit="traduction"/>La fable s’applique au querelleur.</p>
         </div>
@@ -7635,7 +7634,7 @@
           <pb ed="perry" n="P186"/>
           <p><milestone unit="recitprose"/>Ὄνος πλατείας ὁδοῦ ἐκτραπεὶς ἐπὶ κρημνὸν ἐφέρετο. Τοῦ δὲ ὀνηλάτου ἐπιϐοῶντος· « Ἄθλιε, ποῦ φέρει ; » καὶ τῆς οὐρᾶς ἐπιλαϐομένου καὶ ἕλκοντος πρὸς ἑαυτόν, τῆς εἰς τὰ πρόσω φορᾶς ὁ ὄνος οὐχ ἵστατο. Ὁ δὲ ἔτι μᾶλλον ὠθήσας αὐτὸν ἔφη· « Ὕπαγε, νίκα τὴν κακὴν νίκην ἐν τῷ ἀναθέματι. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς ἀπολλυμένους οἰκείᾳ ἀφροσύνῃ ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 107.</p>
+          <bibl>Cod. Ba 107.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-279">
@@ -7646,7 +7645,7 @@
           <pb ed="perry" n="P184"/>
           <p><milestone unit="recitprose"/>Ὄνος ἀκούσας τεττίγων ᾀδόντων [ἥσθη ἐπὶ τῇ εὐφωνίᾳ] καὶ ζηλώσας αὐτῶν τὴν εὐφωνίαν ἐπυνθάνετο τί σιτούμενοι τοιαύτην φωνὴν ἀφιᾶσι. Τῶν δὲ εἰπόντων· « Δρόσον, » ὁ ὄνος προσμένων δρόσον λιμῷ διεφθάρη.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ οἱ τῶν παρὰ φύσιν ἐπιθυμοῦντες πρὸς τῷ μὴ ἐφικνεῖσθαι καὶ τὰ μέγιστα δυστυχοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 183 Pf 100 Ma 125 Mb 157 Me 127 Mf 107 Ca 137.</p>
+          <bibl>Codd. Pa 183 Pf 100 Ma 125 Mb 157 Me 127 Mf 107 Ca 137.</bibl>
           <p><milestone unit="traduction"/>Un âne, ayant entendu chanter des cigales, fut charmé de leur voix harmonieuse et leur envia leur talent. « Que mangez-vous, leur demanda-t-il, pour faire entendre un tel chant ? – De la rosée, » dirent-elles. Dès lors l’âne attendit la rosée, et mourut de faim.</p>
           <p><milestone unit="traduction"/>Ainsi, quand on a des désirs contraires à la nature, non seulement on n’arrive pas à les satisfaire, mais encore on encourt les plus grands malheurs.</p>
         </div>
@@ -7656,7 +7655,7 @@
           <pb ed="perry" n="P184"/>
           <p><milestone unit="recitprose"/>Ὄνος ἀκούσας τεττίγων ᾀδόντων ἥσθη ἐπὶ τῇ εὐφωνίᾳ καὶ ζηλώσας αὐτῶν τὴν φωνὴν ἐπελάθετο καὶ τῆς οἰκείας φωνῆς.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τῶν παρὰ φύσιν ἐπιθυμοῦντες καὶ ἃ ἔχουσι δυστυχοῦσι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pb 180.</p>
+          <bibl>Cod. Pb 180.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-280">
@@ -7667,7 +7666,7 @@
           <pb ed="perry" n="P358"/>
           <p><milestone unit="recitprose"/>Ὄνος δορὰν λέοντος ἐπενδυθεὶς λέων ἐνομίζετο πᾶσιν, καὶ φυγὴ μὲν ἦν ἀνθρώπων, φυγὴ δὲ ποιμνίων. Ὡς δὲ ἀνέμου πνεύσαντος ἡ δορὰ περιῃρέθη καὶ γυμνὸς ὁ ὄνος ἦν, τότε δὴ πάντες ἐπιδραμόντες ξύλοις καὶ ῥοπάλοις αὐτὸν ἔπαιον.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πένης καὶ ἰδιώτης ὢν μὴ μιμοῦ τὰ τῶν πλουσίων, μή ποτε κατεγελασθῇς καὶ κινδυνεύσῃς· τὸ γὰρ ξένον ἀνοίκειον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 99 Bb 61 Md 87 Mh 79 Mi 3 Mm 105 Lc 31 Lg 31.</p>
+          <bibl>Codd. Ba 99 Bb 61 Md 87 Mh 79 Mi 3 Mm 105 Lc 31 Lg 31.</bibl>
           <p><milestone unit="traduction"/>Un âne revêtu d’une peau de lion passait aux yeux de tous pour un lion et il faisait fuir les hommes, il faisait fuir les bêtes. Mais le vent, ayant soufflé, enleva la peau, et l’âne resta nu. Alors tout le monde lui courut sus et le frappa à coups de bâton et de massue.</p>
           <p><milestone unit="traduction"/>Es-tu pauvre et simple particulier, ne prends pas modèle sur les riches : ce serait t’exposer au ridicule et au danger ; car nous ne pouvons nous approprier ce qui nous est étranger.</p>
         </div>
@@ -7677,7 +7676,7 @@
           <pb ed="perry" n="P358"/>
           <p><milestone unit="recitprose"/>Ὄνος ἐπεθύμει λέων εἶναι δοκεῖν. Καὶ μεταθεῖναι τὴν φύσιν οὐκ ἔχων ἐπὶ τοῦ σχήματος ἀνεπλήρου τὸν πόθον, καὶ λεοντῆν περικείμενος, οἷα λέων τοὺς τῶν γεωργῶν ἐλυμαίνετο πόνους. Καὶ πνεύσας βιαιότερος ἄνεμος γυμνοῖ μὲν αὐτὸν τοῦ προκαλύμματος, φανέντα δὲ ὄνον ῥοπάλοις ἀνῄρουν ὧν τοὺς πόνους κατήσθιεν.</p>
           <p><milestone unit="epimythiumprose"/>Κόσμος ἐπείσακτος τοῖς χρωμένοις γίνεται κίνδυνος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 172.</p>
+          <bibl>Cod. Mb 172.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-281">
@@ -7688,7 +7687,7 @@
           <pb ed="perry" n="P360"/>
           <p><milestone unit="recitprose"/>Ὄνος ἀκανθώδεις παλιούρους ἤσθιε. Τοῦτον δὲ ἰδοῦσα ἀλώπηξ εἶπεν· « Πῶς οὕτω τῇ ἁπαλῇ γλώσσῃ τὸ σκληρὸν καὶ ἀκανθῶδες προσφάγιον ἐσθίεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ φλυάρων ἀνδρῶν κατηγορίας ἀκούειν· εἰς κίνδυνον γὰρ ἄγουσι τὸν ἀκούοντα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 108 Bb 66.</p>
+          <bibl>Codd. Ba 108 Bb 66.</bibl>
         </div>
         <div>
           <head>Chambry 281.2</head>
@@ -7699,7 +7698,7 @@
           <l><milestone unit="recitvers"/>« Πῶς οὕτως ἁπαλῇ καὶ ἀνειμένῃ γλώσσῃ</l>
           <l><milestone unit="recitvers"/>σκληρὸν μαλάσσεις προσφάγημα καὶ τρώγεις ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τοὺς σκληροὺς καὶ ἐπικινδύνους προφέροντας διὰ γλώσσης λόγους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 143.</p>
+          <bibl>Cod. Mb 143.</bibl>
           <p><milestone unit="traduction"/>Un âne broutait la chevelure piquante d’un paliure. Un renard l’ayant aperçu lui adressa ces railleuses paroles : « Comment avec une langue si tendre et si molle peux-tu mâcher et manger un mets si dur ? »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse à ceux dont la langue profère des propos durs et dangereux.</p>
         </div>
@@ -7712,7 +7711,7 @@
           <pb ed="perry" n="P187"/>
           <p><milestone unit="recitprose"/>Ὄνος ἔν τινι λειμῶνι νεμόμενος, ὡς ἐθεάσατο λύκον ἐπ’ αὐτὸν ὁρμώμενον, χωλαίνειν προσεποιεῖτο. Τοῦ δὲ προσελθόντος αὐτῷ καὶ τὴν αἰτίαν πυνθανομένου δι’ ἣν χωλαίνει, ἔλεγεν ὡς φραγμὸν διαϐαίνων σκόλοπα ἐπάτησα καὶ παρῄνει αὐτῷ πρῶτον ἐξελεῖν τὸν σκόλοπα, εἶθ’ οὕτως αὐτὸν καταθοινήσασθαι, ἵνα μὴ ἐσθίων περιπαρῇ. Τοῦ δὲ πεισθέντος καὶ τὸν πόδα αὐτοῦ ἐπάραντος ὅλον τε τὸν νοῦν πρὸς τῇ ὁπλῇ ἔχοντος, ὁ ὄνος λὰξ εἰς τὸ στόμα τοὺς ὀδόντας αὐτοῦ ἐτίναξε. Καὶ ὃς κακῶς διατεθεὶς ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γάρ, τοῦ πατρός με μαγειρικὴν τέχνην διδάξαντος, αὐτὸς ἰατρικῆς ἐπελαϐόμην ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων οἱ μηδὲν προσήκουσιν ἐπιχειροῦντες εἰκότως δυστυχοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 186 Pb 183 Pg 118 Mb 160 Ca 140.</p>
+          <bibl>Codd. Pa 186 Pb 183 Pg 118 Mb 160 Ca 140.</bibl>
           <p><milestone unit="traduction"/>Un âne, qui paissait dans un pré, voyant un loup s’avancer vers lui, fit semblant de boiter. Le loup, s’étant approché, lui demanda pourquoi il boitait. Il répondit qu’il avait, en franchissant une clôture, mis le pied sur une épine, et il le pria de la lui enlever d’abord, après quoi il pourrait le manger, sans se percer la bouche en mâchant. Le loup se laissa persuader. Tandis qu’il soulevait la patte de l’âne et fixait toute son attention sur le sabot, l’âne, d’un coup de pied dans la gueul, lui fit sauter les dents. Et le loup mal en point dit : « Je l’ai bien mérité ; car pourquoi, ayant appris de mon père le métier de boucher, ai-je voulu, moi, tâter de la médecine ? »</p>
           <p><milestone unit="traduction"/>Ainsi les hommes qui entreprennent des choses hors de leur compétence s’attirent naturellement des disgrâces.</p>
         </div>
@@ -7741,7 +7740,7 @@
           <l><milestone unit="recitvers"/>μεμαθηκὼς γὰρ πρῶτον μάγειρος εἶναι</l>
           <l><milestone unit="recitvers"/>ἵππων ἰατρὸς ἵνα τί ἐγενόμην ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ τοὺς ἐχθροὺς αὑτῶν ὠφελεῖν πειρώμενοι ἀντὶ ἀμοιϐῆς κακὰ αὐτοῖς παρέχουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 26 Ch 101 Ca 134 Cb 81 Ce 91 Cf 96 Mc 80.</p>
+          <bibl>Codd. Cg 26 Ch 101 Ca 134 Cb 81 Ce 91 Cf 96 Mc 80.</bibl>
         </div>
         <div>
           <head>Chambry 282.3</head>
@@ -7749,7 +7748,7 @@
           <pb ed="perry" n="P187"/>
           <p><milestone unit="recitprose"/>Ὄνος πατήσας σκόλοπα χωλὸς εἱστήκει. Λύκον δὲ ἰδὼν καὶ φοϐηθεὶς εἶπεν· « Ὦ λύκε, ἀποθνῄσκω ἐκ πόνου· καλὸν δέ μοί ἐστι σοῦ δεῖπνον γενέσθαι ἢ γυπῶν καὶ κοράκων. Χάριν δὲ μίαν αἰτῶ σε, ἐξελεῖν τοῦ ποδός μου πρῶτον τὸν σκόλοπα, ὅπως μὴ μετὰ πόνου θνήξωμαι. » Ὁ δὲ λύκος ἄκροις ὀδοῦσι τὸν σκόλοπα δακὼν ἐξεῖλεν. Ὁ δὲ λυθεὶς τοῦ πόνου, τὸν λύκον ἔτι χάσκοντα λακτίσας φεύγει, ῥῖνα καὶ μέτωπον καὶ ὀδόντας συγκλάσας. Ὁ δὲ λύκος ἔφη· « Οἴμοι, δίκαια πάσχω, ὅτι μάγειρος εἶναι μαθὼν πρῶτον, νῦν ἱπποίατρος ἐγενόμην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τινὲς διπλοῖς κινδύνοις περιπεσόντες καὶ τοῖς ἐχθροῖς ὠφελεῖν πειρωμένοις δολίως ἀνταμοιϐὴν κακὴν παρέσχον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 106 Bb 64 Ma 186 Md 89 Mh 81 Mi 5 Mm 107 Mn 27 Ld 27.</p>
+          <bibl>Codd. Ba 106 Bb 64 Ma 186 Md 89 Mh 81 Mi 5 Mm 107 Mn 27 Ld 27.</bibl>
         </div>
         <div>
           <head>Chambry 282.4</head>
@@ -7757,7 +7756,7 @@
           <pb ed="perry" n="P187"/>
           <p><milestone unit="recitprose"/>Χωλὸς ὄναγρος ὑπὸ σκόλοπος ἐγκεκεντρισμένος ὀδυνηρῶς ἔφερε τὸν πόδα ἀλγῶν καὶ διαϐῆναι τὸν ποταμὸν μὴ δυνάμενος. Λύκος δὲ αὐτῷ βριαρὸς συναντήσας ἔμελλε κατεσθίειν, ἕτοιμον εὑρὼν θήραμα. Ὁ ὄναγρος δὲ αὐτοῦ ἐδέετο λέγων· « Παῦσόν με πρῶτον τοῦ πόνου τὸν σκόλοπα ἐκ τοῦ ποδὸς ἑλκύσας. » Τοῦ δὲ λύκου τοῖς ὀδοῦσι τὸν σκόλοπα ἑλκύσαντος, ὁ ὄναγρος κουφισθεὶς τῆς τοῦ ποδὸς ἀλγηδόνος, λακτίσας τοῖς ποσὶ τοῦ λύκου τὸ στόμα, νεκρὸν ἀφῆκε, καὶ εἰς ὄρος δραμὼν διεσώθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι καλὸν κακοῖς ποιήσας οὐχ ἕξεις εὐχαριστίαν, μᾶλλον δὲ λοιδορίαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 227 Pg 148 Mb 232 Cf 129.</p>
+          <bibl>Codd. Pb 227 Pg 148 Mb 232 Cf 129.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-283">
@@ -7766,7 +7765,7 @@
         <pb ed="perry" n="P238"/>
         <p><milestone unit="recitprose"/>Ὀρνιθοθήρας πετάσας τὰ λίνα ἐκ τῶν ἡμέρων περιστερῶν προσέδησεν· εἶτα ἀποστὰς αὐτὸς πόρρωθεν ἀπεκαραδόκει τὸ μέλλον. Ἀγρίων δὲ ταύταις προσελθουσῶν καὶ τοῖς βρόχοις ἐμπλακεισῶν, προσδραμὼν συλλαμϐάνειν αὐτὰς ἐπειρᾶτο. Τῶν δὲ αἰτιωμένων τὰς ἡμέρους, εἴγε ὁμόφυλοι οὖσαι αὐταῖς τὸν δόλον οὐ προεμήνυσαν, ἐκεῖναι ὑποτυχοῦσαι ἔφασαν· « Ἀλλ’ ἡμῖν γε ἄμεινον δεσπότας φυλάττεσθαι ἢ τῇ ἡμετέρᾳ συγγενείᾳ χαρίζεσθαι. »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν οἰκετῶν οὐ μεμπτέοι εἰσὶν ὅσοι δι’ ἀγάπην τῶν οἰκείων δεσποτῶν παραπίπτουσι τῆς τῶν οἰκείων συγγενῶν φιλίας.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pf 105 Me 137.</p>
+        <bibl>Codd. Pf 105 Me 137.</bibl>
         <p><milestone unit="traduction"/>Un oiseleur avait tendu ses filets auxquels il avait attaché des pigeons domestiques. Puis il s’était éloigné, et il observait à distance ce qui allait se passer. Des pigeons sauvages s’approchèrent des captifs et se firent prendre dans les lacets. L’oiseleur accourut et se mit en devoir de les saisir. Comme ils adressaient des reproches aux pigeons domestiques, parce que, étant de la même tribu, ils ne les avaient pas avertis du piège, ceux-ci répondirent : « Nous avons plus d’intérêt à nous garder du mécontentement de nos maîtres qu’à complaire à nos parents. »</p>
         <p><milestone unit="traduction"/>Ainsi en est-il des serviteurs : il ne faut pas les blâmer, quand, par amour de leurs maîtres, ils manquent aux lois de l’amitié envers leurs propres parents.</p>
       </div>
@@ -7778,7 +7777,7 @@
           <pb ed="perry" n="P193"/>
           <p><milestone unit="recitprose"/>Ὀρνιθοθήρας πτηνοῖς πάγην ἵστη. Κορύδαλος δὲ αὐτὸν θεασάμενος ἤρετο τί ποιεῖ. Τοῦ δὲ εἰπόντος πόλιν κτίζειν καὶ μικρὸν ὑποχωρήσαντος, πεισθεὶς τοῖς λόγοις προσῆλθε, καὶ τὸ δέλεαρ ἐσθίων ἔλαθεν ἐμπεσὼν εἰς τοὺ βρόχους. Τοῦ δὲ ὀρνιθοθήρα προσδραμόντος καὶ συλλαϐόντος αὐτόν, ἔφη· « Ὦ οὗτος, ἐὰν τοιαύτας πόλεις κτίζῃς, οὐ πολλοὺς τοὺς ἐνοικοῦντας εὑρήσεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τότε μάλιστα οἶκοι καὶ πόλεις ἐρημοῦνται, ὅταν οἱ προεστῶτες χαλεποὶ ὦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 195 Pb 189 Pc 107 Pf 104 Mb 141 Me 136.</p>
+          <bibl>Codd. Pa 195 Pb 189 Pc 107 Pf 104 Mb 141 Me 136.</bibl>
         </div>
         <div>
           <head>Chambry 284.2</head>
@@ -7786,7 +7785,7 @@
           <pb ed="perry" n="P193"/>
           <p><milestone unit="recitprose"/>Ὀρνιθοθήρας πτηνοῖς παγίδας ἵστη. Κορύδαλος δὲ τοῦτον θεασάμενος ἠρώτα, μακρόθεν ἑστώς· « Τί ἐργάζῃ ; » Τοῦ δὲ εἰπόντος· « Πόλιν κτίζω, » καὶ μικρὸν ὑποχωρήσαντος καὶ κρυϐέντος, ὁ κορύδαλος πεισθεὶς τοῖς λόγοις τοῦ ἀνδρὸς προσῆλθε τῷ τόπῳ, καὶ τὸ δέλεαρ ἐσθίων ἔλαθεν ἐμπεσὼν εἰς τοὺς βρόχους. Ὁ δὲ ὀρνιθοθήρας δραμὼν ἀνελάϐετο αὐτόν. Καὶ ὁ κορύδαλος· « Ὦ οὗτος, ἔφη, ἐὰν τοιαύτας πόλεις κτίζῃς, &lt;οὐ&gt; πολλοὺς τοὺς ἐνοικοῦντας εὑρήσεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τότε μάλιστα οἶκοι καὶ πόλεις ἐρημοῦνται, ὅταν οἱ προεστῶτες χαλεποὶ ὦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 146 Ce 87 Cf 92 Cg 22 Ch 97.</p>
+          <bibl>Codd. Ca 146 Ce 87 Cf 92 Cg 22 Ch 97.</bibl>
         </div>
         <div>
           <head>Chambry 284.3</head>
@@ -7794,7 +7793,7 @@
           <pb ed="perry" n="P193"/>
           <p><milestone unit="recitprose"/>Ὀρνιθορήρας ὄρνισιν ἵστη παγίδας. Κορύδαλος δὲ τοῦτον πόρρωθεν ἰδὼν ἐπυνθάνετο τί ποτ’ ἐργάζοιτο. Τοῦ δὲ πόλιν κτίζειν φαμένου, εἶτα δὲ πορρωτέρω ἀποχωρήσαντος καὶ κρυϐέντος, ὁ κορύδαλος τοῖς τοῦ ἀνδρὸς λόγοις πιστεύσας, προσελθὼν εἰς τὸν βρόχον ἑάλω. Τοῦ δὲ ὀρνιθοθήρα ἐπιδραμόντος, ἐκεῖνος εἶπεν· « Ὦ οὗτος, εἰ τοιαύτην πόλιν κτίζεις, οὐ πολλοὺς εὑρήσεις τοὺς ἐνοικοῦντας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τότε μάλιστα οἶκοι καὶ πόλεις ἐρημοῦνται, ὅταν οἱ προεστῶτες χαλεπαίνωσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 46 Lb 92 Ld 28 Le 92 Lf 46 Mc 85 Md 95 Mg 117 Mi 11 Mj 116 Ml 118 Mm 113 Mn 28.</p>
+          <bibl>Codd. La 46 Lb 92 Ld 28 Le 92 Lf 46 Mc 85 Md 95 Mg 117 Mi 11 Mj 116 Ml 118 Mm 113 Mn 28.</bibl>
           <p><milestone unit="traduction"/>Un oiseleur dressait des pièges aux oiseaux. Une alouette huppée, l’ayant aperçu de loin, lui demanda ce qu’il faisait. Il répondit qu’il fondait une ville, puis il s’éloigna et se cacha. L’alouette, se fiant aux discours de cet homme, s’approcha et fut prise au lacet. L’oiseleur étant accouru, elle lui dit : « Hé ! l’homme, si c’est une ville comme celle-ci que tu fondes, tu n’y trouveras pas beaucoup d’habitants. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que si l’on déserte les maisons et les villes, c’est surtout quand les maîtres y sont incommodes.</p>
         </div>
@@ -7816,7 +7815,7 @@
           <l><milestone unit="epimythiumenvers"/>Ὁ μῦθος τοῦτο λέγει·</l>
           <l><milestone unit="epimythiumenvers"/>οἶκοι καὶ πόλεις μᾶλλον τότ’ ἐρημοῦνται,</l>
           <l><milestone unit="epimythiumenvers"/>ὅταν χαλεπαίνωσιν οἱ προεστῶτες.</l>
-          <p><milestone unit="manuscrits"/>Cod. Cd 96.</p>
+          <bibl>Cod. Cd 96.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-285">
@@ -7827,7 +7826,7 @@
           <pb ed="perry" n="P194"/>
           <p><milestone unit="recitprose"/>Ὀρνιθοθήρας δίκτυα γεράνοις ἀναπετάσας πόρρωθεν ἀπεκαραδόκει  τὴν ἄγραν. Πελαργοῦ δὲ σὺν ταῖς γεράνοις ἐπικαθίσαντος, ἐπιδραμὼν μετ’ ἐκείνων καὶ αὐτὸν συνέλαϐε. Τοῦ δὲ δεομένου μεθεῖναι αὐτὸν καὶ λέγοντος ὡς οὐ μόνον αὐτὸς ἀϐλαϐής ἐστι τοῖς ἀνθρώποις, ἀλλὰ καὶ ὠφελιμώτατος, τοὺς γὰρ ὄφεις καὶ τὰ λοιπὰ ἑρπετὰ συλλαμϐάνων κατεσθίει, ὁ ὀρνιθοθήρας ἀπεκρίνατο· « Ἀλλ’ εἰ τὰ μάλιστα μὴ φαῦλος σὺ εἶ, δι’ αὐτὸ τοῦτο γοῦν ἄξιος εἶ κολάσεως, ὅτι μετὰ πονηρῶν κεκάθικας. »</p>
           <p><milestone unit="epimythiumprose"/>Ἀταρ οὖν καὶ ἡμᾶς δεῖ τὰς τῶν πονηρῶν συνηθείας περιφεύγειν, ἵνα μὴ καὶ αὐτοὶ τῆς ἐκείνων κακίας κοινωνεῖν δόξωμεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 196 Pb 190 Pc 106 Mb 144 Ca 147.</p>
+          <bibl>Codd. Pa 196 Pb 190 Pc 106 Mb 144 Ca 147.</bibl>
           <p><milestone unit="traduction"/>Un oiseleur, ayant tendu des panneaux aux grues, surveillait de loin sa chasse. Or une cigogne s’étant posée parmi les grues, il accourut et la prit elle aussi avec elles. Comme elle le priait de la relâcher, disant que, loin de nuire aux hommes, elle leur était même fort utile, car elle prenait et mangeait les serpents et autres reptiles, l’oiseleur répondit : « Si vraiment tu n’es pas méchante, tu mérites en tout cas un châtiment pour t’être posés parmi les méchants. »</p>
           <p><milestone unit="traduction"/>Nous aussi nous devons fuir la société des méchants, afin qu’on ne nous prenne pas nous-mêmes pour les complices de leur méchanceté.</p>
         </div>
@@ -7854,7 +7853,7 @@
           <l><milestone unit="recitvers"/>ἐπιγινώσκω καὶ τίς ὑπάρχεις οἶδα,</l>
           <l><milestone unit="recitvers"/>ἀλλὰ συλληφθεὶς μετ’ αὐτῶν καὶ τεθνήξῃ. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καλόν ἐστι φεύγειν καὶ μὴ συγκοινωνεῖν τοῖς κακοῖς ἀνδράσι, μήπως σὺν αὐτοῖς κινδύνοις περιπέσωμεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 54 Ca 76 Cb 47 Cd 44 Ce 49 Cf 53 Mc 46 Ml 71.</p>
+          <bibl>Codd. Ch 54 Ca 76 Cb 47 Cd 44 Ce 49 Cf 53 Mc 46 Ml 71.</bibl>
         </div>
         <div>
           <head>Chambry 285.3</head>
@@ -7862,7 +7861,7 @@
           <pb ed="perry" n="P194"/>
           <p><milestone unit="recitprose"/>Ἐν τῇ ἀρούρᾳ γεωργὸς πάγας ἵστα, ὅπως γεράνους ἠδὲ χῆνας θηρεύῃ, τὰς ἐσθιούσας τὰ βλάστη τῆς ἀρούρας. Σὺν τούτοις οὖν καὶ πελαργὸς κατελήφθη τῇ πάγῃ, ὃς θἄτερον τῶν ποδῶν ἐν αὐτῇ συνθλασθεὶς πολλὰ καθικέτευε τὸν γεωργὸν ἐλευθερῶσαι αὐτόν, λέγων τοιαῦτα· « Ὦ γεωργέ, ἐλέησόν με τὸν συντεθλασμένον φέροντα τὸν πόδα καὶ ἀπόλυσόν με· οὐ γὰρ ἐγὼ γέρανος, οὐδὲ χήν, ἀλλὰ πελαργός, εὐγενέστατος ὄρνις εἰμὶ γονεῦσι δουλεύων, ὥραν καὶ χρόαν οὐχ ὁμοίαν τούτοις κεκτημένος. » Ὁ δὲ γεωργὸς γελάσας ἔφη· « Οἶδα κἀγὼ ὅτι πελαργὸς εἶ, ἀλλὰ συλληφθεὶς μετ’ αὐτῶν καὶ τεθνήξει σὺν αὐτοῖς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τοῖς χείροσι συναναστρέφεσθαι, μή πως σὺν αὐτοῖς κινδύνοις περιπέσωμεν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 50.</p>
+          <bibl>Cod. Mk 50.</bibl>
         </div>
         <div>
           <head>Chambry 285.4</head>
@@ -7870,7 +7869,7 @@
           <pb ed="perry" n="P194"/>
           <p><milestone unit="recitprose"/>Γεωργὸν ἠδίκουν οἱ γέρανοι τὰ καταϐαλλόμενα τῇ γῇ προαρπάζοντες σπέρματα. Πελαργὸς δέ τις τοῖς γεράνοις συνῆν τῆς μὲν διατριϐῆς κοινωνῶν, τῆς δὲ ϐλάϐης ὁ γεωργός, βρόχους στήσας, μετὰ τῶν γεράνων εἷλε καὶ τὸν πελαργόν, καὶ δίκην ὑπεῖχεν ὧν οὐδὲν προηδίκησε.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ τοῖς πονηροῖς συνὼν τὴν αὐτὴν αὐτοῖς ὑφίσταται δίκην.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mj 39.</p>
+          <bibl>Cod. Mj 39.</bibl>
         </div>
         <div>
           <head>Chambry 285.5</head>
@@ -7878,7 +7877,7 @@
           <pb ed="perry" n="P194"/>
           <p><milestone unit="recitprose"/>Ἀρούρῃ παγίδας γεωργὸς ἔστησε. Θηρεύσας δὲ γεράνους τοὺς τὸν σπόρον φθείροντας, σὺν αὐτοῖς καὶ πελαργὸν εἰλήφει. Ὁ δὲ χωλεύων ἱκέτευεν ἀφεθῆναι, λέγων· « Οὐ γάρ εἰμι γέρανος· πελαργός εἰμι, εὐσεϐέστατον ζῷον, ὃς τιμῶ τὸν πατέρα καὶ δουλεύω. Ἰδὲ καὶ τὴν χροιὰν ὡς οὐχ ὁμοία. » Ὁ δὲ ἔφη· « Οὐκ οἶδα τί λέγεις· ἐγὼ σὺν οἷς εἴληφά σε, μετ’ αὐτῶν σε καὶ ἀπολέσω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καλόν ἐστι φεύγειν καὶ μὴ συγκοινωνεῖν ἀνδράσι κακοῖς, μή πως κινδύνοις σὺν αὐτοῖς ἐμπαρῇς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 14 Bb 9 Mg 25.</p>
+          <bibl>Codd. Ba 14 Bb 9 Mg 25.</bibl>
         </div>
         <div>
           <head>Chambry 285.6</head>
@@ -7886,7 +7885,7 @@
           <pb ed="perry" n="P194"/>
           <p><milestone unit="recitprose"/>Ἀρούρῃ παγίδας γεωργὸς ἐστήσατο κατὰ τῶν τὸν σπόρον βιϐρωσκομένων γεράνων. Σὺν αὐταῖς οὖν εἰλήφει καὶ πελαργόν. Ὁ δὲ θερμῶς ἠντιϐόλει τοῦ ἀφεθῆναι· « Οὐ γάρ εἰμι γέρανος, » ἔλεγεν, « ἀλλὰ πελαργός, τὸ εὐσεϐέστατον ζῷον καὶ τοῖς πατράσιν εὐνοϊκώτατον. Ἰδὲ γάρ μου καὶ τὴν χροιὰν ὡς οὐχ ὁμοία ἐκείναις. » Ὁ δὲ ἔφη· « Οὐκ οἶδα τί λέγεις. Ἔγωγε σὺν αὐταῖς  σε κατέσχον καὶ τὴν ὁμοίαν ψῆφον ἐπιτάξαι σοι μέλλω. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐπισφαλὲς τὸ συγκοινωνεῖν κακοῖς καὶ ἐπικίνδυνον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 12.</p>
+          <bibl>Cod. Bc 12.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-286">
@@ -7895,7 +7894,7 @@
         <pb ed="perry" n="P265"/>
         <p><milestone unit="recitprose"/>Ὀρνιθοθήρας, ὀψιαίτερον αὐτῷ ξένου παραγενομένου, μὴ ἔχων ὅ τι αὐτῷ παραθείη, ὥρμησεν ἐπὶ τὸν τιθασσὸν πέρδικα καὶ τοῦτον θύειν ἔμελλε. Τοῦ δὲ αἰτιωμένου αὐτὸν ὡς ἀχάριστον, εἴγε πολλὰ ὠφελούμενος παρ’ αὐτοῦ τοὺς ὁμοφύλους ἐκκαλουμένου καὶ παραδιδόντος, αὐτὸς ἀναιρεῖν αὐτὸν μέλλει, ἔφη· « Ἀλλὰ διὰ τοῦτό σε μᾶλλον θύσω, εἰ μηδὲ τῶν ὁμοφύλων ἀπέχῃ. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ τοὺς οἰκείους προδιδόντες οὐ μόνον ὑπὸ τῶν ἀδικουμένων μισοῦνται, ἀλλὰ καὶ ὑπὸ τούτων οἷς προδίδονται.</p>
-        <p><milestone unit="manuscrits"/>Cod. Pa 193.</p>
+        <bibl>Cod. Pa 193.</bibl>
         <p><milestone unit="traduction"/>Un hôte se présenta un peu tard chez un oiseleur. Celui-ci, n’ayant rien à lui offrir, s’en fut vers sa perdrix privée, et il allait la tuer, quand elle lui reprocha son ingratitude : « Ne lui était-elle pas fort utile en appelant les oiseaux de sa tribu et en les lui livrant ? et il allait la tuer ! – Raison de plus pour t’immoler, répondit-il, puisque tu n’épargnes même pas ceux de ta tribu. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que ceux qui trahissent leurs parents sont odieux non seulement à leurs victimes, mais encore à ceux à qui ils les livrent.</p>
       </div>
@@ -7905,7 +7904,7 @@
         <pb ed="perry" n="P192"/>
         <p><milestone unit="recitprose"/>Ὄρνις ὄφεως ὠὰ εὑροῦσα, ταῦτα ἐπιμελῶς ἐθέρμαινε καὶ μετὰ τὸ θερμᾶναι ἐξεκόλαψε. Χελιδὼν δὲ θεασαμένη αὐτὴν ἔφη· « Ὦ ματαία, τί ταῦτα ἀνατρέφεις ἅπερ, ἂν αὐξηθῇ, ἀπὸ σοῦ πρώτης τοῦ ἀδικεῖν ἄρξεται ; »</p>
         <p><milestone unit="epimythiumprose"/>Οὕτως ἀτιθάσσευτός ἐστιν ἡ πονηρία, κἂν τὰ μάλιστα εὐεργετῆται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 194 Pb 188 Pf 106 Pg 121 Ma 9 Mb 140 Me 138 Mf 114 Ca 145 La 121 Lb 107 Le 107 Lf 121 Lh 58 Mg 130 Mj 128 Ml 132.</p>
+        <bibl>Codd. Pa 194 Pb 188 Pf 106 Pg 121 Ma 9 Mb 140 Me 138 Mf 114 Ca 145 La 121 Lb 107 Le 107 Lf 121 Lh 58 Mg 130 Mj 128 Ml 132.</bibl>
         <p><milestone unit="traduction"/>Une poule, ayant trouvé des œufs de serpent, se mit à les couver soigneusement et, après les avoir chauffés, les fit éclore. Une hirondelle, qui l’avait vue faire, lui dit : « Sotte que tu es, pourquoi élèves-tu des êtres qui, une fois grands, commenceront par toi la première le cours de leurs méfaits. »</p>
         <p><milestone unit="traduction"/>La perversité ne se laisse pas apprivoiser, même à force de bienfaits.</p>
       </div>
@@ -7923,7 +7922,7 @@
           <l><milestone unit="recitvers"/>Ὁ δὲ τὸν πλοῦτον εὑρηκέναι νομίσας</l>
           <l><milestone unit="recitvers"/>ἀπεστέρηται καὶ τοῦ μικροῦ τοῦ κέρδους.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἔχων τι ἀρκέσθητι ἐπὶ τούτῳ, τὴν δὲ ἀπληστίαν φεῦγε, μή πως καὶ ὅ ἔχεις ἀπολέσῃς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Cg 27 Ch 102 Ca 153 Cb 82 Mc 81.</p>
+          <bibl>Codd. Cg 27 Ch 102 Ca 153 Cb 82 Mc 81.</bibl>
         </div>
         <div>
           <head>Chambry 288.2</head>
@@ -7936,7 +7935,7 @@
           <l><milestone unit="recitvers"/>κατηφὴς ἐγένετο καὶ τεθλιμμένος.</l>
           <l><milestone unit="recitvers"/>Πολλ’ ἐλπίσας καὶ τοῦ μικροῦ ἐστερήθη.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ τοῖς παροῦσιν ἀρκεῖσθαι καὶ τὴν ἀπληστίαν φεύγειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mh 92.</p>
+          <bibl>Cod. Mh 92.</bibl>
         </div>
         <div>
           <head>Chambry 288.3</head>
@@ -7944,7 +7943,7 @@
           <pb ed="perry" n="P87"/>
           <p><milestone unit="recitprose"/>Ὄρνιν τις εἶχε καλὴν χρυσᾶ ὠὰ τίκτουσαν· νομίσας δὲ ἔνδον αὐτῆς ὄγκον χρυσίου εἶναι καὶ θύσας εὗρεν οὖσαν ὁμοίαν τῶν λοιπῶν ὀρνίθων. Ὁ δὲ ἀθρόον πλοῦτον ἐλπίσας εὑρεῖν καὶ τοῦ μικροῦ κέρδους ἐστερήθη.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῖς παροῦσιν ἀρκείσθω τις καὶ τὴν ἀπληστίαν φευγέτω.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 112 Bb 68 La 140 Lc 45 Lg 45 Mi 7 Mm 109.</p>
+          <bibl>Codd. Ba 112 Bb 68 La 140 Lc 45 Lg 45 Mi 7 Mm 109.</bibl>
           <p><milestone unit="traduction"/>Un homme avait une belle poule qui pondait des œufs d’or. Croyant qu’elle avait dans le ventre une masse d’or, il la tua et la trouva semblable aux autres poules. Il avait espéré trouver la richesse d’un seul coup, et il s’était privé même du petit profit qu’il tenait.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut se contenter de ce qu’on a et éviter la cupidité insatiable.</p>
         </div>
@@ -7954,7 +7953,7 @@
           <pb ed="perry" n="P87"/>
           <p><milestone unit="recitprose"/>Ἑρμῆς θρησκευόμενος ὑπό τινος περιττῶς χῆνα αὐτῷ ἐχαρίσατο ὠὰ χρυσᾶ τίκτουσαν. Ὁ δὲ οὐκ ἀναμείνας τὴν κατὰ μικρὸν ὠφέλειαν, ὑπολαϐὼν δὲ ὅτι πάντα τὰ ἐντὸς χρυσᾶ ἔχει ὁ χήν, οὐδὲν μελλήσας ἔθυσεν αὐτήν. Συνέϐη δὲ αὐτῷ μὴ μόνον ὧν προσεδόκησε σφαλῆναι, ἀλλὰ καὶ τὰ ὠὰ ἀποϐαλεῖν· τὰ γὰρ ἐντὸς πάντα σαρκώδη εὗρεν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις οἱ πλεονέκται δι’ ἐπιθυμίαν πλειόνων καὶ τὰ ἐν χερσὶν ὄντα προίενται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 84 Pb 88 Pe 52.</p>
+          <bibl>Codd. Pa 84 Pb 88 Pe 52.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-289">
@@ -7965,7 +7964,7 @@
           <pb ed="perry" n="P362"/>
           <p><milestone unit="recitprose"/>Οὐρά ποτε ὄφεως ἠξίου πρώτη προάγειν καὶ βαδίζειν. Τὰ δὲ λοιπὰ μέλη ἔλεγον· « Πῶς χωρὶς ὀμμάτων καὶ ῥινὸς ἡμᾶς ἄξεις, ὡς καὶ τὰ λοιπὰ ζῷα ; » Ταύτην δὲ οὐκ ἔπειθον, ἕως τὸ φρονοῦν ἐνικήθη. Ἡ οὐρὰ δὲ ἦρχε καὶ ἦγε, σύρουσα τυφλὴ πᾶν τὸ σῶμα, ἕως, εἰς βάραθρον πετρῶν ἐνεχθεῖσης, &lt;ὁ ὄφις&gt; τὴν ῥάχιν καὶ πᾶν τὸ σῶμα ἐπλήγη. Σαίνουσα δὲ ἱκέτευε τὴν κεφαλὴν λέγουσα· « Σῶσον ἡμᾶς, εἰ θέλεις, δέσποινα· τῆς γὰρ κακῆς ἔριδος ἐπειράθην. »</p>
           <p><milestone unit="epimythiumprose"/>Ἄνδρας δολίους καὶ κακοὺς καὶ τοῖς δεσπόταις ἐπανισταμένους ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 116 Bb 69.</p>
+          <bibl>Codd. Ba 116 Bb 69.</bibl>
           <p><milestone unit="traduction"/>Un jour la queue du serpent eut la prétention de conduire et de marcher la première. Les autres organes lui dirent : « Comment nous conduiras-tu, toi qui n’a pas d’yeux ni de nez, comme les autres animaux ? » Mais ils ne la persuadèrent pas, et à la fin le bon sens eut le dessous. La queue commanda et conduisit, tirant à l’aveugle tout le corps, tant qu’enfin elle tomba dans un trou plein de pierres, où le serpent se meurtrit l’échine et tout le corps. Alors elle s’adressa, flatteuse et suppliante, à la tête : « Sauve-nous, s’il te plaît, maîtresse ; car j’ai eu tort d’entrer en lutte avec toi. »</p>
           <p><milestone unit="traduction"/>Cette fable confond les hommes rusés et pervers qui se révoltent contre leurs maîtres.</p>
         </div>
@@ -7975,7 +7974,7 @@
           <pb ed="perry" n="P362"/>
           <p><milestone unit="recitprose"/>Δράκοντος ἡ οὐρὰ τῇ κεφαλῇ ἐστασίασεν, ἀξιοῦσα ἡγεῖσθαι παρὰ μέρος καὶ μὴ διὰ πάντος ἀκολουθεῖν ἐκείνῃ. Λαϐοῦσα δὲ τὴν ἡγεμονίαν ἑαυτήν τε κακῶς ἀπήλλαττε ἀνοίᾳ πορευομένη καὶ τὴν κεφαλὴν κατέξαινε τυφλοῖς καὶ κωφοῖς μέρεσιν ἀναγκαζομένην παρὰ φύσιν ἕπεσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ πρὸς χάριν ἅπαντα πολιτευόμενοι τοιαῦτα πάσχουσι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 40.</p>
+          <bibl>Cod. Mb 40.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-290">
@@ -7984,7 +7983,7 @@
         <pb ed="perry" n="P197"/>
         <p><milestone unit="recitprose"/>Ὄφις καὶ γαλῆ ἔν τινι οἰκίᾳ ἐμάχοντο. Οἱ δὲ ἐνταῦθα μύες ἀεὶ καταναλισκόμενοι ὑπὸ ἀμφοτέρων, ὡς ἐθεάσαντο αὐτοὺς μαχομένους, ἐξῆλθον βαδίζοντες. Ἰδόντες δὲ τοὺς μύας, τότε ἀφέντες τὴν πρὸς ἑαυτοὺς μάχην, ἐπ’ ἐκείνους ἐτράπησαν.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω καὶ ἐπὶ τῶν πόλεων οἱ ἐν ταῖς τῶν δημαγωγῶν στάσεσιν ἑαυτοὺς παρεισϐάλλοντες λανθάνουσιν αὐτοὶ ἑκατέρων παρανάλωμα γινόμενοι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 199 Pb 193 Pf 109 Mb 169 Me 142 Mf 118.</p>
+        <bibl>Codd. Pa 199 Pb 193 Pf 109 Mb 169 Me 142 Mf 118.</bibl>
         <p><milestone unit="traduction"/>Un serpent et une belette se battaient dans une maison. Les rats du logis, toujours dévorés par l’un et par l’autre, les voyant combattre, sortirent tranquillement de leurs trous. À la vue des rats, les combattants, renonçant à s’entrebattre, se tournèrent contre eux.</p>
         <p><milestone unit="traduction"/>Il en est de même dans les États : les gens qui s’immiscent dans les querelles des démagogues deviennent sans s’en douter les victimes des deux partis.</p>
       </div>
@@ -7996,7 +7995,7 @@
           <pb ed="perry" n="P196"/>
           <p><milestone unit="recitprose"/>Ὄφις καὶ καρκῖνος ἐν ταὐτῷ διέτριϐον. Καὶ ὁ μὲν καρκῖνος ἁπλῶς τῷ ὄφει καὶ εὐνοϊκῶς προσεφέρετο· ὁ δὲ ἀεὶ ὕπουλός τε καὶ πονηρὸς ἦν. Τοῦ δὲ καρκίνου συνεχῶς αὐτῷ παραινοῦντος ἐξαπλοῦσθαι τὰ πρὸς αὐτὸν καὶ τὴν αὐτοῦ διάϐεσιν μιμεῖσθαι, ἐκεῖνος οὐκ ἐπείθετο. Διόπερ ἀγανακτήσας, παρατηρησάμενος αὐτὸν κοιμώμενον, τοῦ φάρυγγος ἐπιλαϐόμενος ἀνεῖλε καὶ ἰδὼν αὐτὸν ἐκτεταμένον, εἶπεν· « Ὦ οὗτος, οὐ νῦν σε ἐχρῆν ἁπλοῦν εἶναι, ὅτε τέθνηκας, ὅτε δέ σοι παρῄνουν· καὶ οὐκ &lt;ἂν&gt; ἀνῄρησο. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτος ὁ λόγος εἰκότως ἂν λέγοιτο ἐπ’ ἐκείνων τῶν ἀνθρώπων οἳ παρὰ τὸν ἑαυτῶν βίον εἰς τοὺς φίλους πονηρευόμενοι μετὰ τὸν θάνατον εὐεργεσίας κατατίθενται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 198 Pb 192 Pf 108 Pg 122 Mb 168 Me 141 Mf 117.</p>
+          <bibl>Codd. Pa 198 Pb 192 Pf 108 Pg 122 Mb 168 Me 141 Mf 117.</bibl>
           <p><milestone unit="traduction"/>Un serpent et un crabe séjournaient dans le même endroit. Le crabe se comportait envers le serpent en toute simplicité et bienveillance ; mais le serpent était toujours sournois et pervers. Le crabe l’exhortait sans cesse à se conduire envers lui avec droiture et à imiter sa manière à lui : il n’était pas écouté. Aussi, indigné, il observa le moment où le serpent dormait, le saisit à la gorge et le tua. En le voyant étendu mort, il dit : « Hé ! camarade, ce n’est pas maintenant que tu es mort, que tu aurais dû être droit, c’est lorsque je t’y exhortais : alors tu n’aurais pas été mis à mort. »</p>
           <p><milestone unit="traduction"/>On pourrait justement conter cette fable à propos des hommes qui pendant leur vie sont méchants envers leurs amis en leur rendant service après leur mort.</p>
         </div>
@@ -8006,7 +8005,7 @@
           <pb ed="perry" n="P196"/>
           <p><milestone unit="recitprose"/>Ὄφις καρκίνῳ συνδιῃτᾶτο, ἑταιρείαν πρὸς αὐτὸν ποιησάμενος. Ὁ μὲν οὖν καρκῖνος ἁπλοῦς ὢν τὸν τρόπον, μεταϐαλέσθαι κἀκείνῳ παρῄνει τῆς πανουργίας. Ὁ δὲ οὐδοτιοῦν ἑαυτὸν παρεῖχε πειθόμενον. Ἐπιτηρήσας δ’ ὁ καρκῖνος αὐτὸν ὑπνοῦντα καὶ τοῦ φάρυγγος τῇ χηλῇ λαϐόμενος καὶ ὅσον οἷόν τε πιέσας, φονεύει. Τοῦ δ’ ὄφεως μετὰ θάνατον ἐκταθέντος, ἐκεῖνος εἶπεν· « Οὕτως ἔδει καὶ πρόσθεν εὐθὺν καὶ ἁπλοῦν εἶναι· οὐδὲ γὰρ ἂν ταύτην τὴν δίκην ἔτισας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοῖς φίλοις σὺν δόλῳ προσιόντες αὐτοὶ μᾶλλον βλάπτονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 71 Lb 98 Le 98 Lf 71 Lh 50 Md 125 Mg 122 Mi 99 Mj 121 Ml 124 Mm 117.</p>
+          <bibl>Codd. La 71 Lb 98 Le 98 Lf 71 Lh 50 Md 125 Mg 122 Mi 99 Mj 121 Ml 124 Mm 117.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-292">
@@ -8015,7 +8014,7 @@
         <pb ed="perry" n="P198"/>
         <p><milestone unit="recitprose"/>Ὄφις ὑπὸ πολλῶν πατούμενος ἀνθρώπων τῷ Διὶ ἐνετύγχανε περὶ τούτου. Ὁ δὲ Ζεὺς πρὸς αὐτὸν εἶπεν· « Ἀλλ’ εἰ τὸν πρότερόν σε πατήσαντα ἔπληξας, οὐκ ἂν ὁ δεύτερος ἐπεχείρησε τοῦτο ποιῆσαι. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ τοῖς πρώτοις ἐπιϐαίνουσιν ἀνθιστάμενοι τοῖς ἄλλοις φοϐεροὶ γίνονται.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pb 194 Pg 123 Mb 170 Ca 149 La 123 Lb 109 Le 109 Lf 123 Lh 59 Me 139 Mf 115 Mg 132 Mj 130 Ml 120.</p>
+        <bibl>Codd. Pb 194 Pg 123 Mb 170 Ca 149 La 123 Lb 109 Le 109 Lf 123 Lh 59 Me 139 Mf 115 Mg 132 Mj 130 Ml 120.</bibl>
         <p><milestone unit="traduction"/>Un serpent, souvent foulé aux pieds par les hommes, alla s’en plaindre à Zeus. Zeus lui dit : « Si tu avais frappé le premier qui t’a marché dessus, le deuxième n’aurait pas essayé d’en faire autant. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que ceux qui tiennent tête aux premiers qui les attaquent se rendent redoutables aux autres.</p>
       </div>
@@ -8027,7 +8026,7 @@
           <pb ed="perry" n="P47"/>
           <p><milestone unit="recitprose"/>Βοῦν τινες ἐπ’ ἀγροῦ θύοντες τοὺς συγγενεῖς ἐκάλεσαν· ἐν δὲ τούτοις ἦν τις καὶ γυνὴ πενιχρά, μεθ’ ἧς καὶ ὁ παῖς εἰσῆλθε. Προϊούσης δὲ τῆς εὐωχίας, τὸ παιδίον διὰ χρόνου πληρωθὲν τῶν σπλάγχων καὶ τοῦ οἴνου, [ἐπειδὴ προειστιᾶτο,] καὶ διαϐασανιζόμενον ἔλεγεν· « Ὦ μῆτερ, ἐμῶ τὰ σπλάγχνα. » Ἡ δὲ εἶπεν· « Οὐχὶ τὰ σά, τέκνον, ἃ δὲ κατέφαγες. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος ἁρμόττει πρὸς ἄνδρα χρεωφειλέτην, ὅστις ἑτοίμως τὰ ἀλλότρια λαμϐάνων, ὅταν ἀποτίνειν δέῃ, οὕτως ἀπέχθεται ὡς οἴκοθεν προιέμενος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 47 Pb 47 Pc 19 Pe 21 Pg 25 Ma 32.</p>
+          <bibl>Codd. Pa 47 Pb 47 Pc 19 Pe 21 Pg 25 Ma 32.</bibl>
         </div>
         <div>
           <head>Chambry 293.2</head>
@@ -8035,7 +8034,7 @@
           <pb ed="perry" n="P47"/>
           <p><milestone unit="recitprose"/>Βοτῆρες ἐπ’ ἀγρῷ θύοντες αἶγα τοὺς σύνεγγυς ἐκάλεσαν. Σὺν αὐτοῖς δὲ ἦν καὶ γυνὴ πενιχρά, μεθ’ ἧς καὶ ὁ παῖς αὐτῆς. Προϊούσης δὲ τῆς εὐωχίας, τὸ παιδίον ὀγκωθὲν τὴν γαστέρα ἐκ τῶν κρεῶν, ὀδυνώμενον ἔλεγεν· « Ὦ μῆτερ, τὰ σπλάγχνα ἐμῶ. » Ἡ δὲ μήτηρ αὐτοῦ εἶπεν· « Οὐχὶ τὰ σά, τέκνον, ἃ δὲ κατέφαγες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος οὗτος πρὸς ἄνδρα χρεωφειλέτην, ὅστις ἑτοίμως τὰ ἀλλότρια λαμϐάνων, ὅταν ἀπαιτηθῇ ταῦτα, οὕτως ἄχθεται ὥσπερ ἐὰν οἴκοθεν ταῦτα ἐδίδου.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 40 Cb 29 Cc 29 Cd 29 Ce 27 Cf 31 Ch 36 Mc 32 Md 34 Mi 69 Mj 29 Mk 33 Ml 31.</p>
+          <bibl>Codd. Ca 40 Cb 29 Cc 29 Cd 29 Ce 27 Cf 31 Ch 36 Mc 32 Md 34 Mi 69 Mj 29 Mk 33 Ml 31.</bibl>
           <p><milestone unit="traduction"/>Des bergers sacrifiant une chèvre à la campagne invitèrent leurs voisins. Parmi eux se trouvait une pauvresse qui amena son enfant avec elle. Comme le festin s’avançait, l’enfant qui avait l’estomac gonflé de viande, se sentant mal, s’écria : « Mère, je vomis mes entrailles. – Non pas les tiennes, mon petit, dit la mère, mais celles que tu as mangées. »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse au débiteur, qui est toujours prêt à prendre le bien d’autrui ; vient-on à le lui réclamer, il s’en afflige autant que s’il payait de son bien propre.</p>
         </div>
@@ -8045,7 +8044,7 @@
           <pb ed="perry" n="P47"/>
           <p><milestone unit="recitprose"/>Βότηρες ἐν ἀγρῷ ἔθυον αἶγα. Συνῆν δ’ αὐτοῖς καὶ γυνὴ πενιχρὰ μετὰ τοῦ ἑαυτῆς παιδός. Τῆς δὲ εὐωχίας προϊούσης, καὶ ἐξογκωθείσης τῆς γαστρὸς τοῦ παιδὸς ἀπὸ τῶν κρεῶν, ὀδυνώμενον ἔλεγεν· « Ὦ μῆτερ, τὰ σπλάγχνα ἐμῶ. » Ἡ δὲ μήτηρ αὐτοῦ εἶπεν· « Οὐχὶ τὰ σά, τέκνον, ἀλλ’ ἃ κατέφαγες. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ πρὸς ἄνδρα χρεωφειλέτην, ὅστις τὰ ἀλλότρια ἑτοίμως ἀπολαμϐάνων, ὅταν ταῦτα ἀπαιτηθῇ, οὕτως ἄχθεται ὡς οἴκοθεν αὐτὰ προδιδούς.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mm 37.</p>
+          <bibl>Cod. Mm 37.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-294">
@@ -8056,7 +8055,7 @@
           <pb ed="perry" n="P199"/>
           <p><milestone unit="recitprose"/>Παῖς πρὸ τοῦ τείχους ἀκρίδας ἐθήρευε. Πολλὰς δὲ συλλαϐών, ὡς ἐθεάσατο σκορπίον, οἰηθεὶς ἀκρίδα εἶναι, κοιλάνας τὴν χεῖρα, οἷός τε ἦν καταφέρειν αὐτόν. Καὶ ὃς τὸ κέντρον ἐπάρας εἶπεν· « Εἶθε γὰρ τοῦτο ἐποίησας, ἵνα καὶ ἃς συνείληφας ἀκρίδας ἀπολέσῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος διδάσκει μὴ δεῖν πᾶσι τοῖς χρηστοῖς καὶ τοῖς πονηροῖς κατὰ ταὐτὰ προσφέρεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 200 Pb 195 Pc 108 Pg 124 Ma 127 Ca 158.</p>
+          <bibl>Codd. Pa 200 Pb 195 Pc 108 Pg 124 Ma 127 Ca 158.</bibl>
           <p><milestone unit="traduction"/>Un enfant faisait la chasse aux sauterelles devant le rempart. Après en avoir pris un certain nombre, il vit un scorpion ; il le prit pour une sauterelle, et, creusant la main, il allait l’y déposer, quand le scorpion, dressant son dard, lui dit : « Plût aux dieux que tu l’eusses fait ! du même coup tu aurais perdu les sauterelles que tu as prises. »</p>
           <p><milestone unit="traduction"/>Cette fable nous enseigne qu’il ne faut pas se comporter de même envers les bons et envers les méchants.</p>
         </div>
@@ -8071,14 +8070,14 @@
           <l><milestone unit="recitvers"/>« Ἄπελθε, ὦ παῖ, καὶ σῴζου μετ’ εἰρήνης,</l>
           <l><milestone unit="recitvers"/>μὴ θηρεύσας με ἀπολέσῃς ἁπάσας. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καλόν ἐστι τὰ ἐναντία γινώσκειν καὶ τὸ μὲν καλὸν πράττειν, τὸ δὲ κακὸν ἐκφεύγειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 171 Cb 89 Cd 103 Cg 34 Ch 109.</p>
+          <bibl>Codd. Ca 171 Cb 89 Cd 103 Cg 34 Ch 109.</bibl>
         </div>
         <div>
           <head>Chambry 294.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P199"/>
           <p><milestone unit="recitprose"/>Παῖς τις συνάγων ἀκρίδας εἷλε καὶ σκορπίον ἀντὶ ἀκρίδος. Ὁ δὲ πρὸς τὸν παῖδα, ἄκακον ὄντα νοήσας, ἔφη· « Ἄπελθε, μὴ θήρευε, μὴ πάσας ἀπολέσῃς. »</p>
-          <p><milestone unit="manuscrits"/>Cod. Cf 104.</p>
+          <bibl>Cod. Cf 104.</bibl>
         </div>
         <div>
           <head>Chambry 294.4</head>
@@ -8086,7 +8085,7 @@
           <pb ed="perry" n="P199"/>
           <p><milestone unit="recitprose"/>Παῖς τις θηρεύων ἀκρίδας περιέτυχε σκορπίῳ. Ὁ δὲ τὸ τοῦ παιδὸς ἁπλοῦν θεασάμενος, τὸ κέντρον ὀξύνας, εἶπεν· « Ἄπελθε, παῖ, καὶ σῴζου, μὴ κἀμὲ θηρεύων πάσας ἃς ἔχεις ἀπολέσῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὄτι προσέχειν δεῖ τοὺς δυναμένους πάντας βλάπτειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Mh 85 Md 99 Mi 15 Mm 121.</p>
+          <bibl>Codd. Mh 85 Md 99 Mi 15 Mm 121.</bibl>
         </div>
         <div>
           <head>Chambry 294.5</head>
@@ -8094,7 +8093,7 @@
           <pb ed="perry" n="P199"/>
           <p><milestone unit="recitprose"/>Παῖς τις ἀκρίδας θηρεύων καὶ σκορπίον ἤμελλεν ἆραι ὡς γένος ἀκρίδος ὄντα. Ὁ δὲ τὸ τοῦ παιδὸς ἁπλοῦν ἰδὼν τὸ οὐραῖον στήσας καὶ τὸ κέντρον ὀξύνας εἶπεν· « Ἄπελθε καὶ σῴζου, ὦ παῖ, μὴ κἀμὲ θηρεύων καὶ πάσας ἃς ἔχεις ἀπολέσῃς. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι καλὸν τὸ γινώσκειν τὰ ἐναντία, καὶ τὸ μὲν καλὸν τιμᾶν, τὸ δὲ κακὸν φεύγειν, ἐκ πείρας δὲ πάντα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 119 Bb 71.</p>
+          <bibl>Codd. Ba 119 Bb 71.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-295">
@@ -8102,7 +8101,7 @@
         <head type="sub">Παῖς καὶ κόραξ — L’enfant et le corbeau.</head>
         <pb ed="perry" n="P162"/>
         <p><milestone unit="recitprose"/>Μαντευομένης τινὸς περὶ τοῦ ἑαυτῆς παιδὸς νηπίου ὄντος, οἱ μάντεις προέλεγον ὅτι ὑπὸ κόρακος ἀναιρεθήσεται. Διόπερ φοϐουμένη λάρνακα μεγίστην κατασκευάσασα ἐν ταύτῃ αὐτὸν καθεῖρξε, φυλαττομένη μὴ ὑπὸ κόρακος ἀναιρεθῇ. Καὶ διετέλει τεταγμέναις ὥραις ἀναπεταννῦσα καὶ τὰς ἐπιτηδείους αὐτῷ τροφὰς παρεχομένη. Καί ποτε ἀνοιξάσης αὐτῆς καὶ τὸ πόμα ἐπιθείσης, ὁ παῖς ἀπροφυλάκτως παρέκυψεν. Οὕτω τε συνέϐη τῆς λάρνακος τὸν κόρακα κατὰ τοῦ βρέγματος κατενεχθέντα ἀποκτεῖναι αὐτόν.</p>
-        <p><milestone unit="manuscrits"/>Cod. Pa 159.</p>
+        <bibl>Cod. Pa 159.</bibl>
         <p><milestone unit="traduction"/>Une femme interrogea les devins sur son fils en bas âge. Ils prédirent qu’il serait tué par un corbeau. Épouvantée de cette prédiction, elle fit construire une arche très grande et l’y enferma, pour l’empêcher d’être tué par un corbeau ; et tous les jours, à des heures déterminées, elle l’ouvrait et donnait à l’enfant la nourriture qu’il lui fallait. Or un jour qu’elle avait ouvert l’arche et remettait le couvercle, l’enfant avait imprudemment passé la tête dehors. Il arriva ainsi que le corbeau de l’arche, s’abattant sur le haut de sa tête, le tua.</p>
       </div>
       <div type="poem" xml:id="chambry-296">
@@ -8113,7 +8112,7 @@
           <pb ed="perry" n="P363"/>
           <p><milestone unit="recitprose"/>Υἱόν τις μονογενῆ γέρων δειλὸς ἔχων γενναῖον καὶ κυνηγεῖν ἐφιέμενον, τοῦτον καθ’ ὕπνους εἶδεν ὑπὸ λέοντος θανατωθέντα. Φοϐηθεὶς δὲ μὴ ὕπαρ γένηται καὶ ἀληθεύσῃ ὁ ὄνειρος, οἴκημα κάλλιστον καὶ μετέωρον κατασκευάσας, ἐκεῖσε τὸν υἱὸν παρεφύλαττε. Ἐζωγράφησε δὲ καὶ τὸ οἴκημα πρὸς τέρψιν παντοίοις ζῴοις, ἐν οἷς καὶ λέων ἐμορφώθη. Ὁ δὲ ταῦτα μᾶλλον ὁρῶν πλείω τὴν λύπην εἶχε. Καὶ δήποτε πλησίον τοῦ λέοντος στάς· « Ὦ κάκιστον θηρίον, εἶπε, διὰ σὲ καὶ τὸν ψεύστην ὄνειρον τοῦ ἐμοῦ πατρὸς γυναικείᾳ ἐνεκλείσθην φρουρᾷ· τί σοι ποιήσω ; » Καὶ εἰπὼν ἐπέϐαλε τὴν χεῖρα τῷ τοίχῳ ὡς τυφλώσων τὸν λέοντα. Σκόλοψ δὲ τῷ ὄνυχι αὐτοῦ ὑπεισδὺς ἄλγημα ὀξὺ καὶ φλεγμονὴν μέχρι βουϐώνων εἰργάσατο· πυρετός τε ἐπὶ τούτοις ἀνάψας τὸν παῖδα θᾶττον τοῦ βίου ὑπεξήγαγεν. Ὁ δὲ λέων καίπερ γραπτὸς ὢν τοῦτον ἀνῃρήκει, μηδὲν τῷ τοῦ πατρὸς ὠφεληθέντα σοφίσματι.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἃ δὴ μέλλει συμϐαίνειν τινί, ἐγκαρτερείτω τούτοις γενναίως καὶ μὴ σοφιζέσθω· οὐ γὰρ ἐκφεύξεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 135 Bb 82.</p>
+          <bibl>Codd. Ba 135 Bb 82.</bibl>
           <p><milestone unit="traduction"/>Un vieillard craintif avait un fils unique plein de courage et passionné pour la chasse ; il le vit en songe périr sous la griffe d’un lion. Craignant que le songe ne fût véritable et ne se réalisât, il fit aménager un appartement élevé et magnifique, et il y garda son fils. Il avait fait peindre, pour le distraire, des animaux de toute sorte, parmi lesquels figurait aussi un lion. Mais la vue de toutes ces peintures ne faisait qu’augmenter l’ennui du jeune homme. Un jour s’approchant du lion : « Mauvaise bête, s’écria-t-il, c’est à cause de toi et du songe menteur de mon père qu’on m’a enfermé dans cette prison pour femmes. Que pourrais-je bien te faire ? » À ces mots, il asséna sa main sur le mur, pour crever l’œil du lion. Mais une pointe s’enfonça sous son ongle et lui causa une douleur aiguë et une inflammation qui aboutit à une tumeur. La fièvre s’étant allumée là-dessus le fit bientôt passer de vie à trépas. Le lion, pour n’être qu’un lion en peinture, n’en tua pas moins le jeune homme, à qui l’artifice de son père ne servit de rien.</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il faut accepter bravement le sort qui nous attend, et ne point ruser avec lui, car on ne saurait y échapper.</p>
         </div>
@@ -8123,7 +8122,7 @@
           <pb ed="perry" n="P363"/>
           <p><milestone unit="recitprose"/>Υἱόν τις γέρων δειλὸς μονογενῆ ἔχων γενναῖον, κυνηγεῖν ἐφιέμενον, εἶδε τοῦτον καθ’ ὕπνους ὑπὸ λέοντος ἀναλωθέντα. Φοϐηθεὶς δὲ μή πως ὁ ὄνειρος ἀληθεύσῃ, οἴκημα κάλλιστον καὶ μετέωρον κατεσκεύασε, κἀκεῖσε τὸν υἱὸν εἰσαγαγὼν ἐφύλαττεν. Ἐζωγράφησε δὲ ἐν τῷ οἰκήματι πρὸς τέρψιν τοῦ υἱοῦ παντοῖα ζῷα, ἐν οἷς ἦν καὶ λέων. Ὁ δὲ ταῦτα μᾶλλον ὁρῶν πλείονα λύπην εἶχε. Καὶ δήποτε πλησίον τοῦ λέοντος στὰς εἶπεν· « Ὦ κάκιστον θηρίον, διὰ σὲ καὶ τὸν ψευδῆ ὄνειρον τοῦ ἐμοῦ πατρὸς τῇδε τῇ οἰκίᾳ κατεκλείσθην, ὡς ἐν φρουρᾷ· τί σοι ποιήσω ; » Καὶ εἰπὼν ἐπέϐαλε τῷ τοίχῳ τὴν χεῖρα ἐκτυφλῶσαι τὸν λέοντα. Σκόλοψ δὲ τῷ δακτύλῳ αὐτοῦ ἐμπαρεὶς ὄγκωμα καὶ φλεγμονὴν μέχρι βουϐῶνος εἰργάσατο· πυρετὸς δὲ ἐπιγενόμενος αὐτῷ θᾶττον τοῦ βίου μετέστησεν. Ὁ δὲ λέων καὶ οὕτως ἀνῄρηκε τὸν παῖδα, μηδὲν τῷ τοῦ πατρὸς ὠφεληθέντα σοφίσματι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδεὶς δύναται τὸ μέλλον ἐκφυγεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Md 105 Mh 89 Mi 21 Mm 130 Mn 32 Ld 32.</p>
+          <bibl>Codd. Md 105 Mh 89 Mi 21 Mm 130 Mn 32 Ld 32.</bibl>
         </div>
         <div>
           <head>Chambry 296.3</head>
@@ -8153,7 +8152,7 @@
           <l><milestone unit="recitvers"/>Ὑπανάψας δὲ πυρετὸς ἐξαπίνης,</l>
           <l><milestone unit="recitvers"/>θᾶττον ὁ νέος ἐξέλιπε τὸν βίον.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἃ μέλλει συμϐῆναί τινι, τούτοις γενναίως ἐγκαρτερείτω καὶ μὴ κατασοφιζέσθω· οὐ γὰρ ἐκφεύξεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 187 Cb 100 Cd 117 Ch 123 Mb 209 Mc 93.</p>
+          <bibl>Codd. Ca 187 Cb 100 Cd 117 Ch 123 Mb 209 Mc 93.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-297">
@@ -8164,7 +8163,7 @@
           <pb ed="perry" n="P200"/>
           <p><milestone unit="recitprose"/>Παῖς ἐκ διδασκαλείου τὴν τοῦ συμφοιτητοῦ δέλτον ὑφελόμενος τῇ μητρὶ ἐκόμισε. Τῆς δὲ οὐ μόνον αὐτῷ μὴ ἐπιπληξάσης, ἀλλὰ μᾶλλον ἐπαινεσάσης αὐτὸν, ἐκ δευτέρου ἱμάτιον κλέψας ἤνεγκεν αὐτῇ. Ἔτι δὲ μᾶλλον ἐπαινεσάσης αὐτὸν ἐκείνης, προϊὼν τοῖς χρόνοις, ὡς νεανίας ἐγένετο, ἤδη καὶ τὰ μείζονα κλέπτειν ἐπεχείρει. Ληφθεὶς δέ ποτε ἐπ’ αὐτοφώρῳ καὶ περιαγκωνισθεὶς ἐπὶ τὸν δήμιον ἀπήγετο. Τῆς δὲ ἐπακολουθούσης αὐτῷ καὶ στερνοκοπουμένης, εἶπε βούλεσθαί τι αὐτῇ εἰπεῖν πρὸς τὸ οὖς· καὶ ἐπεὶ τάχιστα αὐτῷ προσῆλθε, τοῦ ὠτίου ἐπιλαϐόμενος, κατέδακεν αὐτό. Τῆς δὲ κατηγορούσης αὐτοῦ δυσσέϐειαν, εἴπερ μὴ ἀρκεσθεὶς οἷς ἤδη πεπλημμέληκε, καὶ τὴν μητέρα ἐλωϐήσατο, ἐκεῖνος ὑποτυχὼν εἶπεν· « Ἀλλὰ τότε ὅτε σοι πρῶτον τὴν δέλτον κλέψας ἤνεγκα, εἰ ἐπέπληξάς μοι, οὐκ ἂν μέχρι τούτου ἐχώρησα, ὡς καὶ ἐπὶ θάνατον ἀπάγεσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὸ κατ’ ἀρχὰς κολαζόμενον ἐπὶ μεῖζον αὔξεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 201 Pf 111 Pg 125 Mb 176 Me 145 Mf 120.</p>
+          <bibl>Codd. Pa 201 Pf 111 Pg 125 Mb 176 Me 145 Mf 120.</bibl>
           <p><milestone unit="traduction"/>Un enfant déroba à l’école les tablettes de son camarade et les apporta à sa mère, qui, au lieu de le corriger, le loua. Une autre foiss il vola un manteau et le lui apporta ; elle le loua encore davantage. Dès lors, croissant en âge et devenu jeune homme, il se porta à des vols plus importants. Mais un jour il fut pris sur le fait ; on lui lia les mains derrière le dos, et on le conduisit au bourreau. Sa mère l’accompagnait et se frappait la poitrine. Il déclara qu’il voulait lui dire quelque chose à l’oreille. Aussitôt qu’elle se fut approchée, il lui saisit le lobe de l’oreille et le trancha d’un coup de dents. Elle lui reprocha son impiété : non content des crimes qu’il avait déjà commis, il venait encore de mutiler sa mère ! Il répondit : « Si, au temps où je t’apportai pour la première fois la tablette que j’avais volée, tu m’avais battu, je n’en serais pas venu au point où j’en suis : on ne me conduirait pas à la mort. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que ce qu’on ne réprime pas dès le début grandit et s’accroît.</p>
         </div>
@@ -8174,7 +8173,7 @@
           <pb ed="perry" n="P200"/>
           <p><milestone unit="recitprose"/>Παῖς ἐκ διδασκαλείου τὴν τοῦ συμφοιτητοῦ δέλτον ἀνελόμενος τῇ μητρὶ ἐκόμισε. Τῆς δὲ οὐ μόνον αὐτὸν οὐκ ἐπιπληξάσης, ἀλλὰ καὶ ἐπαινεσάσης αὐτόν, ἐκ δευτέρου ἱμάτιον κλέψας ἤνεγκεν αὐτῇ, καὶ ἔτι μᾶλλον ἐκείνη ἀπεδέξατο. Προϊὼν δὲ τοῖς χρόνοις ὁ νεανίας ἐπὶ τὰ μείζονα ἐχώρει. Ληφθεὶς δέ ποτε καὶ περιαγκωνισθεὶς ἐπὶ τὸν δήμιον ἀπήγετο. Τῆς δὲ μητρὸς ἐπακολουθούσης αὐτῷ καὶ στερνοκοπουμένης, ὁ νεανίας εἶπεν· « Θέλω τι εἰπεῖν τῇ μητρί μου εἰς τὸ οὖς. » Τῆς δὲ προσελθούσης ταχέως, ἐπελάϐετο τοῦ ὠτὸς αὐτῆς καὶ ἀπέκοψε. Τῆς δὲ κατηγορούσης αὐτὸν ὡς δυσσεϐῆ, ἐκεῖνος ἔφη· « Ἀλλὰ τότε ὅτε σοι πρῶτον τὴν δέλτον κλέψας ἤνεγκα, εἰ ἔπληξάς με, οὐκ ἂν μέχρι τούτου ἐχώρησα, καὶ ἐπὶ θάνατον ἠγόμην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὸ κατ’ ἀρχὰς μὴ κωλυόμενον ἐπὶ μεῖζον αὔξει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pb 196.</p>
+          <bibl>Cod. Pb 196.</bibl>
         </div>
         <div>
           <head>Chambry 297.3</head>
@@ -8182,7 +8181,7 @@
           <pb ed="perry" n="P200"/>
           <p><milestone unit="recitprose"/>Παῖς ἐκ τοῦ διδασκαλείου τὴν τοῦ συμφοιτητοῦ δέλτον κλέψας τῇ ἑαυτοῦ μητρὶ ἐπιδέδωκε. Τῆς δὲ μὴ ἐπιπληξάσης αὐτόν, ἀλλὰ μᾶλλον ἀποδεξαμένης, ἐκ δευτέρου ἱμάτιον κλέψας ἤνεγκεν αὐτῇ· ἔτι δὲ μᾶλλον αὐτῆς ἀποδεξαμένης, προϊόντος τοῦ χρόνου, ὁ παῖς, ὡς νεανίας ἤδη γέγονεν, ἤρξατο καὶ τὰ μείζονα κλέπτειν. Ληφθεὶς οὖν ποτε ἐπ’ αὐτοφώρῳ καὶ περιαγκωνισθεὶς ἐπὶ τὸν δήμιον ἀπήγετο. Τῆς δὲ μητρὸς ἐπακολουθούσης αὐτῷ καὶ στερνοκτυπούσης, εἶπεν ὁ παῖς πρὸς τοὺς δημίους· « Ἐάσατέ με λαλῆσαι τῇ μητρί μου πρὸς τὸ οὖς λόγον ἕνα. » Τῆς δὲ ταχέως ἐλθούσης, καὶ τὸ οὖς αὐτῆς τῷ στόματι τοῦ υἱοῦ αὐτῆς ἐπιθείσης, τοῖς ὀδοῦσιν αὐτοῦ τοῦ ὠτίου αὐτῆς γενναίως δραξάμενος, ἀπέκοψεν αὐτό. Τῆς δὲ βοησάσης καὶ εἰπούσης ὡς ἤδη πεπλημμέληκεν, οὐ μὴν ἀλλὰ καὶ τοῦ λαοῦ κατηγοροῦντος αὐτοῦ ὡς μὴ ἀρκεσθέντος τοῖς προτέροις κακοῖς, ἀλλὰ καὶ εἰς τὴν ἰδίαν μητέρα ἠσεϐηκότος, ἔφη ἐκεῖνος· « Αὕτη ἐγένετο τῆς ἐμῆς ἀπωλείας αἰτία· εἰ γὰρ ἡνίκα τὴν τοῦ συμφοιτητοῦ μου δέλτον ἔκλεψα καὶ ἤνεγκα αὐτῇ, ἐπέπληξέ μοι, οὐκ ἂν μέχρι τούτων ἐχώρησα καὶ ἐπὶ τὸν θάνατον ἠγόμην. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τὸ κακὸν κατ’ ἀρχὰς μὴ κολαζόμενον ἐπὶ μεῖζον αὔξεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 159 Cb 93 Ce 94 Cf 100 Cg 38 Ch 113.</p>
+          <bibl>Codd. Ca 159 Cb 93 Ce 94 Cf 100 Cg 38 Ch 113.</bibl>
         </div>
         <div>
           <head>Chambry 297.4</head>
@@ -8208,7 +8207,7 @@
           <l><milestone unit="recitvers"/>τὸ πρῶτον ἐτύπτησάς με, ὅτε δέλτον</l>
           <l><milestone unit="recitvers"/>σοι ἔφερον, οὐκ ἂν φόνῳ παρεδόθην. »</l>
           <p><milestone unit="epimythiumprose"/>Οὗτος ὁ μῦθος λέγει· Δεῖ τοὺς φρονίμους τὰς ῥίζας ἐκκόπτειν τῶν σφαλμάτων· ἤγουν τὰς ἀρχὰς τῶν ἁμαρτημάτων καὶ τῶν ἄλλων κακῶν, ὅπως τῆς ῥίζης κοπείσης οἱ κλάδοι ξηρανθῶσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Cd 107.</p>
+          <bibl>Cod. Cd 107.</bibl>
         </div>
         <div>
           <head>Chambry 297.5</head>
@@ -8216,7 +8215,7 @@
           <pb ed="perry" n="P200"/>
           <p><milestone unit="recitprose"/>Παῖς ἐκ διδασκαλείου τὴν τοῦ συμμαθητοῦ δέλτον κλέψας ἤνεγκε τῇ μητρί. Τῆς δὲ μὴ ἐπιπληξάσης, μᾶλλον μὲν οὖν ἀποδεξαμένης, προϊὼν τοῖς χρόνοις ἤρξατο καὶ τὰ μείζω κλέπτειν. Ἐπ’ αὐτοφώρῳ δέ ποτε ληφθεὶς ἀπήγετο τὴν πρὸς θάνατον. Τῆς δὲ μητρὸς ἑπομένης καὶ ὀλοφυρομένης, ἐκεῖνος τῶν δημίων ἐδεῖτο βραχέα τινὰ τῇ μητρὶ διαλεχθῆναι πρὸς οὖς. Τῆς δέ ταχέως τὸ οὖς τῷ στόματι τοῦ παιδὸς προσθείσης, ἐκεῖνος τὸ οὖς τοῖς ὀδοῦσι δακὼν ἀφείλετο. Τῆς δὲ μητρὸς καὶ τῶν ἄλλων κατηγορούντων ὡς οὐ μόνον κέκλοφεν, ἀλλ’ ἤδη καὶ εἰς τὴν μητέρα ἠσέϐηκεν, ἐκεῖνος εἶπεν· « Αὕτη γάρ μοι τῆς ἀπολείας γέγονεν αἴτιος· εἰ γὰρ ὅτε τὴν δέλτον ἐκεκλόφειν, ἐπέπληξέ μοι, οὐκ ἂν μέχρι τούτων χωρήσας νῦν ἠγόμην ἐπὶ τὸν θάνατον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν μὴ κατ’ ἀρχὰς κολαζομένων ἐπὶ μεῖζον αὐξάνει τὰ κακά.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 48 Lb 110 Lc 22 Ld 30 Le 110 Lf 48 Lg 22 Lh 60 Mc 87 Md 97 Mg 134 Mi 13 Mj 131 Ml 137 Mm 119 Mn 30.</p>
+          <bibl>Codd. La 48 Lb 110 Lc 22 Ld 30 Le 110 Lf 48 Lg 22 Lh 60 Mc 87 Md 97 Mg 134 Mi 13 Mj 131 Ml 137 Mm 119 Mn 30.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-298">
@@ -8227,7 +8226,7 @@
           <pb ed="perry" n="P211"/>
           <p><milestone unit="recitprose"/>Παῖς ποτε λουόμενος ἔν τινι ποταμῷ ἐκινδύνευσεν ἀποπνιγῆναι. Ἰδὼν δέ τινα ὁδοιπόρον, τοῦτον ἐπὶ βοηθείᾳ ἐκάλει. Ὁ δὲ ἐμέμφετο τῷ παιδὶ ὡς τολμηρῷ. Τὸ δὲ μειράκιον εἶπε πρὸς αὐτόν· « Ἀλλὰ νῦν μοι βοήθει, ὕστερον δὲ σωθέντι μέμψῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος εἴρηται πρὸς τοὺς ἀφορμὴν καθ’ ἑαυτῶν διδόντας ἀδικεῖσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 167 Pb 207 Pg 132 Mb 177.</p>
+          <bibl>Codd. Ca 167 Pb 207 Pg 132 Mb 177.</bibl>
           <p><milestone unit="traduction"/>Un jour un enfant qui se baignait dans une rivière se vit en danger d’être noyé. Ayant aperçu un voyageur, il l’appela à son secours. Le voyageur lui reprocha sa témérité. « Ah ! répliqua le jeune garçon, tire-moi d’affaire tout de suite ; plus tard, quand tu m’auras sauvé, tu me feras des reproches. »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse aux gens qui fournissent contre eux-mêmes des raisons de les maltraiter.</p>
         </div>
@@ -8237,7 +8236,7 @@
           <pb ed="perry" n="P211"/>
           <p><milestone unit="recitprose"/>Παῖς λουόμενος ἐν ποταμῷ ἐκινδύνευε πνιγῆναι. Καὶ ἰδών τινα παροδίτην ἐπεφώνει· « Βοήθησόν τι. » Ὁ δὲ ἐμέμφετο τῷ παιδὶ τολμηρίαν. Τὸ δὲ παιδίον εἶπεν· « Ἀλλὰ νῦν μοι βοήθησον· ὕστερον δὲ σωθέντα μέμφου. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι μὴ μέμφου, πλὴν ἐλέει· καὶ γὰρ παράπληκτον ποιεῖς τὸν λυπούμενον.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 106 Cf 113.</p>
+          <bibl>Codd. Ce 106 Cf 113.</bibl>
         </div>
         <div>
           <head>Chambry 298.3</head>
@@ -8245,7 +8244,7 @@
           <pb ed="perry" n="P211"/>
           <p><milestone unit="recitprose"/>Οὔπω κολυμϐᾶν μειράκιον μαθὸν ποταμὸν διειδῆ καὶ καλὸν θεωρῆσαν ἔρριψεν ἑαυτὸν γυμνὸν ὡς κολυμϐήσων. Τὸ ῥεῦμα δὲ αὐτὸ καὶ τὸ βάθος οὐκ εἴα στῆναι. Τὸ δὲ βουκόλον ἐφώνει· « Ἀπὸ τῆς ὄχθης τὰς χεῖρας ἔκτεινον. » Ὁ δὲ τολμηρὸν ἐκάλει καὶ οὐκ ἐδίδου χεῖρα. Τὸ δὲ εἶπεν· « Ἄρτι μοι βοήθει, ἕξεις δὲ καιρὸν ἐλέγχειν, ὅταν σώσῃς με. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς ἐν κινδύνοις ἀπείρως ἐμπεσόντας δεῖ πρότερον σῴζειν, ἔπειτα διδάσκειν καὶ νουθετεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 115.</p>
+          <bibl>Cod. Ba 115.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-299">
@@ -8254,7 +8253,7 @@
         <pb ed="perry" n="P239"/>
         <p><milestone unit="recitprose"/>Παρακαταθήκην τις λαϐὼν φίλου ἀποστερεῖν διενοεῖτο. Καὶ δὴ προσκαλουμένου αὐτὸν ἐκείνου ἐπὶ ὅρκον, εὐλαϐούμενος εἰς ἀγρὸν ἐπορεύετο. Γενόμενος δὲ κατὰ τὰς πύλας, ὡς ἐθεάσατό τινα χωλὸν ἐξιόντα, ἐπυνθάνετο αὐτοῦ τίς τε εἴη καὶ ποῖ πορεύοιτο. Τοῦ δὲ εἰπόντος αὑτὸν Ὅρκον εἶναι καὶ ἐπὶ τοὺς ἀσεϐεῖς βαδίζειν, ἐκ δευτέρου ἠρώτα διὰ πόσου χρόνου ἐπιφοιτᾶν ταῖς πόλεσι εἴωθεν. Ὁ δὲ ἔφη· « Διὰ τεσσαράκοντα ἐτῶν, ἐνίοτε δὲ καὶ τριάκοντα. » Καὶ ὃς οὐδὲν μελλήσας τῇ ὑστεραίᾳ ὄμοσε μὴ εἰληφέναι τὴν παρακαταθήκην. Περιπεσὼν δὲ τῷ Ὅρκῳ, καὶ ἀπαγόμενος ὑπ’ αὐτοῦ ἐπὶ κρημνόν, ᾐτιᾶτο αὐτὸν ὡς προειπὼν αὐτῷ διὰ τριάκοντα ἐτῶν ἐπιπορεύεσθαι, οὐδὲ πρὸς μίαν ἡμέραν ἄδειαν δέδωκεν. Ὁ δὲ ὑπολαϐὼν ἔφη· « Ἀλλ’ εὖ ἴσθι ὡς, ὅταν μέλλῃ τις ἀνιᾶσαί με, καὶ αὐθημερὸν ἐπιφοιτᾶν εἴωθα. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἀδιόριστός ἐστιν ἡ κατὰ τῶν ἀσεϐῶν ἐκ θεοῦ τιμωρία.</p>
-        <p><milestone unit="manuscrits"/>Codd. Mb 175 Pf 110 Ma 128 Me 157 Mf 131.</p>
+        <bibl>Codd. Mb 175 Pf 110 Ma 128 Me 157 Mf 131.</bibl>
         <p><milestone unit="traduction"/>Un homme qui avait reçu un dépôt d’un ami projetait de l’en frustrer. Comme cet ami l’appelait à prêter serment, pris d’inquiétude, il partit pour la campagne. Arrivé aux portes de la ville, il aperçut un boiteux qui sortait et lui demanda qui il était et où il allait. Celui-ci ayant répondu qu’il était le Serment et qu’il marchait contre les impies, il lui posa une seconde question : « Après combien de temps reviens-tu d’habitude dans les villes ? – Au bout de quarante ans, parfois même de trente », répondit-il. Dès lors l’homme jura le lendemain sans hésiter qu’il n’avait pas reçu le dépôt. Mais il tomba sur le Serment, qui l’emmena pour le précipiter. L’homme récrimina : « Tu m’as déclaré, dit-il, que tu ne revenais qu’au bout de trente ans, et tu ne m’accordes même pas un jour de sécurité. » Le Serment repartit : « Sache bien que, quand on veut m’agacer, j’ai l’habitude de revenir le jour même. »</p>
         <p><milestone unit="traduction"/>Cette fable montre que Dieu n’a pas de jour fixe pour punir les impies.</p>
       </div>
@@ -8266,7 +8265,7 @@
           <pb ed="perry" n="P94"/>
           <p><milestone unit="recitprose"/>Ἔχων τις δύο θυγατέρας, τὴν μὲν κηπουρῷ ἐξέδωκε πρὸς γάμον, τὴν δὲ ἑτέραν κεραμεῖ. Χρόνου δὲ προελθόντος, ἧκεν ὡς τὴν τοῦ κηπουροῦ καὶ ταύτην ἠρώτα πῶς ἔχοι καὶ ἐν τίνι αὐτοῖς εἴη τὰ πράγματα. Τῆς δὲ εἰπούσης πάντα μὲν αὐτοῖς παρεῖναι, ἓν δὲ τοῦτο εὔχεσθαι τοῖς θεοῖς, ὅπως χειμὼν γένηται καὶ ὄμϐρος, ἵνα τὰ λάχανα ἀρδευθῇ, μετ’ οὐ πολὺ παρεγένετο πρὸς τὴν τοῦ κεραμέως καὶ αὐτῆς ἐπυνθάνετο πῶς ἔχοι. Τῆς δὲ τὰ μὲν ἄλλα μὴ ἐνδεῖσθαι εἰπούσης, τοῦτο δὲ μόνον εὔχεσθαι, ὅπως αἰθρία τε λαμπρὰ ἐπιμείνῃ καὶ λαμρπὸς ἥλιος, ἵνα ξηρανθῇ ὁ κέραμος, εἶπε πρὸς αὐτήν· « Ἐὰν σὺ μὲν εὐδίαν ἐπιζητῇς, ἡ δὲ ἀδελφή σου χειμῶνα, ποτέρᾳ ὑμῶν συνεύξομαι ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ ἐν ταὐτῷ τοῖς ἀνομίοις πράγμασιν ἐπειχειροῦντες εἰκότως περὶ τὰ ἑκάτερα πταίουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 90 Pb 95 Pe 56 Pf 49 Pg 63 Ph 51 Ma 68 Ca 77.</p>
+          <bibl>Codd. Pa 90 Pb 95 Pe 56 Pf 49 Pg 63 Ph 51 Ma 68 Ca 77.</bibl>
           <p><milestone unit="traduction"/>Un homme qui avait deux filles avait donné en mariage l’une à un jardinier, l’autre à un potier. Au bout de quelque temps, il alla voir la femme du jardinier, et lui demanda comment elle allait et où en étaient leurs affaires. Elle répondit que tout marchait à souhait et qu’elle n’avait qu’une chose à demander aux dieux, de l’orage et de la pluie pour arroser les légumes. Peu de temps après il se rendit chez la femme du potier et lui demanda comment elle se trouvait. Elle répondit que rien ne leur manquait et qu’elle n’avait qu’un vœu à former, c’est que le temps restât clair et le soleil brillant, pour sécher la poterie. – « Si toi, reprit le père, tu demandes le beau temps, et ta sœur, le mauvais, avec laquelle de vous formerai-je des vœux ? »</p>
           <p><milestone unit="traduction"/>De même si l’on fait en même temps deux entreprises contraires, on les manque naturellement toutes les deux.</p>
         </div>
@@ -8276,7 +8275,7 @@
           <pb ed="perry" n="P94"/>
           <p><milestone unit="recitprose"/>Γυνή τις, θυγατέρων οὖσα δυοῖν μήτηρ, ἀνδράσι συνῆψε ταύτας, τὴν μὲν κηπωρῷ, θἀτέραν δὲ κεραμεῖ. Ἐλθοῦσα τοίνυν ποτὲ πρὸς τὴν τῷ κηπωρῷ γεγαμημένην, τά τε ἄλλα ὡμίλει, καὶ πῶς ἔχοι διηρώτα. Ἡ δέ· « Τὰ μὲν ἄλλα, μῆτερ, ἔφη, καλῶς· εὔχου δ’ ὑετῶν ἡμῖν γενέσθαι φοράν, ὡς τοῖς λαχάνοις ἐξ ἀρδείας αὔξησις ἡ κατὰ λόγον προσγένοιτο. » Ἐκεῖθεν δ’ ἐξελθοῦσα καὶ πρὸς τὴν συνοικοῦσαν τῷ κεραμεῖ ἀφικνεῖται. Τοῖς δ’ αὐτοῖς χρησαμένη καὶ πρὸς ἐκείνην ἤκουσεν ὡς· « Τὰ μὲν ἄλλα καλῶς ἡμῖν, ὦ μῆτερ, ἔχει· εὔχου δ’ αἰθρίαν ἡμῖν καὶ ἡλίους γίνεσθαι θερμοτέρους τε καὶ καθαρωτέρους, ὡς ἂν θᾶττον οἱ κέραμοι ψύχοιντο. » Καὶ ἡ μήτηρ πρὸς ταῦτα ἔφη· « Σοὶ μὲν αἰθρίαν, τῇ δὲ τῷ κηπωρῷ συνοικούσῃ παμπόλλους ὑετοὺς δοῖεν οἱ θεοί. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος &lt;ὅτι&gt; οἳ μηδὲν ἐκ τῶν ἰδίων ἔχουσι χαρίζεσθαι, ῥᾳδίως τοῖς αἰτοῦσι τὰ τῶν ἄλλων ἐπαγγέλλονται, [κἂν οὐδένων εἰσὶν ἐλάττω].</p>
-          <p><milestone unit="manuscrits"/>Codd. La 68 Lb 29 Le 29 Lf 68 Ml 38 Lh 13 Md 122 Mi 96 Mm 47 Me 36 Mf 33 Mj 34.</p>
+          <bibl>Codd. La 68 Lb 29 Le 29 Lf 68 Ml 38 Lh 13 Md 122 Mi 96 Mm 47 Me 36 Mf 33 Mj 34.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-301">
@@ -8294,7 +8293,7 @@
           <l><milestone unit="recitvers"/>« Διὰ γὰρ τοῦτο μᾶλλον ἐγώ σε θύσω,</l>
           <l><milestone unit="recitvers"/>ὅτι φίλους σοὺς προσενεδρεῦσαι θέλεις. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ κατὰ τῶν ἑαυτοῦ φίλων δολίας μηχανὰς συντιθεὶς αὐτὸς ἐν ταῖς ἐνέδραις τῶν κινδύνων ἐμπεσεῖται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 172 Cb 90 Cd 104 Cg 35 Ch 110 Mb 195.</p>
+          <bibl>Codd. Ca 172 Cb 90 Cd 104 Cg 35 Ch 110 Mb 195.</bibl>
         </div>
         <div>
           <head>Chambry 301.2</head>
@@ -8309,7 +8308,7 @@
           <l><milestone unit="recitvers"/>« Σὺ &lt;δὴ&gt; ταῖς πέρδιξι προσαγγεῖλαι θέλεις</l>
           <l><milestone unit="recitvers"/>εἰς χεῖρας ἐμάς τινα μὴ πλησιάσαι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς τὸ μηδ’ ὅλως πιστεύειν τοῖς ἐχθροῖς.</p>
-          <p><milestone unit="manuscrits"/>Cod. T 4.</p>
+          <bibl>Cod. T 4.</bibl>
         </div>
         <div>
           <head>Chambry 301.3</head>
@@ -8317,7 +8316,7 @@
           <pb ed="perry" n="P265"/>
           <p><milestone unit="recitprose"/>Πέρδικά τις ἀγρεύσας ἤθελε ταύτην καταθῦσαι. Ἡ δὲ παρεκάλει ἐκλυθῆναι καὶ πολλὰς πέρδικας προσάξει τῷ κυνηγέτῃ. Ὁ δὲ κυνηγός· « Διὰ τοῦτο μᾶλλόν σε ἐγὼ θύσω, ὅτι τοὺς συγγενεῖς σου ἐνεδρεῦσαι θέλεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοὺς φίλους προδιδόντες αὐτοὶ ἐν ταῖς ἐνέδραις ἐμπίπτουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 98 Cf 105.</p>
+          <bibl>Codd. Ce 98 Cf 105.</bibl>
         </div>
         <div>
           <head>Chambry 301.4</head>
@@ -8325,7 +8324,7 @@
           <pb ed="perry" n="P265"/>
           <p><milestone unit="epimythiumprose"/>Πέρδικά τις θηρεύσας ἤμελλε σφάξαι. Ἡ δὲ ἱκέτευε λέγουσα· « Ἔασόν με ζῆν καὶ ἀντ’ ἐμοῦ πολλὰς πέρδικας ἐγώ σοι κυνηγήσω. » Ὁ δὲ εἶπεν· « Δι’ αὐτὸ τοῦτο μᾶλλόν σε θύσω, ὅτι τοὺς συνήθεις καὶ φίλους σοι ἐνεδρεῦσαι θέλεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ὁ κατὰ φίλων αὐτοῦ δολίας μηχανὰς συντιθεὶς αὐτὸς ἐν ταῖς ἐνέδραις τῶν κινδύνων ἐμπεσεῖται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 122 Bb 73.</p>
+          <bibl>Codd. Ba 122 Bb 73.</bibl>
           <p><milestone unit="traduction"/>Un homme, ayant pris à la chasse une perdrix, allait la tuer. Elle le supplia en ces termes : « Laisse-moi vivre ; à ma place je te ferai prendre beaucoup de perdrix. – Raison de plus pour te tuer, repartit l’homme, puisque tu veux prendre au piège tes camarades et tes amis. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’homme qui trame des machinations contre ses amis tombera lui-même dans les embûches et le danger.</p>
         </div>
@@ -8338,7 +8337,7 @@
           <pb ed="perry" n="P201"/>
           <p><milestone unit="recitprose"/>Περιστερὰ δίψει συνεχομένη, ὡς ἐθεάσατο ἔν τινι πίνακι κρατῆρα ὕδατος γεγραμμένον, ὑπέλαϐεν ἀληθινὸν εἶναι. Διόπερ πολλῷ ῥοίζῳ ἐνεχθεῖσα ἔλαθεν ἑαυτὴν τῷ πίνακι ἐντινάξασα. Συνέϐη δὲ αὐτῇ, τῶν πτερῶν περιθραυσθέντων, ἐπὶ τῆς γῆς καταπεσοῦσαν ὑπό τινος τῶν παρατυχόντων συλληφθῆναι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων διὰ σφοδρὰς ἐπιθυμίας ἀπροσκέπτως τοῖς πράγμασιν ἐπιχειροῦντες λανθάνουσιν ἑαυτοὺς εἰς ὄλεθρον εἰσιέντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 202 Pb 197 Pf 112 Pg 126 Mb 179 Me 146 Mf 121 Ca 160.</p>
+          <bibl>Codd. Pa 202 Pb 197 Pf 112 Pg 126 Mb 179 Me 146 Mf 121 Ca 160.</bibl>
           <p><milestone unit="traduction"/>Une colombe pressée par la soif, ayant aperçu un cratère d’eau peint sur un tableau, crut qu’il était véritable. Aussi, descendant à grand bruit, elle se heurta imprudemment contre le tableau, et se cassa le bout des ailes. Il arriva ainsi qu’elle tomba à terre et fut prise par quelqu’un qui était là.</p>
           <p><milestone unit="traduction"/>Pareillement certains hommes, entraînés par la violence de leurs passions, s’engagent inconsidérément dans les entreprises et courent, sans qu’ils s’en doutent, à leur perte.</p>
         </div>
@@ -8348,7 +8347,7 @@
           <pb ed="perry" n="P201"/>
           <p><milestone unit="recitprose"/>Περιστερὰ δίψῃ συνεχομένη, ὡς ἐθεάσατο ἔν τινι τόπῳ κρατῆρα ὕδατος γεγραμμένον, ἐνόμισεν ἀληθινὸν εἶναι. Διὸ καὶ πολλῷ τῷ ῥοίζῳ ἐνεχθεῖσα ἔλαθεν ἑαυτὴν τῷ πίνακι ἐμπεσοῦσα, ὡς καὶ τῶν πτερῶν αὐτῆς περικλασθέντων καταπεσεῖν ἐπὶ γῆν καὶ ὑπό τινος τῶν παρατυχόντων ἁλῶναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἔνιοι τῶν ἀνθρώπων διὰ σφοδρὰς προθυμίας ἀπερισκέπτως τοῖς πράγμασιν ἐγχειροῦντες ἐμϐάλλουσιν ἑαυτοὺς εἰς ὄλεθρον.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 124 Lb 114 Le 114 Lf 124 Lh 64 Mg 138 Mj 135 Ml 140.</p>
+          <bibl>Codd. La 124 Lb 114 Le 114 Lf 124 Lh 64 Mg 138 Mj 135 Ml 140.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-303">
@@ -8359,7 +8358,7 @@
           <pb ed="perry" n="P202"/>
           <p><milestone unit="recitprose"/>Περιστερὰ ἔν τινι περιστεροτροφείῳ τρεφομένη ἐπὶ πολυτεκνίᾳ ἐφρυάττετο. Κορώνη δὲ ἀκούσασα αὐτῆς τῶν λόγων ἔφη· « Ἀλλ’, ὦ αὕτη, πέπαυσο ἐπὶ τούτῳ ἀλαζονευομένη· ὅσῳ γὰρ ἂν πλέονα τέκνα σχῇς, τοσούτῳ περισσοτέρας δουλείας στενάξεις. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν οἰκετῶν δυστυχέστατοί εἰσιν ὅσοι ἐν τῇ δουλείᾳ τεκνοποιοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 203 Pb 198 Pc 109 Pe 60 Pf 113 Pg 127 Ma 129 Mb 180 Me 147 Mf 122 Ca 161 La 125 Lb 115 Le 115 Lf 125 Lh 65 Mg 139 Mj 136 Ml 136.</p>
+          <bibl>Codd. Pa 203 Pb 198 Pc 109 Pe 60 Pf 113 Pg 127 Ma 129 Mb 180 Me 147 Mf 122 Ca 161 La 125 Lb 115 Le 115 Lf 125 Lh 65 Mg 139 Mj 136 Ml 136.</bibl>
           <p><milestone unit="traduction"/>Une colombe nourrie dans un pigeonnier faisait grand bruit de sa fécondité. Une corneille ayant entendu ses vanteries, lui dit : « Hé ! l’amie, cesse de te vanter de cela ; car plus tu feras d’enfants, plus tu auras d’esclavages à déplorer. »</p>
           <p><milestone unit="traduction"/>Il en est de même des serviteurs : les plus malheureux sont ceux qui ont le plus d’enfants dans la servitude.</p>
         </div>
@@ -8369,7 +8368,7 @@
           <pb ed="perry" n="P202"/>
           <p><milestone unit="recitprose"/>Περιστερὰ ἔν τινι περιστερεῶνι τρεφομένη ἐν πολυτεκνογονείᾳ ἐφρυάττετο. Κορώνη δὲ ἀκούσασα ταύτην ἔφη· « Παῦσαι τοῦ ἀλαζομεύεσθαι· ὅσον γὰρ πλέονα τέκνα ἔχεις, τοσοῦτον περισσοτέρους δούλους συνάξεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τῶν οἰκετῶν δυστυχέστεροί εἰσιν ὅσοι ἐν δουλείᾳ τεκνοποιοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 100 Cf 107.</p>
+          <bibl>Codd. Ce 100 Cf 107.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-304">
@@ -8380,7 +8379,7 @@
           <pb ed="perry" n="P266"/>
           <p><milestone unit="recitprose"/>Προμηθεὺς πλάσας ποτὲ ἀνθρώπους δύο πήρας ἐξ αὐτῶν ἀπεκρέμασε, τὴν μὲν ἀλλοτρίων κακῶν, τὴν δὲ ἰδίων, καὶ τὴν μὲν τῶν ὀθνείων ἔμπροσθεν ἔταξε, τὴν δὲ ἑτέραν ὄπισθεν ἀπήρτησεν. Ἐξ οὗ δὴ συνέϐη τοὺς ἀνθρώπους τὰ μὲν ἀλλότρια κακὰ ἐξ ἀπόπτου κατοπτάζεσθαι, τὰ δὲ ἴδια μὴ προορᾶσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Τούτῳ τῷ λόγῳ χρήσαιτο ἄν τις πρὸς ἄνδρα πολυπράγμονα, ὃς ἐν τοῖς ἑαυτοῦ πράγμασι τυφλώττων τῶν μηδὲν προσηκόντων κήδεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 214 Pc 113.</p>
+          <bibl>Codd. Pa 214 Pc 113.</bibl>
           <p><milestone unit="traduction"/>Jadis Prométhée, ayant façonné les hommes, suspendit à leur cou deux sacs, l’un qui renferme les défauts d’autrui, l’autre, leurs propres défauts, et il plaça par devant le sac des défauts d’autrui, tandis qu’il suspendit l’autre par derrière. Il en est résulté que les hommes voient d’emblée les défauts d’autrui, mais n’aperçoivent pas les leurs.</p>
           <p><milestone unit="traduction"/>On peut appliquer cette fable au brouillon, qui, aveugle dans ses propres affaires, se mêle de celles qui ne le regardent aucunement.</p>
         </div>
@@ -8390,7 +8389,7 @@
           <pb ed="perry" n="P266"/>
           <p><milestone unit="recitprose"/>Προμηθεὺς ὁ θεός, ὥς φασι, πρῶτον ἄνθρωπον πλάττων, δύο πήρας πηλίνας αὐτῷ ἀπεκρέμασε γεμούσας κακῶν, τὴν μὲν ἔμπροσθεν, τὴν βραχυτάτην, τῶν ἀλλοτρίων, τὴν δὲ ὄπισθεν, τὴν μείζω, τῶν ἰδίων.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ ἄνθρωποι τὰς ἀλλοτρίας μᾶλλον συμφορὰς βλέπουσιν ἀκριϐῶς, τὰς δὲ οἰκείας ἀγνοοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Mb 196 Ba 50.</p>
+          <bibl>Codd. Mb 196 Ba 50.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-305">
@@ -8401,7 +8400,7 @@
           <pb ed="perry" n="P203"/>
           <p><milestone unit="recitprose"/>Πίθηκος ἐπί τινος ὑψηλοῦ δένδρου καθίσας, ὡς ἐθεάσατο ἁλιεῖς ἐπί τινος ἠϊόνος σαγήνην βάλλοντας, παρετηρεῖτο τὰ ὑπ’ αὐτῶν πραττόμενα. Ὡς δὲ ἐκεῖνοι τὴν σαγήνην ἀνασπάσαντες μικρὸν ἄποθεν ἠρίστων, καταϐὰς ἐπειρᾶτο καὶ αὐτὸς τὰ αὐτὰ πράττειν· φασὶ δὲ μιμητικὸν εἶναι τὸ ζῷον. Ἐφαψάμενος δὲ τῶν δικτύων, ὡς συνελήφθη, ἔφη πρὸς ἑαυτόν· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γὰρ ἁλιεύειν μὴ μαθὼν τούτῳ ἐπεχείρουν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ τῶν μηδὲν προσηκόντων ἐπιχείρησις οὐ μόνον ἀσύμφορος, ἀλλὰ καὶ ἐπιϐλαϐής ἐστιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 204 Pb 199 Pg 128 Mb 181.</p>
+          <bibl>Codd. Pa 204 Pb 199 Pg 128 Mb 181.</bibl>
         </div>
         <div>
           <head>Chambry 305.2</head>
@@ -8409,7 +8408,7 @@
           <pb ed="perry" n="P203"/>
           <p><milestone unit="recitprose"/>Πίθηξ ἔν τινι ὑψηλῷ δένδρῳ καθήμενος, ὡς ἐθεάσατο ἁλιεῖς ἐπί τινος ποταμοῦ σαγήνην βάλλοντας, παρετήρει τὰ ὑπ’ αὐτῶν γινόμενα. Καὶ δὴ τούτων τὴν σαγήνην ἐασάντων, καὶ μικρὸν ὑποχωρησάντων τοῦ φαγεῖν, καταϐὰς ἀπὸ τοῦ δένδρου, ἐπειρᾶτο μιμεῖσθαι αὐτούς· φασὶ γὰρ μιμητικὸν εἶναι τὸ ζῷον τοῦτο. Ἐφαψάμενος δὲ τῶν δικτύων καὶ συλληφθεὶς ἐκινδύνευε πνιγῆναι. Ὁ δὲ πρὸς ἑαυτὸν ἔφη· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γὰρ ἁλιεύειν μὴ μαθὼν τούτῳ ἐπεχείρουν ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ τῶν μηδὲν προσηκόντων ἐπιχείρησις οὐ μόνον ἀσύμφορος, ἀλλὰ καὶ ἐπιϐλαϐής ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 162 Cd 108 Ce 95 Cf 101 Cg 39 Ch 114 Ml 144.</p>
+          <bibl>Codd. Ca 162 Cd 108 Ce 95 Cf 101 Cg 39 Ch 114 Ml 144.</bibl>
           <p><milestone unit="traduction"/>Un singe perché sur un arbre élevé, ayant vu des pêcheurs jeter la seine dans une rivière, observait leur manière de faire. A un moment donné, laissant là leur seine, ils se retirèrent à quelque distance pour prendre leur déjeuner. Alors le singe, descendant de son arbre, essaya de faire comme eux ; car cette bête a, dit-on, l’instinct d’imitation. Mais quand il eut touché aux filets, il se prit dedans et se vit en danger d’être noyé. Il se dit alors : « Je n’ai que ce que je mérite : pourquoi ai-je entrepris de pêcher, sans avoir appris ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’à se mêler d’affaire que l’on n’entend pas, non seulement on ne gagne rien, mais encore on se nuit.</p>
         </div>
@@ -8419,7 +8418,7 @@
           <pb ed="perry" n="P203"/>
           <p><milestone unit="recitprose"/>Μίμηλόν ἐστι φύσει ζῷον ἡ πίθηκος. Μία οὖν ἐπὶ τοῦ αἰγιαλοῦ ἑστῶσα εἶδεν ἐπὶ τοῦ χείλους τῆς θαλάσσης ἡπλωμένον καὶ ἡλιαζόμενον δίκτυον. Τοῦτο ἄρασα ἐπειρᾶτο εἰς βυθὸν βαλεῖν· τὸ δὲ ἐπὶ τοῦ τραχήλου εἰληθὲν εἷλκε τὴν μιμῶ κατὰ τοῦ βυθοῦ. Ἡ δ’ ἐλάλαζεν ὅτι μηδεὶς ὃ μὴ ἔμαθεν μηδὲ ποιείτω.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι μηδεὶς ὃ μὴ ἔμαθε μηδὲ ἐκ πείρας ἔχει πειράτω ποιεῖν· σὺν τῇ ἀπειρίᾳ γὰρ καὶ κακόν τι προσλήψεται.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 93.</p>
+          <bibl>Cod. Ba 93.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-306">
@@ -8430,7 +8429,7 @@
           <pb ed="perry" n="P73"/>
           <p><milestone unit="recitprose"/>Ἔθος ἐστὶ τοῖς πλέουσιν ἐπάγεσθαι κύνας Μελιταίους καὶ πιθήκους πρὸς παραμυθίαν τοῦ πλοῦ. Καὶ δή τις πλεῖν μέλλων πίθηκον συνανήνεγκε. Γενομένων δὲ αὐτῶν κατὰ Σούνιον (ἐστὶ δὲ τοῦτο Ἀθηναίων ἀκρωτήριον) συνέϐη χειμῶνα σφοδρὸν γενέσθαι. Περιτραπείσης δὲ τῆς νηὸς καὶ πάντων διακολυμϐώντων, καὶ ὁ πίθηκος ἐνήχετο. Δελφὶς δὲ θεασάμενος αὐτὸν καὶ οἰόμενος ἄνθρωπον εἶναι ὑπεξελθὼν διεκόμιζεν. Ὡς δὲ ἐγένετο κατὰ τὸν Πειραιᾶ, τὸν λιμένα τῶν Ἀθηναίων, ἐπυνθάνετο τοῦ πιθήκου εἰ τὸ γένος Ἀθηναῖός ἐστι. Τοῦ δὲ εἰπόντος καὶ λαμπρῶν ἐνταῦθα τετυχηκέναι γονέων, ἐκ δευτέρου ἤρετο αὐτὸν εἰ ἐπίσταται τὸν Πειραιᾶ. Καὶ ὃς ὑπολαϐὼν αὐτὸν ἄνθρωπον λέγειν, ἔφασκε καὶ φίλον αὐτῷ καὶ συνήθη τοῦτον. Καὶ ὁ δελφὶς ἀγανακτήσας κατὰ τῆς αὐτοῦ ψευδολογίας βαπτίζων αὐτὸν ἀπέκτεινε.</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ψευδολόγον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 70 Pb 74 Pe 40 Pg 47 Ma 53 Mb 41.</p>
+          <bibl>Codd. Pa 70 Pb 74 Pe 40 Pg 47 Ma 53 Mb 41.</bibl>
         </div>
         <div>
           <head>Chambry 306.2</head>
@@ -8438,7 +8437,7 @@
           <pb ed="perry" n="P73"/>
           <p><milestone unit="recitprose"/>Ἔθους ὄντος τοῖς πλέουσι Μελιταῖα κυνίδια καὶ πιθήκους ἐπάγεσθαι πρὸς παραμυθίαν τοῦ πλοῦ, πλέων τις εἶχε σὺν ἑαυτῷ καὶ πίθηκον. Γενομένων δ’ αὐτῶν κατὰ τὸ Σούνιον, τὸ τῆς Ἀττικῆς ἀκρωτήριον, χειμῶνα σφοδρὸν συνέϐη γενέσθαι. Τῆς δὲ νεὼς περιτραπείσης καὶ πάντων διακολυμϐώντων, ἐνήχετο καὶ ὁ πίθηκος. Δελφὶς δέ τις αὐτὸν θεασάμενος καὶ ἄνθρωπον εἶναι ὑπολαϐών, ὑπελθὼν ἀνεῖχε διακομίζων ἐπὶ τὴν χέρσον. Ὡς δὲ κατὰ τὸν Πειραιᾶ ἐγένετο, τὸ τῶν Ἀθηναίων ἐπίνειον, ἐπυνθάνετο τοῦ πιθήκου εἰ τὸ γένος ἐστὶν Ἀθηναῖος. Τοῦ δὲ εἰπόντος καὶ λαμπρῶν ἐνταῦθα τετυχηκέναι γονέων, ἐπανήρετο εἰ καὶ τὸν Πειραῖα ἐπίσταται. Ὑπολαϐὼν δὲ ὁ πίθηκος περὶ ἀνθρώπου αὐτὸν λέγειν, ἔφη καὶ μάλα φίλον εἶναι αὐτῷ καὶ συνήθη. Καὶ ὁ δελφὶς ἐπὶ τοσούτῳ ψεύδει ἀγανακτήσας, βαπτίζων αὐτὸν ἀπέκτεινεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας οἳ τὴν ἀλήθειαν οὐκ εἰδότες ἀπατᾶν νομίζουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 92 Lb 47 Le 47 Lf 92 Me 54 Mg 70 Mj 57 Ml 67.</p>
+          <bibl>Codd. La 92 Lb 47 Le 47 Lf 92 Me 54 Mg 70 Mj 57 Ml 67.</bibl>
           <p><milestone unit="traduction"/>C’est la coutume, quand on voyage par mer, d’emmener avec soi de petits chiens de Malte et des singes pour se distraire pendant la traversée. Or donc un homme qui naviguait avait avec lui un singe. Quand on arriva à Sunion, promontoire de l’Attique, une tempête violente se déchaîna. Le navire chavira et tout le monde se sauva à la nage, le singe comme les autres. Un dauphin l’aperçut, et, le prenant pour un homme, il se glissa sous lui, le soutint et le transporta vers la terre ferme. Comme il arrivait au Pirée, entrepôt maritime d’Athènes, il demanda au singe s’il était Athénien. Le singe ayant répondu que oui, et qu’il avait même à Athènes des parents illustres, il lui demanda s’il connaissait aussi le Pirée. Le singe, croyant qu’il voulait parler d’un homme, dit que oui, et que c’était même un de ses intimes amis. Indigné d’un tel mensonge, le dauphin le plongea dans l’eau et le noya.</p>
           <p><milestone unit="traduction"/>Cette fable vise les hommes qui, ne connaissant pas la vérité, pensent en faire accroire aux autres.</p>
         </div>
@@ -8449,7 +8448,7 @@
         <pb ed="perry" n="P83"/>
         <p><milestone unit="recitprose"/>Ἐν συνόδῳ τῶν ἀλόγων ζῴων πίθηκος ἀναστὰς ὠρχήσατο. Σφόδρα δὲ αὐτοῦ εὐδοκιμοῦντος καὶ ὑπὸ πάντων ὑποσημαινομένου, κάμηλος φθονήσασα ἐϐουλήθη τῶν αὐτῶν ἐφικέσθαι. Διόπερ ἐξαναστᾶσα ἐπειρᾶτο καὶ αὐτὴ ὀρχεῖσθαι. Πολλὰ δὲ αὐτῆς ἄτοπα ποιούσης, τὰ ζῷα ἀγανακτήσαντα ῥοπάλοις αὐτὴν παίοντα ἐξήλασαν.</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς διὰ φθόνον κρείττοσιν ἁμιλλωμένους ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 80 Pb 84 Pc 43 Pe 48 Ma 63 Mb 49 Mj 51 Ca 71 Lb 54 Le 54.</p>
+        <bibl>Codd. Pa 80 Pb 84 Pc 43 Pe 48 Ma 63 Mb 49 Mj 51 Ca 71 Lb 54 Le 54.</bibl>
         <p><milestone unit="traduction"/>Dans une assemblée des bêtes un singe se leva et dansa. Il fut fort apprécié et applaudi de toute l’assistance. Un chameau envieux voulut gagner les mêmes éloges. Il se leva et essaya lui aussi de danser ; mais il fit mainte extravagance, et les animaux indignés le mirent dehors à coups de bâton.</p>
         <p><milestone unit="traduction"/>Cette fable convient à ceux qui par envie rivalisent avec de meilleurs qu’eux.</p>
       </div>
@@ -8461,7 +8460,7 @@
           <pb ed="perry" n="P218"/>
           <p><milestone unit="recitprose"/>Τοὺς πιθήκους φασὶ δύο τίκτειν καὶ τὸ μὲν ἓν τῶν γεννημάτων στέργειν καὶ μετ’ ἐπιμελείας τρέφειν, τὸ δὲ ἕτερον μισεῖν καὶ ἀμελεῖν. Συμϐαίνει δὲ κατά τινα θείαν τύχην τὸ μὲν ἐπιμελούμενον ἡδέως καὶ στερρῶς ἀγκαλιζόμενον παρὰ τῆς μητρὸς ἀποπνίγεσθαι, τὸ δὲ ὀλιγωρούμενον ἐκτελειοῦσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πάσης προνοίας ἡ τύχη δυνατωτέρα καθέστηκε.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 182 Cb 99 Cd 115 Ce 113 Cf 121 Ch 122 Mc 92 Pb 215 Pb 139 Ma 135.</p>
+          <bibl>Codd. Ca 182 Cb 99 Cd 115 Ce 113 Cf 121 Ch 122 Mc 92 Pb 215 Pb 139 Ma 135.</bibl>
           <p><milestone unit="traduction"/>Les guenons, dit-on, mettent au monde deux petits ; de ces deux enfants elles chérissent et nourrissent l’un avec sollicitude, quant à l’autre, elles le haïssent et le négligent. Or il arrive par une fatalité divine que le petit que sa mère soigne avec complaisance et serre avec force dans ses bras meurt étouffé par elle, et que celui qu’elle néglige arrive à une croissance parfaite.</p>
           <p><milestone unit="traduction"/>Cette fable montre que la fortune est plus puissante que toute notre prévoyance.</p>
         </div>
@@ -8471,7 +8470,7 @@
           <pb ed="perry" n="P218"/>
           <p><milestone unit="recitprose"/>Δύο γεννᾷ τέκνα μιμώ· καὶ τὸ μὲν ἓν ἀγαπᾷ, τὸ δὲ ἕτερον μισεῖ. Καὶ ὃ μὲν στέργει, ἀεὶ ἐν τοῖς κόλποις περιφέρουσα καὶ τιθεῖσα ἔνθεν κἀκεῖθεν καὶ τοῦτο καταφιλοῦσα ἀποπνίγει· ὃ δὲ μισεῖ, διώκει. Τοῦτο δὲ ἐν ταῖς ἐρημίαις ἀπελθὸν ζῇ καθ’ ἑαυτό.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοιοῦτον ἦθός τινες τῶν ἀνθρώπων ἔχουσιν, οἷς ἀεὶ μᾶλλον ἐχθραίνειν ἐστὶ καλὸν ἢ φιλεῖν· [ὅπερ καὶ περὶ γονέων πολλάκις πρὸς οἰκεῖα γίνεται τέκνα, ὡς δῆθεν φίλων αὐτὰ τῆς σωτηρίας ἐμποδίζουσιν· ὅσα δὲ δῆθεν μισοῦσι, αὐτὰ εὐκόλως πρὸς σωτηρίαν ἀπέρχονται καὶ τὸ τῶν μονάχων σχῆμα περιϐάλλονται.]</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 30 Bb 19 Mg 53.</p>
+          <bibl>Codd. Ba 30 Bb 19 Mg 53.</bibl>
         </div>
         <div>
           <head>Chambry 308.3</head>
@@ -8479,14 +8478,14 @@
           <pb ed="perry" n="P218"/>
           <p><milestone unit="recitprose"/>Δύο τέκνων μητέρα τὸν πίθηκον εἶναι ἀκήκοα· ἀμφοτέροις οὖν κληρονομίαν χαρίζεσθαι, τῷ μὲν τὸ μῖσος, τῷ δὲ τὴν οἰκείαν ἀγάπην, δι’ ἧς καὶ ἀποκτείνει τὸ πεφιλημένον, συχνῶς περιπτυσσομένη καὶ περιλείχουσα. Τὸ δὲ μισηθὲν τὰς ἐρήμους φοιτῆσαν, διέδρασε τὸν κίνδυνον.</p>
           <p><milestone unit="epimythiumprose"/>Κρείττω ἡμῖν τῆς κακίστης φιλίας τὴν ἐχθρὰν ἐλέγχει ὁ μῦθος.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 24.</p>
+          <bibl>Cod. Bc 24.</bibl>
         </div>
         <div>
           <head>Chambry 308.4</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P218"/>
           <p><milestone unit="recitprose"/>Ὁ πίθηκος δύο τέκνα τεκών· τὸ μὲν ἕτερον τούτων ἀγαπῶν ἐνστερνίζεται, τὸ δὲ ἕτερον ἀποστρέφεται· καὶ ὃ μὲν ἀγαπᾷ, ἐν τοῖς κόλποις ἀεὶ περισφίγγει καὶ θανατοῖ ἀποπνίγουσα· ὃ δὲ μισεῖ, μὴ περισφιγγόμενον ἀποφεύγει τὸν θάνατον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 13.</p>
+          <bibl>Cod. Bd 13.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-309">
@@ -8495,7 +8494,7 @@
         <pb ed="perry" n="P78"/>
         <p><milestone unit="recitprose"/>Ἐμϐάντες τινὲς εἰς σκάφος ἔπλεον. Γενομένων δὲ αὐτῶν πελαγίων, συνέϐη χειμῶνα ἐξαίσιον γενέσθαι καὶ τὴν ναῦν μικροῦ καταδύεσθαι. Τῶν δὲ πλέοντων ἕτερος περιρρηξάμενος τοὺς πατρῴους θεοὺς ἐπεκαλεῖτο μετ’ οἰμωγῆς καὶ στεναγμοῦ χαριστήρια ἀποδώσειν ἐπαγγελλόμενος, ἐὰν περισωθῶσι. Παυσαμένου δὲ τοῦ χειμῶνος καὶ πάλιν καινῆς γαληνῆς γενομένης, εἰς εὐωχίαν τραπέντες ὠρχοῦντό τε καὶ ἐσκίρτων, ἅτε δὴ ἐξ ἀπροσδοκήτου διαπεφευγότες κινδύνου. Καὶ στερρὸς ὁ κυϐερνήτης ὑπάρχων ἔφη πρὸς αὐτούς· « Ἀλλ’, ὦ φίλοι, οὕτως ἡμᾶς γεγηθέναι δεῖ ὡς πάλιν, ἐὰν τύχῃ, χειμῶνος γενησομένου. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος διδάσκει μὴ σφόδρα ταῖς εὐτυχίαις ἐπαίρεσθαι τῆς τύχης τὸ εὐμετάϐλητον ἐννοουμένους.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 75 Pb 79 Pc 40 Pf 38 Ph 40 Ma 58.</p>
+        <bibl>Codd. Pa 75 Pb 79 Pc 40 Pf 38 Ph 40 Ma 58.</bibl>
         <p><milestone unit="traduction"/>Des gens, étant montés dans un bateau, prirent la mer. Quand ils furent au large, une violente tempête se déclara, et le vaisseau fut sur le point de sombrer. L’un des passagers déchirant ses vêtements invoquait les dieux de son pays avec larmes et gémissements et leur promettait des offrandes en actions de grâces, s’ils sauvaient le vaisseau. Mais la tempête ayant cessé et le calme étant revenu, ils se mirent à faire bonne chère, à danser, à sauter, comme des gens qui viennent d’échapper à un danger inattendu. Alors le pilote, esprit solide, leur dit : « Mes amis, réjouissons-nous, mais comme des gens qui reverront peut-être la tempête. »</p>
         <p><milestone unit="traduction"/>La fable enseigne qu’il ne faut pas trop s’enorgueillir de ses succès, et qu’il faut songer à l’inconstance de la fortune.</p>
       </div>
@@ -8507,7 +8506,7 @@
           <pb ed="perry" n="P204"/>
           <p><milestone unit="recitprose"/>Πλούσιος βυρσοδέψῃ παρῳκίσθη· μὴ δυνάμενος δὲ τὴν δυσωδίαν φέρειν διετέλει ἑκάστοτε αὐτῷ ἐπικείμενος, ἵνα μεταϐῇ. Ὁ δὲ ἀεὶ αὐτὸν διανεϐάλλετο λέγων μετ’ ὀλίγον χρόνον μεταϐήσεσθαι. Τούτου δὲ συνεχῶς γενομένου, συνέϐη, χρόνου διελθόντος, τὸν πλούσιον ἠθάδα τῆς ὀσμῆς γενόμενον μηκέτι αὐτῷ διενοχλεῖν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ συνήθεια καὶ τὰ δυσχερῆ τῶν πραγμάτων καταπραΰνει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 205 Pb 200 Ma 130 Mb 182.</p>
+          <bibl>Codd. Pa 205 Pb 200 Ma 130 Mb 182.</bibl>
           <p><milestone unit="traduction"/>Un homme riche vint demeurer près d’un tanneur. Comme il ne pouvait supporter la mauvaise odeur, il le pressait sans cesse de déménager. Le tanneur le remettait toujours, promettant de déménager dans quelque temps. Comme leur débat se renouvelait sans cesse, il advint à la longue que l’homme riche s’habitua à l’odeur et cessa d’importuner le tanneur.</p>
           <p><milestone unit="traduction"/>Cette fable montre que l’habitude adoucit les désagréments.</p>
         </div>
@@ -8517,7 +8516,7 @@
           <pb ed="perry" n="P204"/>
           <p><milestone unit="recitprose"/>Πλούσιος βυρσεῖ γειτονεύων καὶ μὴ δυνάμενος τὴν δυσωδίαν φέρειν ἐπέκειτο τῷ βυρσεῖ τοῦ μεταϐῆναι ἐκεῖθεν. Ὁ δὲ ἀνεϐάλετο λέγων μετ’ ὀλίγον χρόνον. Τούτου δὲ συχνῶς γενομένου, συνέϐη γενέσθαι συνήθη τῇ δυσωδίᾳ, καὶ οὐκέτ’ αὐτὸν ἐνώχλει.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἡ συνήθεια καὶ τὰ δυσχερῆ καταπραΰνει πράγματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 101 Cf 108.</p>
+          <bibl>Codd. Ce 101 Cf 108.</bibl>
         </div>
         <div>
           <head>Chambry 310.3</head>
@@ -8525,7 +8524,7 @@
           <pb ed="perry" n="P204"/>
           <p><milestone unit="recitprose"/>Ἐν τόπῳ τινὶ πλησίον ἀνδρὸς πλουσίου βυρσοδέψης ἔμελλεν οἰκῆσαι. Ὁ δὲ τοῦτον ἐδίωκε διὰ τὴν δυσοσμίαν. Τοῦ δὲ λέγοντος· « Πρὸς ὀλίγον ἀνιαθήσῃ, μέχρις οὗ συνεθίσῃς, καὶ ἔκτοτε οὐκέτι ὀσφρανθήσῃ, » ἔφη· « Οὐ διὰ τὴν σὴν τέχνην ἡμεῖς τὴν αἴσθησιν ἡμῶν ἀποϐαλοῦμεν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ δεῖ κοινωνεῖν ταῖς ματαίαις συμϐουλίαις, μάλιστα ταῖς πρὸς βλάϐην τῆς φύσεως οὔσαις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 35 Mg 61.</p>
+          <bibl>Codd. Ba 35 Mg 61.</bibl>
         </div>
         <div>
           <head>Chambry 310.4</head>
@@ -8540,7 +8539,7 @@
           <l><milestone unit="recitvers"/>« Τί διὰ τὴν σὴν ἥνπερ κτᾶσαι νῦν τέχνην</l>
           <l><milestone unit="recitvers"/>ἡμεῖς ἅπαντες διώξομεν ὀσφρήσεις ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι οὐ χρὴ ἡμᾶς συγκοινωνεῖν ταῖς ματαίαις συμϐουλίαις.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 120.</p>
+          <bibl>Cod. Mb 120.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-311">
@@ -8551,7 +8550,7 @@
           <pb ed="perry" n="P205"/>
           <p><milestone unit="recitprose"/>Πλούσιος δύο θυγατέρας ἔχων, τῆς ἑτέρας ἀποθανούσης, τὰς θρηνούσας ἐμισθώσατο. Τῆς δὲ ἑτέρας παιδὸς λεγούσης πρὸς τὴν μητέρα· « Ἄθλιαι ἡμεῖς, εἴγε αὐταί, ὧν ἐστι τὸ πάθος, θρηνεῖν οὐκ ἴσμεν, αἱ δὲ μηδὲν προσήκουσαι οὕτω σφόδρα κόπτονται καὶ κλαίουσιν, » ἐκείνη ὑποτοχοῦσα εἶπεν· « Ἀλλὰ μὴ θαύμαζε, τέκνον, εἰ οὕτως οἰκτρῶς αὗται θρηνοῦσιν· ἐπὶ γὰρ ἀργυρίῳ τοῦτο ποιοῦσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀνθρώπων διὰ φιλαργυρίαν οὐκ ὀκνοῦσι καὶ ἀλλοτρίας συμφορὰς ἐργολαϐεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 206 Pb 201 Pc 110 Pe 61 Pf 114 Pg 129 Mb 183 Me 148 Mf 123 Ca 163 Cf 109 La 126 Lb 116 Le 116 Lf 126 Mg 140 Mj 137 Ml 141.</p>
+          <bibl>Codd. Pa 206 Pb 201 Pc 110 Pe 61 Pf 114 Pg 129 Mb 183 Me 148 Mf 123 Ca 163 Cf 109 La 126 Lb 116 Le 116 Lf 126 Mg 140 Mj 137 Ml 141.</bibl>
           <p><milestone unit="traduction"/>Un homme riche avait deux filles. L’une d’elles étant morte, il loua des pleureuses à gages. L’autre fille dit à sa mère : « Nous sommes bien malheureuses : c’est nous que regarde le deuil et nous ne savons pas faire les lamentations, tandis que ces femmes, qui ne nous sont rien, se frappent et pleurent avec tant de violence. » La mère lui répondit : « Ne t’étonne pas, mon enfant, si ces femmes font des lamentations si pitoyables : elles les font pour de l’argent. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que certains hommes, poussés par l’intérêt, n’hésitent pas à trafiquer des malheurs d’autrui.</p>
         </div>
@@ -8561,7 +8560,7 @@
           <pb ed="perry" n="P205"/>
           <p><milestone unit="recitprose"/>Πλούσιός τις δύο θυγατέρας ἔχων, συνέϐη τελευτῆσαι τὴν μίαν. Καὶ δὴ θρηνητρίας μισθωσάμενος, ᾠδικώτερον ἔκλαιον. Τῆς δὲ ἑτέρας αὐτοῦ θυγατρὸς πρὸς τὴν αὑτῆς μητέρα εἰπούσης· « Ἄθλιαι αὐταί, εἴγε ὧν ἐστι τὸ πάθος θρηνεῖν οὐκ ἴσμεν, αἱ δὲ &lt;μὴ&gt; προσήκουσαι αὗται οὕτω σφοδρῶς κόπτονται. » Πρὸς δὲ &lt;αὐτὴν&gt; ἡ μήτηρ ἔφη· « Μὴ θαύμαζε, τέκνον· ἐπὶ προσδοκίᾳ γὰρ ἀργυρίου τοῦτο ποιοῦσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ &lt;ὅτι&gt; διὰ φιλαργυρίαν οὐκ ὀκνοῦσιν ἀλλοτρίας συμφορὰς ἐργολαϐεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ce 102.</p>
+          <bibl>Cod. Ce 102.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-312">
@@ -8572,7 +8571,7 @@
           <pb ed="perry" n="P207"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἔν τινι παραθαλασσίῳ τόπῳ νέμων, ὡς ἐθεάσατο τὴν θάλασσαν γαληνήν τε καὶ πραεῖαν, ἐπεθύμησε πλεῖν. Διόπερ πωλήσας τὰ πρόϐατα, φοίνικας ἐπρίατο καὶ ναῦν ἐμφορτισάμενος ἀνήχθη. Χειμῶνος δὲ σφοδροῦ γενομένου καὶ τῆς νηὸς περιτραπείσης, πάντα ἀπολέσας, μόλις ἐπὶ γῆς διενήξατο. Πάλιν δὲ γαλήνης γενομένης, ὡς ἐθεάσατό τινα ἐπὶ τῆς ἠϊόνος ἐπαινοῦντα τῆς θαλάσσης τὴν ἠρεμίαν, ἔφη· « Ἀλλ’, ὦ οὗτος, αὕτη γάρ σοι φοινίκων ἐπιθυμεῖ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις τὰ παθήματα τοῖς φρονίμοις γίνονται μαθήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 208 Pb 203 Pe 63 Pf 116 Pg 130 Mb 185.</p>
+          <bibl>Codd. Pa 208 Pb 203 Pe 63 Pf 116 Pg 130 Mb 185.</bibl>
         </div>
         <div>
           <head>Chambry 312.2</head>
@@ -8580,7 +8579,7 @@
           <pb ed="perry" n="P207"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἔν τινι τόπῳ παραθαλασσίῳ ποίμνια νέμων, ὡς ἐθεάσατο τὴν θάλασσαν γαληνήν τε καὶ πραεῖαν, ἐπεθύμησε πλεῦσαι πρὸς ἐμπορίαν. Διόπερ πωλήσας αὐτοῦ τὰ πρόϐατα καὶ φοίνικας ἀγοράσας ναῦν ἐμφορτωσάμενος ἀνήχθη. Χειμῶνος δὲ σφορδοῦ γενομένου καὶ τῆς νηὸς περιτραπείσης, πάντα ἀπολέσας, αὐτὸς μόλις ἐπὶ τῆς γῆς διεσώθη. Μετ’ οὐ πολλὰς οὖν ἡμέρας τῆς θαλάσσης γαληνιώσης, ὡς ἐθεάσατό τινα παριόντα καὶ ἐπαινοῦντα τῆς θαλάσσης τὴν ἠρεμίαν ἔφη· « Ὦ οὗτος, αὕτη γάρ σοι φοινίκων ἐπιθυμεῖ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλάκις τὰ παθήματα τοῖς φρονίμοις γίνεται μαθήματα.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 164 Cb 94 Cd 109 Ce 96 Cf 102 Cg 40 Ch 115.</p>
+          <bibl>Codd. Ca 164 Cb 94 Cd 109 Ce 96 Cf 102 Cg 40 Ch 115.</bibl>
         </div>
         <div>
           <head>Chambry 312.3</head>
@@ -8588,7 +8587,7 @@
           <pb ed="perry" n="P207"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἐν παραθαλασσίῳ τόπῳ ποίμνιον νέμων, ἑωρακὼς γαληνιῶσαν τὴν θάλατταν, ἐπεθύμησε πλεῦσαι πρὸς ἐμπορίαν. Ἀπεμπολήσας οὖν τὰ πρόϐατα καὶ φοινίκων βαλάνους πριάμενος ἀνήχθη. Χειμῶνος δὲ σφοδροῦ γενομένου καὶ τῆς νεὼς κινδυνευούσης βαπτίζεσθαι, πάντα τὸν φόρτον ἐκϐαλὼν εἰς τὴν θάλατταν, μόλις κενῇ τῇ νηῒ διεσώθη. Μετὰ δ’ ἡμέρας οὐκ ὀλίγας παριόντος τινὸς καὶ τῆς θαλάττης (ἔτυχε γὰρ αὕτη γαληνιῶσα) τὴν ἠρεμίαν θαυμάζοντος, ὑπολαϐὼν οὗτος εἶπεν· « Ὦ λῷστε, φοινίκων αὖθις, ὡς ἔοικεν, ἐπιθυμεῖ, καὶ διὰ τοῦτο φαίνεται ἡσυχάζουσα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τὰ παθήματα τοῖς ἀνθρώποις μαθήματα γίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 49 Lb 111 Lc 23 Ld 31 Le 111 Lf 49 Lg 23 Lh 61 Mc 88 Md 98 Me 150 Mf 125 Mg 135 Mi 14 Mj 132 Ml 138 Mm 120 Mn 31.</p>
+          <bibl>Codd. La 49 Lb 111 Lc 23 Ld 31 Le 111 Lf 49 Lg 23 Lh 61 Mc 88 Md 98 Me 150 Mf 125 Mg 135 Mi 14 Mj 132 Ml 138 Mm 120 Mn 31.</bibl>
           <p><milestone unit="traduction"/>Un berger qui paissait un troupeau sur le bord de la mer, en voyant le calme des flots, se mit en tête de naviguer pour faire du commerce. En conséquence il vendit ses moutons, acheta des dattes et mit à la voile. Mais une violente tempête survint, et, le bateau risquant de sombrer, il jeta à la mer toute sa cargaison, et se sauva à grand’peine avec son vaisseau vide. Assez longtemps après, un homme vint à passer. Comme il admirait le calme de la mer, qui était en effet tranquille à ce moment, notre berger, prenant la parole, lui dit : « Ah ! mon brave, elle a encore envie de dattes, à ce qu’il paraît : c’est pour cela qu’elle se montre tranquille.</p>
           <p><milestone unit="traduction"/>Cette fable montre que les accidents sont des leçons pour les hommes.</p>
         </div>
@@ -8601,7 +8600,7 @@
           <pb ed="perry" n="P206"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἔχων κύνα παμμεγέθη τούτῳ εἰώθει τὰ ἔμϐρυα καὶ τὰ ἀποθνῄσκοντα τῶν προϐάτων παραϐάλλειν. Καὶ δή ποτε εἰσελθούσης τῆς ποίμνης, ὁ ποιμὴν θεασάμενος τὸν κύνα προσιόντα τοῖς προϐάτοις καὶ σαίνοντα αὐτὰ εἶπεν· « Ἀλλ’, ὦ οὗτος, ὃ θέλεις σὺ τούτοις ἐπὶ τῇ σῇ κεφαλῇ γένοιτο. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα κόλακα ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 207 Pb 202 Pc 111 Pe 62 Pf 115 Mb 184 Me 149 Mf 124 Ce 103 Cf 110.</p>
+          <bibl>Codd. Pa 207 Pb 202 Pc 111 Pe 62 Pf 115 Mb 184 Me 149 Mf 124 Ce 103 Cf 110.</bibl>
           <p><milestone unit="traduction"/>Un berger qui avait un très gros chien avait l’habitude de lui jeter les agneaux morts-nés et les moutons qui venaient de mourir. Or un jour que le troupeau était resté à l’étable, le berger vit son chien qui s’approchait des brebis et les caressait. « Hé ! toi, lui cria-t-il, puisse le sort que tu souhaites à celles-ci retomber sur ta tête ! »</p>
           <p><milestone unit="traduction"/>Cette fable est à l’adresse des flatteurs.</p>
         </div>
@@ -8611,7 +8610,7 @@
           <pb ed="perry" n="P206"/>
           <p><milestone unit="recitprose"/>Ποιμὴν σκύλακα εἰώθει τρέφειν ἐκ τῶν θνῃσκόντων προϐάτων. Καὶ δή ποτε ἐγγὺς ἀμνάδος νοσούσης ἱστάμενον εἶδε τὸν κύνα, κατηφῆ καὶ δοκοῦντα δακρύειν, καὶ ὁμαλίζων αὐτὸν εἶπεν· « Καλῶς ποιεῖς συμπαθῶν· πλὴν ἀλλὰ μὴ γένοιτο μηδὲ συμϐαίη ὅπερ θέλεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοιοῦτός ἐστι πᾶς ὃς κληρονόμος ἐστὶν οὐσίας, τῷ νοσοῦντι συναλγῶν καὶ προσποιούμενος κλαίειν ὑπούλως.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 123 Bb 74 Mb 189 Mh 86.</p>
+          <bibl>Codd. Ba 123 Bb 74 Mb 189 Mh 86.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-314">
@@ -8622,7 +8621,7 @@
           <pb ed="perry" n="P209"/>
           <p><milestone unit="recitprose"/>Ποιμὴν εὑρὼν λυκιδεῖς, τούτους μετὰ πολλῆς ἐπιμελείας ἔτρεφεν, οἰόμενος ὅτι τελειωθέντες οὐ μόνον τὰ ἑαυτοῦ πρόϐατα τηρήσουσιν, ἀλλὰ καὶ ἕτερα ἁρπαζοντες αὐτῷ οἴσουσιν. Οἱ δέ, ὡς τάχιστα ηὐξήθησαν, ἀδείας τυχόντες πρῶτον αὐτοῦ τὴν ποίμνην διαφθείρειν ἤρξαντο. Καὶ ὡς ταῦτα ᾔσθετο, ἀναστενάξας εἶπεν· « Ἀλλ’ ἔγωγε δίκαια πέπονθα· τί γὰρ τούτους νηπίους ὄντας ἔσῳζον οὓς ἔδει καὶ ηὐξημένους ἀναιρεῖν ; »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ τοὺς πονηροὺς περισῴζοντες λανθάνουσι καθ’ ἑαυτῶν πρῶτον αὐτοὺς ῥωννύντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 210 Pb 205 Pf 119 Mb 187 Me 154 Mf 129.</p>
+          <bibl>Codd. Pa 210 Pb 205 Pf 119 Mb 187 Me 154 Mf 129.</bibl>
           <p><milestone unit="traduction"/>Un berger ayant trouvé des louveteaux les nourrit avec beaucoup de soin, dans l’espoir que, devenus grands, non seulement ils lui garderaient ses propres moutons, mais encore en enlèveraient d’autres et les lui apporteraient. Mais aussitôt qu’ils eurent achevé leur croissance, ils saisirent une occasion où ils n’avaient rien à craindre et commencèrent par ravager son troupeau. Quand il s’aperçut du désastre, il gémit et dit : « Je l’ai bien mérité ; pourquoi ai-je sauvé, petits, des animaux qu’il faudrait tuer, même adultes ? »</p>
           <p><milestone unit="traduction"/>Sauver les méchants, c’est leur donner à notre insu des forces qu’ils tourneront contre nous d’abord.</p>
         </div>
@@ -8632,7 +8631,7 @@
           <pb ed="perry" n="P209"/>
           <p><milestone unit="recitprose"/>Ποιμὴν εὑρὼν λυκίδια, ἔτρεφεν ἐπιμελῶς, οἰόμενος ὅτι μεγαλυνθέντα τηρήσουσι τὰ ἑαυτοῦ πρόϐατα, ἀλλὰ καὶ ἔτι προσθήσουσιν ἁρπάζοντες ἕτερα καὶ εἰσάξουσιν ἐν τῇ αὐτοῦ μάνδρᾳ. Οἱ δὲ, ὡς ηὐξήνθησαν, πρῶτον αὐτοῦ τὴν ποίμνην διέφθειραν. Καὶ ὃς ἀναστενάξας εἶπεν· « Δίκαια πέπονθα· τί γὰρ μὴ νηπίους ἀπέκτεινον ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοὺς πονηροὺς διασῴζοντες λανθάνουσι καθ’ &lt;ἑαυτῶν&gt; πρῶτον αὐτοὺς ῥωννύντες.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 105 Cf 112.</p>
+          <bibl>Codd. Ce 105 Cf 112.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-315">
@@ -8641,7 +8640,7 @@
         <pb ed="perry" n="P267"/>
         <p><milestone unit="recitprose"/>Ποιμὴν νεογνὸν λύκου σκύμνον εὑρὼν καὶ ἀνελόμενος σὺν τοῖς κυσὶν ἔτρεφεν. Ἐπεὶ δὲ ηὐξήθη, εἴ ποτε λύκος πρόϐατον ἥρπασε, μετὰ τῶν κυνῶν καὶ αὐτὸς ἐδίωκε. Τῶν δὲ κυνῶν ἔσθ’ ὅτε μὴ δυναμένων καταλαϐεῖν τὸν λύκον καὶ διὰ ταῦτα ὑποστρεφόντων, ἐκεῖνος ἠκολούθει, μέχρις ἂν τοῦτον καταλαϐών, οἷα δὴ λύκος, συμμετάσχῃ τῆς θήρας· εἶτα ὑπέστρεφεν. Εἰ δὲ μὴ λύκος ἔξωθεν ἁρπάσειε πρόϐατον, αὐτὸς λάθρᾳ θύων ἅμα τοῖς κυσὶν ἐθοινεῖτο, ἕως ὁ ποιμὴν στοχασάμενος καὶ συνεὶς τὸ δρώμενον, εἰς δένδρον αὐτὸν ἀναρτήσας ἀπέκτεινεν.</p>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι φύσις πονηρὰ χρηστὸν ἦθος οὐ τρέφει.</p>
-        <p><milestone unit="manuscrits"/>Codd. La 72 Lb 112 Lc 41 Le 112 Lf 72 Lg 41 Lh 62 Md 126 Me 153 Mf 128 Mg 136 Mi 100 Mj 133 Ml 139 Mm 124.</p>
+        <bibl>Codd. La 72 Lb 112 Lc 41 Le 112 Lf 72 Lg 41 Lh 62 Md 126 Me 153 Mf 128 Mg 136 Mi 100 Mj 133 Ml 139 Mm 124.</bibl>
         <p><milestone unit="traduction"/>Un berger, ayant trouvé un louveteau nouveau-né, l’emporta et l’éleva avec ses chiens. Quand le louveteau fut devenu grand, si parfois un loup enlevait un mouton, il lui donnait la chasse lui aussi, avec les chiens. Quand parfois les chiens ne pouvaient pas atteindre le loup et par suite s’en retournaient, lui le suivait jusqu’à ce qu’il le joignît, et qu’il eût, en tant que loup, sa part de la proie ; puis il prenait le chemin du retour. Si un loup n’emportait pas de mouton hors de la bergerie, lui-même en tuait un en cachette et le mangeait avec les chiens. Mais à la fin le berger devina et comprit ce qui se passait, et tua le loup en le pendant à un arbre.</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’un naturel pervers ne peut donner un caractère honnête.</p>
       </div>
@@ -8651,7 +8650,7 @@
         <pb ed="perry" n="P366"/>
         <p><milestone unit="recitprose"/>Ποιμὴν μικρὸν λύκον εὑρὼν ἐθρέψατο, εἶτα σκύμνον γενόμενον ἐδίδαξεν ἁρπάζειν ἐκ τῶν σύνεγγυς ποιμνίων. Ὁ λύκος δὲ διδαχθεὶς ἔφη· « Ὅρα μή πως σὺ ἐθίσας με ἁρπάζειν πολλὰ τῶν σεαυτοῦ προϐάτων ζητήσῃς. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι οἱ τῇ φύσει δεινοὶ ἁρπάζειν καὶ πλεονεκτεῖν μαθόντες τοὺς διδάξαντας πολλάκις ἔϐλαψαν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 127 Mb 190.</p>
+        <bibl>Codd. Ba 127 Mb 190.</bibl>
         <p><milestone unit="traduction"/>Un berger, ayant trouvé un petit loup, le nourrit ; puis, quand il fut devenu louveteau, il lui apprit à enlever des moutons dans les troupeaux du voisinage. Le loup une fois dressé lui dit : « Maintenant que tu m’as habitué à voler, prends garde qu’il ne te manque beaucoup de moutons. »</p>
         <p><milestone unit="traduction"/>Les gens que la nature a faits redoutables, une fois dressés à la rapine et au vol, ont souvent fait plus de mal à leurs maîtres qu’aux étrangers.</p>
       </div>
@@ -8663,7 +8662,7 @@
           <pb ed="perry" n="P208"/>
           <p><milestone unit="recitprose"/>Ποιμὴν εἰσελάσας τὰ πρόϐατα εἴς τινα δρυμῶνα, ὡς ἐθεάσατο δρῦν παμμεγέθη μεστὴν βαλάνων, ὑποστρώσας τὸ ἱματίον αὐτοῦ ἐπὶ ταύτην ἀνέϐη καὶ τὸν καρπὸν κατέσειε. Τὰ δὲ πρόϐατα ἐσθίοντα τὰς βαλάνους ἔλαθε καὶ τὰ ἱμάτια συγκαταφαγόντα. Ὁ δὲ ποιμὴν καταϐάς, ὡς ἐθεάσατο τὸ γεγονός, εἶπεν· « Ὦ κάκιστα ζῷα, ὑμεῖς τοῖς λοιποῖς ἔρια εἰς ἐσθῆτας παρεχόμενα, ἐμοῦ τοῦ τρέφοντος καὶ τὸ ἱμάτιον ἀφείλεσθε. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω τῶν ἀνθρώπων πολλοὶ δι’ ἄγνοιαν τοὺς μηδὲν προσήκοντας εὐεργετοῦντες κατὰ τῶν οἰκείων φαῦλα ἐργάζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 209 Pb 204 Pc 112 Pf 117 Mb 186 Me 151 Mf 126 Ca 165.</p>
+          <bibl>Codd. Pa 209 Pb 204 Pc 112 Pf 117 Mb 186 Me 151 Mf 126 Ca 165.</bibl>
           <p><milestone unit="traduction"/>Un berger, ayant conduit ses moutons dans un bois de chênes, aperçut un gros chêne chargé de glands ; il étendit son manteau par dessous, puis monta dessus et secoua les fruits. Les moutons, mangeant les glands, mangèrent aussi par mégarde le manteau. Le berger, étant descendu, et voyant le méfait, s’écria : « Méchantes bêtes, vous donnez aux autres de la laine pour se vêtir, et à moi qui vous nourris, vous m’avez enlevé même mon manteau. »</p>
           <p><milestone unit="traduction"/>Ainsi beaucoup de gens obligent sottement ceux qui ne leur sont rien, et se conduisent vilainement envers leurs proches.</p>
         </div>
@@ -8673,7 +8672,7 @@
           <pb ed="perry" n="P208"/>
           <p><milestone unit="recitprose"/>Ποιμὴν νέμων πρόϐατα εἰς δρυμῶνα, ὡς ἐθεάσατο δρῦν μεστὴν βαλάνων, ὑπεστρώσατο τὸ ἱμάτιον καὶ ἀνέϐη ἐπ’ αὐτὴν καὶ τὸν καρπὸν κατασείων ἔρριπτεν. Τὰ δὲ πρόϐατα ἐσθίοντα τοὺς βαλάνους συγκατέφαγον καὶ τὸ ἱμάτιον. Ὡς δὲ καταϐὰς ὁ ποιμὴν [καὶ] τὸ γεγονὸς ἐθεάσατο, εἶπεν· « Ὦ κάκιστα &lt;ζῷα&gt;, ὑμεῖς τοῖς λοιποῖς ἔρια παρέχετε καὶ ἐσθῆτας· ἐμοῦ δὲ τρέφοντος καὶ τὸ ἱμάτιον ἀφείλασθε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ δι’ ἄγνοιαν πολλοὺς τοὺς μηδὲ προσήκοντας εὐεργετεῖν καὶ κατὰ τῶν οἰκείων φαῦλα ἐργάζεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 104 Cf 111.</p>
+          <bibl>Codd. Ce 104 Cf 111.</bibl>
         </div>
         <div>
           <head>Chambry 317.3</head>
@@ -8681,7 +8680,7 @@
           <pb ed="perry" n="P208"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἐλάσας εἴς τινα δρυμῶνα τὰ πρόϐατα, ὑποστρώσας ὑπὸ δρῦν τὸ ἱμάτιον καὶ ἀναϐὰς τὸν καρπὸν κατέσειε. Τὰ δὲ πρόϐατα ἐσθίοντα τοὺς βαλάνους ἔλαθον καὶ τὰ ἱμάτια συγκαταφαγόντα. Ὁ δὲ ποιμὴν καταϐάς, ὡς εἶδε τὸ γεγονός· « Ὦ κάκιστα, ἔφη, ζῷα, ὑμεῖς τοῖς λοιποῖς ἔρια εἰς ἐσθῆτας παρέχετε, ἐμοῦ δὲ τρέφοντος ὑμᾶς καὶ τὸ ἱμάτιον ἀφείλεσθε. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ πολλοὶ τῶν ἀνθρώπων δι’ ἄνοιαν τοὺς μηδὲν προσήκοντας εὐεργετοῦντες κατὰ τῶν οἰκείων φαῦλα ἐργάζονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 127 Lb 117 Le 117 Lf 127 Lh 66 Mg 141 Mj 138 Ml 142.</p>
+          <bibl>Codd. La 127 Lb 117 Le 117 Lf 127 Lh 66 Mg 141 Mj 138 Ml 142.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-318">
@@ -8696,7 +8695,7 @@
           <l><milestone unit="recitvers"/>« Πῶς τὰ πρόϐατα τῆς ποίμνης θέλων σῶσαι</l>
           <l><milestone unit="recitvers"/>τόνδε τὸν λύκον συνεισάγεις τῇ ποίμνῃ ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι μεγίστην βλάϐην καὶ θανάτου παραιτίαν οἶδε ποιεῖν τῶν κακῶν ἡ συνοίκησις.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 89 Bb 57 Ma 183 Md 81 Mh 76 Mm 97.</p>
+          <bibl>Codd. Ba 89 Bb 57 Ma 183 Md 81 Mh 76 Mm 97.</bibl>
           <p><milestone unit="traduction"/>Un berger, qui faisait rentrer ses moutons à l’intérieur de l’étable, allait enfermer avec eux un loup, si son chien, qui s’en était aperçu, ne lui eût dit : « Comment toi, qui tiens à la vie de tes moutons, fais-tu entrer ce loup avec eux ? »</p>
           <p><milestone unit="traduction"/>La société des méchants est propre à causer les plus grands dommages et même la mort.</p>
         </div>
@@ -8710,7 +8709,7 @@
           <l><milestone unit="recitvers"/>« Πῶς ἄγων τοῦτον ἔνδοθεν εἰς τὴν μάνδραν</l>
           <l><milestone unit="recitvers"/>ποίμνια βούλει σοι τοῦ ζωογονεῖσθαι ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι μεγίστην βλάϐην καὶ θάνατον οἶδε ποιεῖν τῶν κακῶν ἡ συνουσία.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 192.</p>
+          <bibl>Cod. Mb 192.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-319">
@@ -8721,7 +8720,7 @@
           <pb ed="perry" n="P210"/>
           <p><milestone unit="recitprose"/>Ποιμὴν ἐξελαύνων αὐτοῦ τὴν ποίμνην ἀπό τινος κώμης πορρωτέρω, διετέλει τοιαύτῃ παιδιᾷ χρώμενος· ἐπιϐοώμενος γὰρ τοὺς κωμήτας ἐπὶ βοήθειαν, ἔλεγεν ὡς λύκοι τοῖς προϐάτοις ἐπῆλθον. Δὶς δὲ καὶ τρὶς τῶν ἐκ τῆς κώμης ἐκπλαγέντων καὶ ἐκπηδησάντων, εἶτα μετὰ γέλωτος ἀπαλλαγέντων, συνέϐη τὸ τελευταῖον τῇ ἀληθείᾳ λύκους ἐπελθεῖν. Ἀποτεμνομένων δὲ αὐτῶν τὴν ποίμνην καὶ τοῦ ποιμένος ἐπὶ βοηθείᾳ τοὺς κωμήτας ἐπικαλουμένου, ἐκεινοῖ ὑπολαϐόντες αὐτὸν παίζειν κατὰ τὸ ἔθος, ἧττον ἐφρόντιζον· καὶ οὕτως αὐτῷ συνέϐη τῶν προϐάτων στερηθῆναι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τοῦτο κερδαίνουσιν οἱ ψευδολόγοι τὸ μηδὲ ὅταν ἀληθεύωσι, πιστεύεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 211 Pb 206 Pg 131 Mb 188 Ca 166.</p>
+          <bibl>Codd. Pa 211 Pb 206 Pg 131 Mb 188 Ca 166.</bibl>
           <p><milestone unit="traduction"/>Un berger, qui menait son troupeau assez loin du village, se livrait constamment à la plaisanterie que voici. Il appelait les habitants du village à son secours, en criant que les loups attaquaient ses moutons. Deux ou trois fois les gens du village s’effrayèrent et sortirent précipitamment, puis ils s’en retournèrent mystifiés. Mais à la fin il arriva que les loups se présentèrent réellement. Tandis qu’ils saccageaient le troupeau, le berger appelait au secours les villageois ; mais ceux-ci, s’imaginant qu’il plaisantait comme d’habitude, se soucièrent peu de lui. Il arriva ainsi qu’il perdit ses moutons.</p>
           <p><milestone unit="traduction"/>Cette fable montre que les menteurs ne gagnent qu’une chose, c’est de n’être pas crus, même lorsqu’ils disent la vérité.</p>
         </div>
@@ -8731,7 +8730,7 @@
           <pb ed="perry" n="P210"/>
           <p><milestone unit="recitprose"/>Παιδίον που πρόϐατα νέμον, &lt;ὥσπερ&gt; λύκον ἐρχόμενον πρὸς διαφθορὰν ὁρῶν, ἐπικαλούμενον τοὺς ἀγρότας ἔλεγε· « Βοηθεῖτε ὧδε, ἔρχεται λύκος. » Οἱ δὲ ἀγρόται τρέχοντες τοῦτον εὕρισκον μὴ ἀληθεύειν. Τοῦτο δὲ ποιήσαντος πολλάκις, εὕρισκον ψευδόμενον. Μετὰ δὲ ταῦτα τοῦ λύκου προσελθόντος, καὶ τοῦ παιδὸς βοῶτος· « Δεῦτε, λύκος, » οὐκέτι τις πεπίστευκε προσδραμεῖν αὐτῷ καὶ βοηθῆσαι. Ὁ δὲ λύκος εὑρηκὼς ἄδειαν τὴν ποίμνην πᾶσαν διέφθειρεν εὐκόλως.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοσοῦτον ὄφελος τῷ ψεύστῃ, ὅτι καὶ ἀληθῆ λέγων πολλάκις οὐ πιστεύεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ma 170 Md 61 Mh 56 Mm 118.</p>
+          <bibl>Codd. Ma 170 Md 61 Mh 56 Mm 118.</bibl>
         </div>
         <div>
           <head>Chambry 319.3</head>
@@ -8750,7 +8749,7 @@
           <l><milestone unit="recitvers"/>Εὐθὺς δ’ ὁ λύκος τυχὼν πάσης ἀδείας</l>
           <l><milestone unit="recitvers"/>τὴν ποίμνην πᾶσαν διέφθειρεν εὐκόλως.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοσοῦτον ὄφελος τῷ ψεύστῃ ὅτι πολλάκις, κἂν ἀλήθειαν εἴπῃ, οὐδὲ ἐκεῖνο πιστεύεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 64 Cb 57 Cd 55 Ce 93 Cf 99 Mc 57 Ml 143.</p>
+          <bibl>Codd. Ch 64 Cb 57 Cd 55 Ce 93 Cf 99 Mc 57 Ml 143.</bibl>
         </div>
         <div>
           <head>Chambry 319.4</head>
@@ -8758,7 +8757,7 @@
           <pb ed="perry" n="P210"/>
           <p><milestone unit="recitprose"/>Καί που παιδίον ποίμνια νέμον ἐφ’ ὑψηλοῦ τόπου ἱστάμενον πολλάκις ἀνέκραγε· « Βοηθεῖτέ μοι, λύκοι. » Οἱ δὲ ἀγρότεροι τρέχοντες ἐν τῇ ποίμνῃ τοῦτον ηὕρισκον μηδαμῶς ἀληθεύοντα. Τοῦτο δὲ πολλάκις τοῦ παιδὸς πραξαμένου, οἱ τοιοῦτοι συνήρχοντο καὶ ἀεὶ ψεῦδος εὑρίσκοντες ἀπήρχοντο. Μετὰ δὲ ταῦτα τοῦ λύκου προσελθόντος, ὁ παῖς ἐϐόα· « Ὁ λύκος, δεῦτε. » Ἐπεὶ δὲ οὐδεὶς ἐπίστευεν οὐδ’ ἀπήρχετο βοηθῆσαι, ὁ λύκος ἀδείας λαϐόμενος, εὐκόλως τὴν ποίμνην πᾶσαν διέφθειρεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοσοῦτον οὐκ ὠφελεῖ τινα τὸ μὴ λαλεῖν τὰ ἀληθῆ ὅσον δεῖ φοϐεῖσθαι μήπως ἐκ τούτου οὐδὲ τὰ ἀληθῆ λέγων εἰσακούσθῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 59.</p>
+          <bibl>Cod. Mk 59.</bibl>
         </div>
         <div>
           <head>Chambry 319.5</head>
@@ -8766,7 +8765,7 @@
           <pb ed="perry" n="P210"/>
           <p><milestone unit="recitprose"/>Παῖς τις νέμων πρόϐατα συνεχῶς ἐπὶ τὸ χῶμα ἀνιὼν ἐϐόα· « Λύκος, βοηθεῖτε. » Οἱ δὲ ἀγρόται τρέχοντες ἐκεῖσε εὕρισκον ψεῦσμα. Τοῦ δὲ λύκου ἀληθῶς ἐλθόντος καὶ τοῦ παιδὸς βοῶντος, οὐδεὶς ἐπίστευσε καὶ ἀπῆλθε πρὸς βοήθειαν. Ὁ δὲ λύκος τὰ πρόϐατα διέφθειρε.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι τοῦτο ὄφελος τῷ ψεύστῃ, ἵνα, κἂν ἀλήθειαν λέγῃ, μὴ πιστεύηται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 120 Bb 72.</p>
+          <bibl>Codd. Ba 120 Bb 72.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-320">
@@ -8775,7 +8774,7 @@
         <pb ed="perry" n="P367"/>
         <p><milestone unit="recitprose"/>Θεοὶ πάντες ἔγημαν ἣν ἕκαστος εἴληφεν ἐν κλήρῳ. Πόλεμος παρῆν ἐσχάτῳ κλήρῳ· Ὕϐριν δὲ μόνην κατέλαϐεν· ταύτης περισσῶς ἐρασθεὶς ἔγημεν. Ἐπακολουθεῖ δὲ αὐτῇ πανταχοῦ βαδιζούσῃ.</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι ἔνθα &lt;ἂν&gt; προέλθῃ ὕϐρις ἢ ἐν πόλει ἢ ἐν ἔθνεσι, πόλεμος καὶ μάχαι εὐθὺς μετ’ αὐτὴν ἀκολουθεῖ.</p>
-        <p><milestone unit="manuscrits"/>Cod. Ba 51.</p>
+        <bibl>Cod. Ba 51.</bibl>
         <p><milestone unit="traduction"/>Tous les dieux ayant décidé de se marier, chacun prit la femme que le sort lui assignait. Le dieu de la guerre, étant resté pour le dernier tirage, ne trouva plus que la Violence. Il s’en éprit follement et l’épousa. Voilà pourquoi il l’accompagne partout où elle va.</p>
         <p><milestone unit="traduction"/>Partout où paraît la violence, dans une cité ou parmi les nations, la guerre et les combats marchent aussitôt après elle.</p>
       </div>
@@ -8785,7 +8784,7 @@
         <pb ed="perry" n="P368"/>
         <p><milestone unit="recitprose"/>Ποταμὸς δι’ αὐτοῦ βύρσαν βοείαν φερομένην ἰδὼν ἠρώτησε· « Τίς καλῇ ; » Τῆς δὲ εἰπούσης· « Σκληρὰ καλοῦμαι, » ἐπικαχλάσας τῷ ῥεύματι εἶπεν· « Ἄλλο τι ζητεῖ καλεῖσθαι· ἐγὼ γὰρ ἤδη ἁπαλήν σε ποιήσω. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι τολμηρὸν ἄνδρα καὶ αὐθάδη πολλάκις εἰς γῆν κατήγαγε συμφορὰ βίου.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 124 Md 100 Mh 87 Mi 16 Mm 122.</p>
+        <bibl>Codd. Ba 124 Md 100 Mh 87 Mi 16 Mm 122.</bibl>
         <p><milestone unit="recitprose"/>Une rivière, apercevant une peau de bœuf qu’elle charriait dans ses eaux, lui demanda son nom. « Je m’appelle Dure », répondit-elle. Alors précipitant son courant sur elle : « Cherche un autre nom, dit-elle ; car je t’aurai vite rendue molle. »</p>
         <p><milestone unit="recitprose"/>Souvent les audacieux et les orgueilleux sont terrassés par les malheurs de la vie.</p>
       </div>
@@ -8797,7 +8796,7 @@
           <pb ed="perry" n="P212"/>
           <p><milestone unit="recitprose"/>Πρόϐατον ἀφυῶς κειρόμενον πρὸς τὸν κείροντα ἔφη· « Εἰ μὲν ἔρια ζητεῖς, ἀνωτέρω τέμνε· εἰ δὲ κρεῶν ἐπιθυμεῖς, ἅπαξ με καταθύσας τοῦ κατὰ μικρὸν βασανίζειν ἀπάλλαξον. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς ἀφυῶς ταῖς τέχναις προσφερομένους ὁ λόγος ἁρμόδιός ἐστι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 168 Pb 208 Pg 133 Mb 194 Ce 107 Cf 114.</p>
+          <bibl>Codd. Ca 168 Pb 208 Pg 133 Mb 194 Ce 107 Cf 114.</bibl>
           <p><milestone unit="traduction"/>Une brebis que l’on tondait maladroitement dit à celui qui le tondait : « Si c’est ma laine que tu veux, coupe plus haut ; si au contraire c’est ma chair que tu désires, tue-moi une fois pour toutes, et cesse de me torturer pièce à pièce. »</p>
           <p><milestone unit="traduction"/>Cette fable s’applique à ceux qui sont mladroits dans leur métier.</p>
         </div>
@@ -8807,7 +8806,7 @@
           <pb ed="perry" n="P212"/>
           <p><milestone unit="recitprose"/>Ἐν τόπῳ τινὶ χήρα τις εἶχε πρόϐατον. Τούτου δὲ τὸν πόκον θέλουσα λαϐεῖν ἔκειρεν ἀτέχνως σὺν τῷ μαλλῷ καὶ τὴν σάρκα ψαλίζουσα. Τὸ δὲ πρόϐατον ἀλγοῦν ἔλεγε· « Τί με βλάπτεις ; πόσην γὰρ ὁλκὴν τὸ ἐμὸν αἷμα προσθήσει ; Καὶ εἰ μὲν κρεῶν, ὦ δέσποινα, χρῄζεις, μάγειρος ἔστιν ὅς με συντόμως θύσει· εἰ δὲ ἐρίου καὶ πόκου, κουρεὺς ἔστι πάλιν ὃς καὶ κερεῖ με καὶ σώσει. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ ἀπειρίαν πράγματός τινος ἔχοντες καὶ διὰ πλεονεξίαν τοῦτο μεταχειριζόμενοι οὐ τοσοῦτον κέρδος ὅσην βλάϐην καρποῦνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 39 Bb 26 Mg 65.</p>
+          <bibl>Codd. Ba 39 Bb 26 Mg 65.</bibl>
         </div>
         <div>
           <head>Chambry 322.3</head>
@@ -8825,7 +8824,7 @@
           <l><milestone unit="recitvers"/>εἰ δὲ τὸν πόκον ἐθέλεις ἀποκεῖραι,</l>
           <l><milestone unit="recitvers"/>ἐλθέτω κουρεὺς πάλιν, ἵνα με κείρῃ. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ ἀπειρίαν τινὸς ἔχοντες καὶ διὰ πλεονεξίαν μεταχειριζόμενοι τοῦτο βλάϐην &lt;μᾶλλον&gt; ἢ κέρδος ἔχουσιν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 229.</p>
+          <bibl>Cod. Mb 229.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-323">
@@ -8834,7 +8833,7 @@
         <pb ed="perry" n="P240"/>
         <p><milestone unit="recitprose"/>Προμηθεὺς κατὰ πρόσταξιν Διὸς ἀνθρώπους ἔπλασε καὶ θηρία. Ὁ δὲ Ζεὺς θεασάμενος πολλῷ πλείονα τὰ ἄλογα ζῷα ἐκέλευσεν αὐτὸν τῶν θηρίων τινὰ διαφθείροντα ἀνθρώπους μετατυπῶσαι. Τοῦ δὲ τὸ προσταχθὲν ποιήσαντος, συνέϐη ἐκ τούτου τοὺς μὴ ἐξ ἀρχῆς ἀνθρώπους πλασθέντας τὴν μὲν μορφὴν ἀνθρώπων ἔχειν, τὰς δὲ ψυχὰς θηριώδεις.</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα σκαιὸν καὶ θηριώδη ὁ λόγος εὔκαιρος.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 213 Pf 121 Me 156 Mf 130.</p>
+        <bibl>Codd. Pa 213 Pf 121 Me 156 Mf 130.</bibl>
         <p><milestone unit="traduction"/>Prométhée, sur l’ordre de Zeus, avait modelé les hommes et les bêtes. Mais Zeus, ayant remarqué que les bêtes étaient beaucoup plus nombreuses, lui commanda d’en faire disparaître un certain nombre en les métamorphosant en hommes. Prométhée exécuta cet ordre. Il enr ésulta que ceux qui n’ont pas reçu la forme humaine dès le début ont bien une forme d’homme, mais une âme de bête.</p>
         <p><milestone unit="traduction"/>La fable s’applique aux hommes balourds et brutaux.</p>
       </div>
@@ -8844,7 +8843,7 @@
         <pb ed="perry" n="P369"/>
         <p><milestone unit="recitprose"/>Ῥόδῳ παραφυὲν ἀμάραντον ἔφη· « Οἷον ἄνθος εὐπρεπὲς εἶ, καὶ ποθητὸν καὶ θεοῖς καὶ ἀνθρώποις· μακαρίζω σε τοῦ κάλλους καὶ τῆς εὐωδίας. » Τὸ δὲ εἶπεν· « Ἐγὼ μέν, ὦ ἀμάραντον, πρὸς ὀλίγον καιρὸν ζῶ, καί, κἂν μηδεὶς ἐκκόψῃ με, τήκομαι· σὺ δὲ ἀνθεῖς καὶ ζῇς ἀεὶ οὕτω νέον. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι κρεῖσσον ὀλιγαρκούμενόν τινα διαμένειν ἢ πρὸς ὀλίγον τρυφήσαντα μεταϐολῆς δυστυχοῦς τυχεῖν ἢ καὶ ἀποθανεῖν.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 130 Bb 78 Mb 200.</p>
+        <bibl>Codd. Ba 130 Bb 78 Mb 200.</bibl>
         <p><milestone unit="traduction"/>Une amarante qui avait poussé à côté d’une rose lui dit : « Comme tu es belle ! tu fais les délices des dieux et des hommes. Je te félicite de ta beauté et de ton parfum. – Moi, répondit la rose, je ne vis que peu de jours, amarante, et même si l’on ne me cueille pas, je me flétris ; mais toi, tu es toujours en fleur et tu restes toujours aussi jeune. »</p>
         <p><milestone unit="traduction"/>Il vaut mieux durer en se contentant de peu que vivre dans le luxe quelque temps, pour subir ensuite un changement de fortune et même la mort.</p>
       </div>
@@ -8856,7 +8855,7 @@
           <pb ed="perry" n="P213"/>
           <p><milestone unit="recitprose"/>Ῥοιὰ καὶ μηλέα καὶ ἐλαία περὶ εὐκαρπίας ἤριζον. Πολλοῦ δὲ τοῦ νείκους ἀναφθέντος, βάτος ἐκ τοῦ πλησίον φραγμοῦ ἀκούσασα εἶπεν· « Ἀλλ’, ὦ φίλαι, παυσώμεθά ποτε μαχόμεναι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω παρὰ τὰς τῶν ἀμεινόνων στάσεις καὶ οἱ μηδενὸς ἄξιοι πειρῶνται δοκεῖν τι εἶναι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 215 Pb 209 Pc 114 Pf 122 Pg 134 Mb 201.</p>
+          <bibl>Codd. Pa 215 Pb 209 Pc 114 Pf 122 Pg 134 Mb 201.</bibl>
           <p><milestone unit="traduction"/>Le grenadier, le pommier et l’olivier contestaient de la qualité de leurs fruits. Comme la discussion s’animait, une ronce qui les écoutait de la haie voisine, dit : « Mes amis, cessons enfin de nous quereller. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que, dans les temps où les meilleurs citoyens sont divisés, les gens de rien essayent de se donner de l’importance.</p>
         </div>
@@ -8866,7 +8865,7 @@
           <pb ed="perry" n="P213"/>
           <p><milestone unit="recitprose"/>Ῥοιὰ καὶ μηλέα περὶ κάλλους ἤριζον. Πολλῆς δὲ φιλονεικίας παρὰ τῶν ἀμφοτέρων γεγονυίας, βάτος ἐκ τοῦ πλησίον φραγμοῦ ἀκούσασα εἶπεν· « Ὦ φίλαι, παυσώμεθά ποτε μαχόμεναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτως παρὰ τὰς τῶν ἀμεινόνων στάσεις καὶ οἱ μηδενὸς ἄξιοι πειρῶνται εἶναί τι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 176 Cb 95 Cd 111 Cf 115 Ch 117 Mc 89.</p>
+          <bibl>Codd. Ca 176 Cb 95 Cd 111 Cf 115 Ch 117 Mc 89.</bibl>
         </div>
         <div>
           <head>Chambry 325.3</head>
@@ -8874,7 +8873,7 @@
           <pb ed="perry" n="P213"/>
           <p><milestone unit="recitprose"/>Ῥοιὰ καὶ μηλέα περὶ κάλλους ἤριζον· πολλῶν δ’ ἀμπισϐητήσεων μέταξυ γενομένων, βὰτος ἐκ τοῦ πλησίον ἀκούσασα φραγμοῦ· « Παυσώμεθα, εἶπεν, ὦ φίλαι, ποτὲ μαχόμεναι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἐν ταῖς τῶν ἀμεινόνων στάσεσι καὶ οἱ μηδενὸς ἄξιοι πειρῶνται εἶναί τι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 50 Lb 118 Le 118 Lf 50 Lh 67 Md 102 Me 158 Mf 132 Mg 142 Mi 18 Mj 139 Ml 146 Mm 126.</p>
+          <bibl>Codd. La 50 Lb 118 Le 118 Lf 50 Lh 67 Md 102 Me 158 Mf 132 Mg 142 Mi 18 Mj 139 Ml 146 Mm 126.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-326">
@@ -8893,7 +8892,7 @@
           <l><milestone unit="recitvers"/>ὅτι μηδὲν δυνάμενος ἐν πολέμῳ</l>
           <l><milestone unit="recitvers"/>τοῖς πᾶσι κράζεις πρὸς μάχην ἐπεγείρων. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πλεῖστον πταίουσιν οἱ τοὺς κακοὺς καὶ βαρεῖς δυνάστας ἐπεγείροντες εἰς τὸ κακοποιῆσαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 81 Cb 50 Cd 47 Cf 56 Ch 57 Ma 166 Mc 49 Md 54 Mh 49 Mi 89 Mm 70 Mn 20 Lc 58 Ld 20 Lg 58.</p>
+          <bibl>Codd. Ca 81 Cb 50 Cd 47 Cf 56 Ch 57 Ma 166 Mc 49 Md 54 Mh 49 Mi 89 Mm 70 Mn 20 Lc 58 Ld 20 Lg 58.</bibl>
         </div>
         <div>
           <head>Chambry 326.2</head>
@@ -8901,7 +8900,7 @@
           <pb ed="perry" n="P370"/>
           <p><milestone unit="recitprose"/>Ἦν τις σαλπιστὴς στρατὸν ἐπισυνάγων, ὅστις κρατηθεὶς ἐϐόα τοῖς ἐναντίοις· « Ὦ ἄνδρες, μὴ κτείνετέ με, ἐπεὶ κἀγὼ οὐδένα ἔκτεινα· πλὴν γὰρ τούτου τοῦ χαλκοῦ δι’ οὗ αὐλῶ, ἕτερον οὐ πράττω. » Οἱ δὲ πρὸς αὐτὸν ἐϐόων· « Διὰ τοῦτο γὰρ μᾶλλον τεθνήξῃ, ὅτι σὺ μὴ δυνάμενος πολεμεῖν, τοὺς νέους κράζων πρὸς μάχην ἐξήγειρας. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πλέον πταίουσιν οἱ τοὺς κακοὺς καὶ δυνάστας ἐπεγείροντες εἰς μάχην.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ce 52.</p>
+          <bibl>Cod. Ce 52.</bibl>
         </div>
         <div>
           <head>Chambry 326.3</head>
@@ -8909,7 +8908,7 @@
           <pb ed="perry" n="P370"/>
           <p><milestone unit="recitprose"/>Ἦν τις σαλπιγκτὴς ἐν στρατῷ, ὃς σαλπίζων εἰς παράταξιν καὶ πόλεμον ἐκάλει τὸν στρατόν. Κρατηθεὶς δὲ ὑπὸ τῶν ἐναντίων ἐϐόα· « Ἄνδρες, μὴ κτείνετέ με· οὐδένα γὰρ ἐγὼ ἔκτεινα, οὐδ’ ἐπίσταμαί τι ἄλλο ἢ χρῆσθαι τῇ σάλπιγγι. » Οἱ δὲ πρὸς αὐτὸν εἶπον· « Τούτου ἕνεκα μάλιστα ἄξιος ὑπάρχεις ἀποθανεῖν, ὅτι μὴ δυνάμενος αὐτὸς πολεμεῖν, τοὺς ἄλλους ἐγείρεις εἰς πόλεμον. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πλέον πταίουσι οἱ τοὺς κακοὺς καὶ δυνάστας ἐγείροντες εἰς τὸ κακοποιεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 53.</p>
+          <bibl>Cod. Mk 53.</bibl>
         </div>
         <div>
           <head>Chambry 326.4</head>
@@ -8917,7 +8916,7 @@
           <pb ed="perry" n="P370"/>
           <p><milestone unit="recitprose"/>Σαλπιγκτὴς στρατὸν ἐπισυνάγων καὶ κρατηθεὶς ὑπὸ τῶν πολεμίων ἐϐόα· « Μὴ κτείνετέ με, ὦ ἄνδρες, εἰκῆ καὶ μάτην· οὐδένα γὰρ ὑμῶν ἀπέκτεινα· πλὴν γὰρ τοῦ χαλκοῦ τούτου οὐδὲν ἄλλο κτῶμαι. » Οἱ δὲ πρὸς αὐτὸν ἔφασαν· « Διὰ τοῦτο γὰρ μᾶλλον τεθνήξῃ, ὅτι σὺ μὴ δυνάμενος πολεμεῖν τοὺς πάντας πρὸς μάχην ἐγείρεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πλέον πταίουσιν οἱ τοὺς κακοὺς καὶ βαρεῖς δυνάστας ἐπεγείροντες εἰς τὸ κακοποιεῖν.</p>
-          <p><milestone unit="manuscrits"/>Cod. La 146.</p>
+          <bibl>Cod. La 146.</bibl>
           <p><milestone unit="epimythiumprose"/>Un trompette qui sonnait le rassemblement ayant été pris par les ennemis, criait : « Ne me tuez pas, camarades, à la légère et sans raison ; car je n’ai tué aucun de vous, et, en dehors de ce cuivre, je ne possède rien. » Mais on lui répondit : « Raison de plus pour que tu meures, puisque, ne pouvant toi-même faire la guerre, tu excites tout le monde au combat. »</p>
           <p><milestone unit="epimythiumprose"/>Cette fable montre que les plus coupables sont ceux qui excitent au mal les princes méchants et cruels.</p>
         </div>
@@ -8930,7 +8929,7 @@
           <pb ed="perry" n="P214"/>
           <p><milestone unit="recitprose"/>Σπάλαξ (ἐστὶ δὲ τοῦτο τὸ ζῷον τυφλὸν) λέγει πρὸς τὴν ἑαυτοῦ μητέρα ὅτι βλέπει. Κἀκείνη πειράζουσα αὐτὸν χόνδρον λιϐανωτοῦ δοῦσα ἐπηρώτα τί ποτε εἴη. Τοῦ δὲ εἰπόντος ψηφῖδα, ἔφη· « Ὦ τέκνον, οὐ μόνον τοῦ βλέπειν ἐστέρησαι, ἀλλὰ καὶ τὰς ὀσφρήσεις ἀποϐέϐλησαι. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως ἔνιοι τῶν ἀλαζόνων, [μέχρις οὗ] τὰ ἀδύνατα κατεπαγγέλλονται, καὶ ἐν τοῖς ἐλαχίστοις ἐξελέγχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 219 Pb 210 Pe 65 Pf 124 Pg 135 Ma 131 Me 162 Ca 177.</p>
+          <bibl>Codd. Pa 219 Pb 210 Pe 65 Pf 124 Pg 135 Ma 131 Me 162 Ca 177.</bibl>
           <p><milestone unit="traduction"/>Une taupe — la taupe est un animal aveugle — disait à sa mère qu’elle voyait clair. Sa mère, pour l’éprouver, lui donna un grain d’encens, et lui demanda ce que c’était : « C’est un caillou, dit-elle. – Mon enfant, reprit la mère, non seulement tu es privée de la vue, mais encore tu as perdu l’odorat. »</p>
           <p><milestone unit="traduction"/>Pareillement certains fanfarons promettent l’impossible et sont convaincus d’impuissance dans les cas les plus simples.</p>
         </div>
@@ -8947,7 +8946,7 @@
           <l><milestone unit="recitvers"/>ὡς ὁρῶ, οὐ μόνον τὸ βλέπειν στερίσκῃ,</l>
           <l><milestone unit="recitvers"/>ἀλλὰ καὶ τὰς ἀκοὰς καὶ τὰς ὀσφρήσεις. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὕτως ἔνιοι τῶν ἀλαζόνων ἀνθρώπων τὰ ἀδύνατα κατεπαγγέλλονται καὶ ἐν τοῖς ἐλαχίστοις ἐλέγχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 118 Cb 96 Cd 112 Ce 109 Cf 117.</p>
+          <bibl>Codd. Ch 118 Cb 96 Cd 112 Ce 109 Cf 117.</bibl>
         </div>
         <div>
           <head>Chambry 327.3</head>
@@ -8955,7 +8954,7 @@
           <pb ed="perry" n="P214"/>
           <p><milestone unit="recitprose"/>Ὁ ἀσπάλαξ τυφλὸν ζῷόν ἐστι. Φησὶν οὖν ποτε τῇ μητρί· « Συκαμινέαν, μῆτερ, ὁρῶ. » Εἶτα αὖθίς φησι· « Λιϐάνου ὀσμῆς πεπλήρωμαι. » Κἀκ τρίτου πάλιν· « Χαλκῆς, φησί, ψηφῖδος κτύπον ἀκούω. » Ἡ δὲ μήτηρ ὑπολαϐοῦσα εἶπεν· « Ὦ τέκνον, ὡς ἤδη μανθάνω, οὐ μόνον ὄψεως ἐστέρησαι, ἀλλὰ καὶ ἀκοῆς καὶ ὀσφρήσεως. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ἔνιοι τῶν ἀλαζόνων τὰ ἀδύνατα κατεπαγγέλλονται καὶ ἐν τοῖς ἐλαχίστοις ἐλέγχονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 51 Lb 94 Le 94 Lf 51 Md 113 Me 143 Mg 143 Mi 29 Mj 117 Ml 122 Mm 34.</p>
+          <bibl>Codd. La 51 Lb 94 Le 94 Lf 51 Md 113 Me 143 Mg 143 Mi 29 Mj 117 Ml 122 Mm 34.</bibl>
         </div>
         <div>
           <head>Chambry 327.4</head>
@@ -8963,7 +8962,7 @@
           <pb ed="perry" n="P214"/>
           <p><milestone unit="recitprose"/>Πηρὸν ἀσπάλαξ καὶ τυφλὸν ζῷον. Εἷς οὖν τὴν μητέρα θέλων φιλῆσαι, ἀντὶ τοῦ στόματος τῷ αἰδοίῳ προσψαύει. Τοῦτο δὲ ποιῶν τοὺς ἄλλους ἀδελφοὺς οὐκ ἔλαθεν. Εἷς δὲ αὐτῶν εἶπεν ὡς « θέλων τι μέγα ποιῆσαι καὶ πνοῆς ἧς εἶχες ἐστέρησαι δικαίως. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πονηρὰ γνώμη καὶ αὐτὴν τὴν φύσιν ἀλλοιοῖ καὶ βλάπτει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 121.</p>
+          <bibl>Cod. Ba 121.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-328">
@@ -8974,7 +8973,7 @@
           <pb ed="perry" n="P224"/>
           <p><milestone unit="recitprose"/>Σῦς ἄγριος ἑστὼς παρά τι δένδρον τοὺς ὀδόντας ἠκόνα. Ἀλώπεκος δὲ αὐτὸν ἐρομένης τὴν αἰτίαν δι’ ἥν, μηδενὸς αὐτῷ μήτε κυνηγέτου μήτε κινδύνου ἐφεστῶτος, τοὺς ὀδόντας θήγει, ἔφη· « Ἀλλ’ ἔγωγε οὐ ματαίως τοῦτο ποιῶ· ἐὰν γάρ με κίνδυνος καταλάϐῃ, οὐ τότε περὶ τὸ ἀκονᾶν ἀσχοληθήσομαι, ἑτοίμοις δὲ οὖσι χρήσομαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος διδάσκει δεῖν πρὸ τῶν κινδύνων τὰς παρασκευὰς ποιεῖσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 217 Pb 222 Pc 116 Pd 40 Pe 64 Pf 123 Pg 142 Mb 210 Me 161 Mf 135.</p>
+          <bibl>Codd. Pa 217 Pb 222 Pc 116 Pd 40 Pe 64 Pf 123 Pg 142 Mb 210 Me 161 Mf 135.</bibl>
           <p><milestone unit="traduction"/>Un sanglier, posté près d’un arbre, aiguisait ses défenses. Un renard lui demanda pour quelle raison, quand ni chasseur ni danger ne le pressaient, il affilait ses défenses. « Ce n’est pas pour rien, dit-il, que je le fais ; car si le danger vient à me surprendre, je n’aurai pas alors le loisir de les aiguiser ; mais je les trouverai toutes prêtes à faire leur office. »</p>
           <p><milestone unit="traduction"/>Cette fable enseigne qu’il ne faut pas attendre le danger pour faire ses préparatifs.</p>
         </div>
@@ -8984,7 +8983,7 @@
           <pb ed="perry" n="P224"/>
           <p><milestone unit="recitprose"/>Ὗς ἄγριος ἑστὼς παρά τι δένδρον τοὺς ὀδόντας ἠκόνα. Ἀλώπεκος δὲ αὐτὸν ἐρωτησάσης τὴν αἰτίαν, ὅτι, μηδεμιᾶς ἀνάγκης οὔσης, μήτε κυνηγοῦ, μήτε κινδύνου ἐφεστῶτος, τοὺς ὀδόντας τί θήγεις ; ἔφη· Ἀλλ οὐ ματαίως τοῦτο ποιῶ· ἐὰν γάρ με κίνδυνος καταλάϐῃ, οὐ τότε περὶ τὸ ἀκονᾶν ἀσχοληθήσομαι, ἑτοίμοις δὲ οὖσι χρήσομαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ πρὸ τῶν κινδύνων τὰς παρασκευὰς ποιεῖν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 185 Cb 101 Cd 116 Ce 77 Cf 81 Ch 124 Mc 94.</p>
+          <bibl>Codd. Ca 185 Cb 101 Cd 116 Ce 77 Cf 81 Ch 124 Mc 94.</bibl>
         </div>
         <div>
           <head>Chambry 328.3</head>
@@ -8992,7 +8991,7 @@
           <pb ed="perry" n="P224"/>
           <p><milestone unit="recitprose"/>Μόνιος ἄγριος ἐπί τινος ἑστὼς δένδρου τοὺς ὀδόντας ἔθηγεν. Ἀλώπεκος δ’ ἐρομένης τὴν αἰτίαν, ὅτι, μηδεμιᾶς προκειμένης ἀνάγκης, τοὺς ὀδόντας θήγει, ἔφη· « Οὐκ ἀλόγως τοῦτο ποιῶ· εἰ γάρ με κίνδυνος περισταίη, οὔκουν με τηνικαῦτα πρὸς τὸ τοὺς ὀδόντας ἀκονᾶν ἀσχολεῖσθαι δεήσει, ἀλλὰ μᾶλλον ἑτοίμοις οὖσι χρῆσθαι. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι δεῖ πρὸς τὸν κίνδυνον παρασκευάζεσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 54 Lb 83 Le 83 Lf 54 Lh 39 Md 114 Me 113 Mg 114 Mi 30 Ml 108 Mm 99.</p>
+          <bibl>Codd. La 54 Lb 83 Le 83 Lf 54 Lh 39 Md 114 Me 113 Mg 114 Mi 30 Ml 108 Mm 99.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-329">
@@ -9001,7 +9000,7 @@
         <pb ed="perry" n="P269"/>
         <p><milestone unit="recitprose"/>Σῦς ἄγριος καὶ ἵππος ἐν ταὐτῷ ἐνέμοντο. Τοῦ δὲ συὸς παρ’ ἕκαστα τὴν πόαν διαφθείροντος καὶ τὸ ὕδωρ θολοῦντος, ὁ ἵππος βουλόμενος αὐτὸν ἀμύνασθαι [ἐπὶ] κυνηγέτην σύμμαχον παρέλαϐε. Κἀκείνου εἰπόντος μὴ ἄλλως δύνασθαι αὐτῷ βοηθεῖν, ἐὰν μὴ χαλινόν τε ὑπομείνῃ καὶ αὐτὸν ἐπιϐάτην δέξηται, ὁ ἵππος πάντα ὑπέστη. Καὶ ὁ κυνηγέτης ἐποχηθεὶς αὐτῷ καὶ τὸν σῦν κατηγωνίσατο καὶ τὸν ἵππον προσαγαγὼν τῇ φάτνῃ προσέδησεν.</p>
         <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ δι’ ἀλόγιστον ὀργήν, ἕως τοὺς ἐχθροὺς ἀμύνασθαι θέλουσιν, ἑαυτοὺς ἑτέροις ὑπορρίπτουσιν.</p>
-        <p><milestone unit="manuscrits"/>Cod. Pa 218.</p>
+        <bibl>Cod. Pa 218.</bibl>
         <p><milestone unit="traduction"/>Le sanglier et le cheval partageaient le même pâtis. Comme le sanglier à chaque instant détruisait l’herbe et troublait l’eau, le cheval, voulant se venger de lui, recourut à l’aide d’un chasseur. Mais celui-ci ayant déclaré qu’il ne pouvait lui prêter main-forte que s’il consentait à recevoir un frein et à le prendre lui-même sur son dos, le cheval se soumit à toutes ses exigences. Alors le chasseur monté sur son dos mit le sanglier hors de combat, et, emmenant le cheval chez lui, l’attacha au râtelier.</p>
         <p><milestone unit="traduction"/>Ainsi bien des gens, en voulant, sous le coup d’une colère aveugle, se venger de leurs ennemis, se jettent sous le joug d’autrui.</p>
       </div>
@@ -9013,15 +9012,15 @@
           <pb ed="perry" n="P215"/>
           <p><milestone unit="recitprose"/>Σφῆκές ποτε καὶ πέρδικες δίψει συνεχόμενοι ἧκον πρὸς γεωργὸν καὶ παρὰ τούτου ποτὸν ᾔτουν ἐπαγγελλόμενοι ἀντὶ τοῦ ὕδατος, οἱ μὲν πέρδικες περισκάψειν τὰς ἀμπέλους καὶ τοὺς βότρυας εὐπρεπεῖς ποιήσειν, οἱ δὲ κύκλῳ περιστάντες τοῖς κέντροις τοὺς κλέπτας ἀπώσεσθαι. Κἀκεῖνος ὑποτυχὼν εἶπεν· « Ἀλλ’ ἔμοιγέ εἰσι δύο βόες, οἵτινες μηδέν μοι κατεπαγγελλόμενοι πάντα ποιοῦσιν· οἷς ἄμεινόν ἐστιν ἢ ὑμῖν τὸ ποτὸν παρασχεῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ἀχάριστον ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 220 Pb 211 Pc 117 Pe 67 Pf 126 Pg 136 Me 159 Mf 133.</p>
+          <bibl>Codd. Pa 220 Pb 211 Pc 117 Pe 67 Pf 126 Pg 136 Me 159 Mf 133.</bibl>
         </div>
         <div>
           <head>Chambry 330.2</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P215"/>
           <p><milestone unit="recitprose"/>Σφῆκές ποτε καὶ πέρδικες δίψει συνεχόμενοι ἧκον πρὸς γεωργὸν καὶ παρ’ αὐτοῦ ποτὸν ᾖτουν, ἐπαγγελλόμενοι ἀντὶ τοῦ ὕδατος χάριν αὐτῷ ποιῆσαι. Καὶ οἱ μέν πέρδικες περισκάψειν τοὺς ἀμπελῶνας καὶ τοὺς βότρυας εὐπρεπεῖς ποιήσειν, αἱ δὲ σφῆκες κύκλῳ περιιοῦσαι τοῖς κέντροις τοὺς κλέπτας ἀπώσεσθαι ἔλεγον. Κἀκεῖνος ὑποτυχὼν ἔφη· « Ἀλλ’ ἔμοιγέ εἰσι δύο βόες, οἵτινές μοι μηδὲν κατεπαγγελλόμενοι πάντα ποιοῦσιν, οἷς ἄμεινόν ἐστιν ἢ ὑμῖν ποτὸν παρέχειν. »</p>
-          <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος πρὸς ἄνδρα ἀχάριστον.<space rend="tab">    </space></p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 178 Cb 97 Cd 113 Ce 110 Cf 118 Ch 119 Mc 90.</p>
+          <p><milestone unit="epimythiumprose"/>Οὗτος ὁ λόγος πρὸς ἄνδρα ἀχάριστον.</p>
+          <bibl>Codd. Ca 178 Cb 97 Cd 113 Ce 110 Cf 118 Ch 119 Mc 90.</bibl>
         </div>
         <div>
           <head>Chambry 330.3</head>
@@ -9029,7 +9028,7 @@
           <pb ed="perry" n="P215"/>
           <p><milestone unit="recitprose"/>Σφῆκες καὶ πέρδικες δίψῃ συνεχόμενοι πρὸς γεωργὸν ἦλθον παρ’ αὐτοῦ αἰτοῦντες πιεῖν, ἐπαγγελλόμενοι ἀντὶ τοῦ ὕδατος ταύτην τὴν χάριν ἀποδώσειν· οἱ μὲν πέρδικες σκάπτειν τὰς ἀμπέλους, οἱ δὲ σφῆκες κύκλῳ περιιόντες τοῖς κέντροις ἀποσοϐεῖν τοὺς κλέπτας. Ὁ δὲ γεωργὸς ἔφη· « Ἀλλ’ ἔμοιγέ εἰσι δύο βόες, οἳ μηδὲν ἐπαγγελλόμενοι πάντα ποιοῦσιν· ἄμεινον οὖν ἐστιν ἐκείνοις δοῦναι ἤπερ ὑμῖν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος πρὸς ἄνδρας ἐξώλεις ὠφελεῖν μὲν ἐπαγγελλομένους, βλάπτοντας δὲ μεγάλα.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 52 Lb 119 Lc 25 Le 119 Lf 52 Lg 25 Lh 68 Md 103 Mg 144 Mi 19 Mj 140 Ml 149 Mm 127.</p>
+          <bibl>Codd. La 52 Lb 119 Lc 25 Le 119 Lf 52 Lg 25 Lh 68 Md 103 Mg 144 Mi 19 Mj 140 Ml 149 Mm 127.</bibl>
           <p><milestone unit="traduction"/>Des guêpes et des perdrix, pressées par la soif, vinrent trouver un laboureur, pour lui demander à boire, promettant, en échange d’un peu d’eau, de lui rendre un service, les perdrix en bêchant sa vigne, et les guêpes en en faisant le tour pour écarter les voleurs avec leurs aiguillons. Le laboureur répondit : « Mais j’ai deux bœufs qui me font tout sans rien promettre : il vaut donc mieux que je leur donne qu’à vous. »</p>
           <p><milestone unit="traduction"/>Cette fable s’adresse aux hommes corrompus qui promettent des services et causent de grands dommages.</p>
         </div>
@@ -9042,7 +9041,7 @@
           <pb ed="perry" n="P216"/>
           <p><milestone unit="recitprose"/>Σφὴξ ἐπὶ κεφαλὴν ὄφεως καθίσας καὶ συνεχῶς τῷ κέντρῳ πλήττων ἐχείμαζε. Ὁ δὲ περιώδυνος γενόμενος καὶ τὸν ἐχθρὸν οὐκ ἔχων ἀμύνασθαι, τὴν κεφαλὴν ἁμάξης τρόχῳ ὑπέθηκε, καὶ οὕτω τῷ σφηκὶ συναπέθανεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τινὲς τοῖς ἐχθροῖς αἱροῦνται συναποθνῄσκειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 212 Pg 137 Ma 132 Mj 141 Ce 108 Ch 116 Lb 120 Le 120.</p>
+          <bibl>Codd. Pb 212 Pg 137 Ma 132 Mj 141 Ce 108 Ch 116 Lb 120 Le 120.</bibl>
           <p><milestone unit="traduction"/>Un jour une guêpe se posta sur la tête d’un serpent, et le tourmenta, en le piquant sans relâche avec son aiguillon. Le serpent, fou de douleur, ne pouvant se venger de son ennemi, mit sa tête sous la roue d’un chariot et mourut ainsi avec la guêpe.</p>
           <p><milestone unit="traduction"/>Cette fable montre que certaines gens ne reculent pas à l’idée de mourir avec leurs ennemis.</p>
         </div>
@@ -9052,7 +9051,7 @@
           <pb ed="perry" n="P216"/>
           <p><milestone unit="recitprose"/>Σφὴξ ἐπὶ κεφαλὴν ὄφεως καθίσας καὶ συνεχῶς τῷ κέντρῳ πλήσσων ἐχείμαζεν. Ὁ δὲ περιώδυνος γενόμενος καὶ τὸν ἐχθρὸν οὐκ ἔχων ἀμύνασθαι, ἐξελθὼν ἐν τῇ ὁδῷ καὶ ἰδὼν ἅμαξαν ἐρχομένην, τὴν κεφαλὴν τῷ τρόχῳ ὑπέθηκε, φάσκων· « Συναπόλλυμαι τῷ ἐχθρῷ μου. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς τοὺς συγκινδυνεύειν τῷ ἐχθρῷ ἐπιχειροῦντας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pe 66 Pf 125 Me 160 Mf 134 Ca 179.</p>
+          <bibl>Codd. Pe 66 Pf 125 Me 160 Mf 134 Ca 179.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-332">
@@ -9063,7 +9062,7 @@
           <pb ed="perry" n="P217"/>
           <p><milestone unit="recitprose"/>Ταῦρος διωκόμενος ὑπὸ λέοντος κατέφυγεν εἴς τι σπήλαιον, ἐν ᾧ ἦσαν αἶγες ἄγριαι. Τυπτόμενος δὲ ὑπ’ αὐτῶν καὶ κερατιζόμενος ἔφη· « Ἀλλ’ οὐχ ὑμᾶς φοϐούμενος ἀνέχομαι, τὸν δὲ πρὸ τοῦ στομίου ἑστῶτα [λέοντα]. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω πολλοὶ διὰ φόϐον τῶν κρειττόνων καὶ τὰς ἐκ τῶν ἡττόνων ὕϐρεις ὑπομένουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 223 Pb 214 Pg 138 Ma 134 Mb 202 Ca 181 Ce 115 Cf 123.</p>
+          <bibl>Codd. Pa 223 Pb 214 Pg 138 Ma 134 Mb 202 Ca 181 Ce 115 Cf 123.</bibl>
           <p><milestone unit="traduction"/>Un taureau poursuivi par un lion se réfugia dans un antre où se trouvaient des chèvres sauvages. Frappé et encorné par elles, il leur dit : « Si j’endure vos coups, ce n’est pas que j’aie peur de vous, mais je crains celui qui se tient à l’entrée de la caverne. »</p>
           <p><milestone unit="traduction"/>C’est ainsi que souvent la crainte d’un plus fort nous fait supporter les outrages d’un moins fort que nous.</p>
         </div>
@@ -9073,7 +9072,7 @@
           <pb ed="perry" n="P217"/>
           <p><milestone unit="recitprose"/>Λέοντα φεύγων ταῦρος εἰς σπήλαιον ἔδυ· τράγος δὲ τοῦτον τοῖς κέρασιν ἐξώθει. Ὁ δὲ εἶπεν· « Οὐ σέ, ἀλλὰ τὸν λέοντα φοϐοῦμαι· ἐπεὶ παρελθέτω, καὶ τότε γνώσῃ τίς ἡ δύναμις ταύρου καὶ τράγου. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλάκις καὶ δυνατοὺς ἄνδρας αἱ συμφοραὶ ταπεινοῦσιν &lt;ὥστε&gt; τὰς ἐξ εὐτελῶν καὶ δειλῶν ὑπομένειν αἰκίας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 72 Bd 46 Mb 93.</p>
+          <bibl>Codd. Ba 72 Bd 46 Mb 93.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-333">
@@ -9084,7 +9083,7 @@
           <pb ed="perry" n="P294"/>
           <p><milestone unit="recitprose"/>Ταὼν γεράνου κατεγέλα, κωμῳδῶν τὴν χροιὰν αὐτοῦ καὶ λέγων ὡς « ἐγὼ μὲν χρυσὸν καὶ πορφύραν ἐνδέδυμαι, σὺ δὲ οὐδὲν καλὸν φέρεις ἐν πτεροῖς. » Ὁ δέ· « Ἀλλ’ ἐγώ, ἔφη, τῶν ἀστέρων ἔγγιστα φωνῶ, καὶ εἰς τὰ οὐράνια ὕψη ἵπταμαι· σὺ δέ, ὡς ἀλέκτωρ, κάτω μετ’ ὀρνίθων βαίνεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρεῖττον περίϐλεπτον εἶναί τινα ἐν πενιχρᾷ ἐσθῆτι ἢ ζῆν ἀδόξως πλούτῳ γαυρούμενον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Pb 219.</p>
+          <bibl>Cod. Pb 219.</bibl>
           <p><milestone unit="traduction"/>Le paon se moquait de la grue et critiquait sa couleur. « Moi, disait-il, je suis vêtu d’or et de pourpre ; toi, tu ne portes rien de beau sur tes ailes. – Mais moi, répliqua la grue, je chante tout près des astres et je m’élève dans les hauteurs du ciel ; toi, comme les coqs, tu marches sur le sol, avec les poules. »</p>
           <p><milestone unit="traduction"/>Il vaut mieux être illustre sous un vêtement pauvre que de vivre sans gloire, en se panadant dans la richesse.</p>
         </div>
@@ -9094,7 +9093,7 @@
           <pb ed="perry" n="P294"/>
           <p><milestone unit="recitprose"/>Ἢριζεν εὐφυεῖ γεράνῳ ταὼς χρυσόπτερος, σκώπτουσα τὴν χροιὰν τῆς γεράνου. Ἡ δὲ ἔφη· « Ἀλλ’ ἐγὼ ἄστρων ἐγγὺς ἵπταμαι καὶ φωνῶ· σὺ δὲ, ὡς ἀλέκτωρ, χαμαὶ πτερύσσῃ οὐδ’ ἄνω φαίνῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρεῖσσον περίϐλεπτόν τινα εἶναι σὺν πενιχρᾷ ἐσθῆτι ἢ ζῆν &lt;ἀδόξως&gt; σὺν πλουσίᾳ ἐστθῆτι.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 47.</p>
+          <bibl>Cod. Ba 47.</bibl>
         </div>
         <div>
           <head>Chambry 333.3</head>
@@ -9111,7 +9110,7 @@
           <l><milestone unit="recitvers"/>σὺ δ’, ὡς ἀλέκτωρ, κάτωθεν βηματίζεις</l>
           <l><milestone unit="recitvers"/>μετὰ ὀρνίθων καὶ τῶν ἀλεκτορίδων. »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι κρεῖσσόν ἐστι περίϐλεπτόν τινα εἶναι ἐν πενιχρᾷ ἐσθῆτι ἢ ζῆν ἀδόξως ἐν πλούτῳ γαυρούμενον.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 207.</p>
+          <bibl>Cod. Mb 207.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-334">
@@ -9122,7 +9121,7 @@
           <pb ed="perry" n="P219"/>
           <p><milestone unit="recitprose"/>Τῶν ὀρνέων βουλευομένων περὶ βασιλείας, ταὼς ἠξίου αὐτὸν χειροτονῆσαι βασιλέα διὰ τὸ κάλλος. Ὡρμημένων δὲ ἐπὶ τοῦτο τῶν ὀρνέων, κολοιὸς εἶπεν· « Ἀλλ’ ἐάν, σοῦ βασιλεύοντος, ἀετὸς ἡμᾶς διώκῃ, πῶς ἡμῖν ἐπαρκέσεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ μεμπτοὶ ὅσοι προειδότες τοὺς μέλλοντας κινδύνους, πρὶν παθεῖν, φυλάττονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 226 Pb 216 Pf 131 Pg 140 Mb 171.</p>
+          <bibl>Codd. Pa 226 Pb 216 Pf 131 Pg 140 Mb 171.</bibl>
           <p><milestone unit="traduction"/>Les oiseaux délibéraient sur le choix d’un roi. Le paon prétendit se faire nommer roi à cause de sa beauté, et les oiseaux allaient voter pour lui, quand le choucas s’écria : « Mais si, quand tu règneras, l’aigle nous donne la chasse, quel secours pourrons-nous attendre de toi ? »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas blâmer ceux qui, prévoyant les périls futurs, prennent leurs précautions à l’avance.</p>
         </div>
@@ -9132,7 +9131,7 @@
           <pb ed="perry" n="P219"/>
           <p><milestone unit="recitprose"/>Τῶν ὀρνέων βουλομένων ποιῆσαι βασιλέα, ταὼς ἠξίου ἑαυτὸν χειροτονεῖσθαι βασιλέα διὰ τὸ κάλλος. Ἀρεσθέντων δὲ πάντων ἐπὶ τούτῳ τῶν ὀρνέων, κολοιὸς αὐτῷ εἶπεν· « Ἀλλ’ ἐάν, σοῦ βασιλεύοντος, ἀετὸς ἡμᾶς καταδιῶξαι ἐπιχειρήσῃ, πῶς ἡμῖν ἐπαρκέσεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἀεὶ τοὺς δυνάστας μὴ κάλλει, ἀλλὰ φρονήσει καὶ δυνάμει δεῖ κομεῖσθαι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 183 Ce 111 Cf 119 Ch 120.</p>
+          <bibl>Codd. Ca 183 Ce 111 Cf 119 Ch 120.</bibl>
         </div>
         <div>
           <head>Chambry 334.3</head>
@@ -9140,7 +9139,7 @@
           <pb ed="perry" n="P219"/>
           <p><milestone unit="recitprose"/>Τῶν ὀρνίθων βουλομένων ποιῆσαι βασιλέα, ταὼς ἑαυτὸν ἠξίου διὰ τὸ κάλλος χειροτονεῖν. Αἱρουμένων δὲ τοῦτον πάντων, κολοιὸς ὑπολαϐὼν ἔφη· « Ἀλλ’ εἰ, σοῦ βασιλεύοντος, ἀετὸς ἡμᾶς καταδιώκειν ἐπιχειρήσει, πῶς ἡμῖν ἐπαρκέσεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς ἄρχοντας οὐ διὰ κάλλος μόνον, ἀλλὰ καὶ ῥώμην καὶ φρόνησιν ἐκλέγεσθαι δεῖ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 53 Lb 121 Lc 29 Le 121 Lf 53 Lg 29 Lh 69 Md 104 Me 168 Mf 139 Mg 147 Mi 20 Mj 142 Ml 150 Mm 129.</p>
+          <bibl>Codd. La 53 Lb 121 Lc 29 Le 121 Lf 53 Lg 29 Lh 69 Md 104 Me 168 Mf 139 Mg 147 Mi 20 Mj 142 Ml 150 Mm 129.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-335">
@@ -9148,8 +9147,8 @@
         <head type="sub">Τέττιξ καὶ ἀλώπηξ — La cigale et le renard.</head>
         <pb ed="perry" n="P241"/>
         <p><milestone unit="recitprose"/>Τέττιξ ἐπὶ τινος ὑψηλοῦ δένδρου ᾖδεν. Ἀλώπηξ δὲ βουλομένη αὐτὸν καταφαγεῖν τοιοῦτόν τι ἐπενόησεν. Ἄντικρυς στᾶσα ἐθαύμαζεν αὐτοῦ τὴν εὐφωνίαν, καὶ παρεκάλει καταϐῆναι, λέγουσα ὅτι ἐπιθυμεῖ θεάσασθαι πηλίκον ζῷον τηλικαύτην φωνὴν φθέγγεται. Κἀκεῖνος ὑπονοήσας αὐτῆς τὴν ἐνέδραν, φύλλον ἀποσπάσας καθῆκε. Προσδραμούσης δὲ ὡς ἐπὶ τὸν τέττιγα, ἔφη· « Ἀλλὰ πεπλάνησαι, ὦ αὕτη, εἰ ὑπέλαϐές με καταϐήσεσθαι· ἐγὼ γὰρ ἀπ’ ἐκείνου ἀλώπεκας φυλάττομαι ἀφ’ οὗ ἐν ἀφοδεύματι ἀλώπεκος πτερὰ τέττιγος ἐθεασάμην. »</p>
-        <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς φρονίνους τῶν ἀνθρώπων αἱ τῶν πέλας συμφοραὶ σωφρονίζουσι.<space rend="tab">    </space></p>
-        <p><milestone unit="manuscrits"/>Codd. Pa 224 Pe 69 Pf 129 Me 166 Mf 137.</p>
+        <p><milestone unit="epimythiumprose"/>Ὅτι τοὺς φρονίνους τῶν ἀνθρώπων αἱ τῶν πέλας συμφοραὶ σωφρονίζουσι.</p>
+        <bibl>Codd. Pa 224 Pe 69 Pf 129 Me 166 Mf 137.</bibl>
         <p><milestone unit="traduction"/>Une cigale chantait sur un arbre élevé. Un renard qui voulait la dévorer imagina la ruse que voici. Il se plaça en face d’elle, il admira sa belle voix et il l’invita à descendre : il désirait, disait-il, voir l’animal qui avait une telle voix. Soupçonnant le piège, la cigale arracha une feuille et la laissa tomber. Le renard accourut, croyant que c’était la cigale. « Tu te trompes, compère, lui dit-elle, si tu as cru que je descendrais : je me défie des renards depuis le jour où j’ai vu dans la fiente de l’un d’eux des ailes de cigale. »</p>
         <p><milestone unit="traduction"/>Les malheurs du voisin assagissent les hommes sensés.</p>
       </div>
@@ -9174,7 +9173,7 @@
           <l><milestone unit="recitvers"/>ἀλλ’ ἐν θέρει σὺ τὸν σῖτον ἀποτίθει</l>
           <l><milestone unit="recitvers"/>καὶ μὴ λυρίζων ἡδύνῃς ὁδοιπόρους. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τινα ἀμελεῖν ἢ ὀκνεῖν ἐπί τινος πράγματος, ἀλλὰ τὰ δέοντα ποιεῖν, μή πως ὀκνήσας κινδύνῳ περιπέσῃ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ca 198.</p>
+          <bibl>Cod. Ca 198.</bibl>
         </div>
         <div>
           <head>Chambry 336.2</head>
@@ -9195,7 +9194,7 @@
           <l><milestone unit="recitvers"/>σῖτον γὰρ θέρους ταῖς ἀποθήκαις βάλλε,</l>
           <l><milestone unit="recitvers"/>καὶ μὴ λυρίζων ὁδίτας κατατέρπῃς. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τινα ὀκνεῖν ἢ ἀμελεῖν ἐπί τινος πράγματος, ἀλλὰ τὰ δέοντα ποιεῖν, μή πως ὀκνῶν κινδύνῳ περιπέσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 130 Cb 107 Cd 121.</p>
+          <bibl>Codd. Ch 130 Cb 107 Cd 121.</bibl>
         </div>
         <div>
           <head>Chambry 336.3</head>
@@ -9203,7 +9202,7 @@
           <pb ed="perry" n="P373"/>
           <p><milestone unit="recitprose"/>Χειμῶνος ὥρᾳ τὸν σῖτον βραχέντα οἱ μύρμηκες ἔψυχον. Τέττιξ δὲ λιμώττων ᾔτει αὐτοὺς τροφήν. Οἱ δὲ μύρμηκες εἶπον αὐτῷ· « Διὰ τί τὸ θέρος οὐ συνῆγες καὶ σὺ τροφήν ; » Ὁ δὲ εἶπεν· « Οὐκ ἐσχόλαζον, ἀλλ’ ᾖδον μουσικῶς. » Οἱ δὲ γελάσαντες εἶπον· « Ἀλλ’ εἰ θέρους ὥραις ηὔλεις, χειμῶνος ὀρχοῦ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐ δεῖ τινα ἀμελεῖν ἐν παντὶ πράγματι, ἵνα μὴ λυπηθῇ καὶ κινδυνεύσῃ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 138 Lc 40 Mh 94 Mi 25 Mm 140 Ba 146.</p>
+          <bibl>Codd. La 138 Lc 40 Mh 94 Mi 25 Mm 140 Ba 146.</bibl>
           <p><milestone unit="traduction"/>C’était en hiver ; leur grain étant mouillé, les fourmis le faisaient sécher. Une cigale qui avait faim leur demanda de quoi manger. Les fourmis lui dirent : « Pourquoi, pendant l’été, n’amassais-tu pas, toi aussi, des provisions ? – Je n’en avais pas le temps, répondit la cigale : je chantais mélodieusement. » Les fourmis lui rirent au nez : « Eh bien ! dirent-elles, si tu chantais en été, danse en hiver. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’en toute affaire il faut se garder de la négligence, si l’on veut éviter le chagrin et le danger.</p>
         </div>
@@ -9213,7 +9212,7 @@
           <pb ed="perry" n="P373"/>
           <p><milestone unit="recitprose"/>Ψύχος ἦν καὶ χειμὼν κατ’ Ὀλύμπου. Μύρμηξ δὲ πολλὰς συνάξας τροφὰς ἐν ἀμητοῖς ἐν ἰδίοις οἴκοις ἀπέθηκε. Τέττιξ δὲ ἐπὶ τρώγλης ἐνδύνας ἐξέπνεε τῇ πείνῃ, λιμῷ κατεχόμενος καὶ ψύχει πολλῷ· ἐδέετο δὲ τοῦ μύρμηκος τροφῆς μεταδοῦναι, ὅπως καὶ αὐτὸς γευσάμενός τινος σωθείη. Ὁ μύρμηξ δὲ πρὸς αὐτόν· « Ποῦ, φησίν, ἦς τῷ θέρει ; πῶς δ’ οὐ συνῆξας τροφὰς ἐν ἀμητῷ ; » Ὁ δὲ τέττιξ· « ᾞδον καὶ ἔτερπον τοὺς ὀδοιποροῦντας. » Ὁ δὲ μύρμηξ γέλωτα πολὺν καταχέας ἔφη· « Οὐκοῦν χειμῶνος ὀρχοῦ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐδὲν κρεῖττον τοῦ φροντίζειν τῶν ἀναγκαίων τροφῶν, καὶ μὴ ἀπασχολεῖσθαι εἰς τέρψιν καὶ κωμασίαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 195 Cf 132 Pg 151 Ma 143.</p>
+          <bibl>Codd. Ca 195 Cf 132 Pg 151 Ma 143.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-337">
@@ -9221,7 +9220,7 @@
         <head type="sub">Τοῖχος καὶ πάλος — La muraille et la cheville.</head>
         <pb ed="perry" n="P270"/>
         <p><milestone unit="recitprose"/>Τοῖχος σπαραττόμενος ὑπὸ πάλου βιαίως ἐφώνει· « Τί με σπαράττεις μηδὲν ἠδικηκότα ; » Καὶ ὅς· « Οὐκ ἐγώ, φησίν, αἴτιος τούτου, ἀλλ’ ὁ ὄπισθεν σφοδρῶς με τύπτων. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 208.</p>
+        <bibl>Cod. Mb 208.</bibl>
         <p><milestone unit="traduction"/>Une muraille, percée brutalement pa une cheville, criait : « Pourquoi me perces-tu, moi qui ne t’ai fait aucun mal ? – Ce n’est pas moi, dit la cheville, qui suis la cause de ce que tu souffres, mais celui qui me frappe violemment par derrière. »</p>
       </div>
       <div type="poem" xml:id="chambry-338">
@@ -9232,7 +9231,7 @@
           <pb ed="perry" n="P340"/>
           <p><milestone unit="recitprose"/>Ἀνῆλθέ τις εἰς ὄρος τοξότης ἔμπειρος κυνηγῆσαι. Πάντα δὲ τὰ ζῷα ἔφυγον, λέων δὲ μόνος προεκαλεῖτο αὐτὸν πρὸς μάχην. Ὁ δὲ βέλος πέμψας καὶ τὸν λέοντα βαλὼν εἶπεν· « Ἰδὲ τὸν ἐμὸν ἄγγελον οἷός ἐστιν, καὶ δὴ τότε ἐπέρχομαί σοι κἀγώ. » Ὁ δὲ λέων βληθεὶς ὥρμησε φεύγειν. Ἀλώπεκος δὲ τούτῳ θαρρεῖν καὶ μὴ φεύγειν λεγούσης, ἔφη ὁ λέων· « Οὐδαμῶς με πλανήσεις· ὅπου γὰρ τοιοῦτον πικρὸν ἄγγελον ἔχει, ἐὰν αὐτὸς ἐπέλθῃ μοι, τί ποιήσω ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐκ τῆς ἀρχῆς τὰ τέλη δεῖ προσκοπῆσαι καὶ τότε δὴ λοιπὸν ἑαυτοὺς περισῴζειν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 11 Ma 156 Md 31 Mg 24 Mm 31.</p>
+          <bibl>Codd. Ba 11 Ma 156 Md 31 Mg 24 Mm 31.</bibl>
           <p><milestone unit="traduction"/>Un habile archer monta dans la montagne pour y chasser. Tous les animaux s’enfuirent ; seul, le lion le provoqua au combat. L’homme lui lança un trait et l’ayant atteint, lui dit : « Vois quel est mon messager, après quoi j’irai à toi moi aussi. » Le lion blessé se mit à fuir. Cependant un renard lui cria d’avoir confiance et de ne pas fuir. Le lion lui répondit : « Tu ne m’en imposeras pas ; s’il a un messager si amer, quand il viendra lui-même, que ferai-je ? »</p>
           <p><milestone unit="traduction"/>C’est au début qu’il faut examiner la fin et dès lors assurer son salut.</p>
         </div>
@@ -9242,7 +9241,7 @@
           <pb ed="perry" n="P340"/>
           <p><milestone unit="recitprose"/>Ἀνῆλθέ τις ἐν ὄρει κυνηγίου χάριν. Ἰδόντα δὲ αὐτὸν ἅπαντα τὰ θηρία μακρὸν ᾤχοντο· λέων δὲ μόνος πρὸς μάχην μετεκαλεῖτο αὐτόν. Ὁ δὲ τὸ βέλος ἀφεὶς καιρίως τὸν ἰσχυρὸν ἐτραυμάτισεν, εἰπών· « Ἰδὲ τὸν ἐμὸν ἄγγελον πρῶτον οἱός ἐστι καὶ αὖθις δὴ τὴν ἐμὴν ἰσχὺν δοκιμάσεις. » Ὁ δὲ λέων βληθεὶς φεύγειν ὥρμησε ἀμεταστρεπτί. Ἀλώπηξ δὲ τούτῳ συνήντησε καὶ θαρρεῖν συνεϐούλευεν. Ἔφη δὲ οὗτος· « Οὐδαμῶς με πλανήσεις, δολία· ἐπεὶ γὰρ τοιοῦτον πικρὸν ἄγγελον ὁ ἄνθρωπος ἔχει, ἐὰν αὐτός μοι ἐπέλθῃ, τί ποιήσω ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐκ τῆς ἀρχῆς τὸ τέλος δεῖ προιδεῖν καὶ ἑαυτοὺς περισώζειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Bc 9.</p>
+          <bibl>Cod. Bc 9.</bibl>
         </div>
         <div>
           <head>Chambry 338.3</head>
@@ -9264,7 +9263,7 @@
           <l><milestone unit="recitvers"/>τί δ’ ἄρα, εἴπέ μοι, καινὸν οὐ ποιήσει</l>
           <l><milestone unit="recitvers"/>μετὰ μαχαίρας καὶ κόντου ὃν βαστάζει ; »</l>
           <p><milestone unit="epimythiumprose"/>Ὅτι ἐκ τῆς ἀρκῆς χρὴ σκοπεῖν τὰ τέλη ὅπως καὶ αὐτοὶ περισωθῶσι πάνυ.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 206.</p>
+          <bibl>Cod. Mb 206.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-339">
@@ -9275,7 +9274,7 @@
           <pb ed="perry" n="P374"/>
           <p><milestone unit="recitprose"/>Τράγος ἐν τῇ ἐκϐολῇ τῆς ἀμπέλου τὴν βλάστην ἔτρωγε. Τούτῳ δὲ προσεῖπεν ἡ ἄμπελος· « Τί με βλάπτεις ; μὴ γὰρ οὐκ ἐστι χλόη ; Ὅμως ὅσον σοῦ θυομένου οἶνον χρῄζουσιν, ἐγὼ παρέξω. »</p>
           <p><milestone unit="epimythiumprose"/>Τοὺς ἀχαρίστους καὶ βουλομένους τοὺς φίλους πλεονεκτεῖν ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 133 Bb 80.</p>
+          <bibl>Codd. Ba 133 Bb 80.</bibl>
           <p><milestone unit="traduction"/>Au temps où la vigne jette ses pousses, un bouc en broutait les bourgeons. La vigne lui dit : « Pourquoi m’endommages-tu ? N’y a-t-il plus d’herbe verte ? Je n’en fournirai pas moins tout le vin nécessaire, lorsqu’on te sacrifiera. »</p>
           <p><milestone unit="traduction"/>Cette fable confond les gens ingrats et qui veulent voler leurs amis.</p>
         </div>
@@ -9288,7 +9287,7 @@
           <l><milestone unit="recitvers"/>μὴ γάρ, ὦ τράγε, οὐκ ἔστιν ἄρτι χλόη ;</l>
           <l><milestone unit="recitvers"/>Ὅμως, πάναφρον, ποτὲ σοῦ θυομένου,</l>
           <l><milestone unit="recitvers"/>ἐγὼ τὸν οἶνον παρέξω τῷ σῷ φόνῳ. »</l>
-          <p><milestone unit="manuscrits"/>Cod. Mb 204.</p>
+          <bibl>Cod. Mb 204.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-340">
@@ -9299,7 +9298,7 @@
           <pb ed="perry" n="P243"/>
           <p><milestone unit="recitprose"/>Τὰς ὑαίνας φασὶ παρ’ ἐνιαυτὸν ἀλλάττειν τὴν φύσιν καὶ ποτὲ μὲν ἄρρενας γίνεσθαι, ποτὲ δὲ θηλείας. Καὶ δή ποτε ὕαινα ἄρσην &lt;πρὸς&gt; ὕαιναν θήλειαν παρὰ φύσιν διετέθη. Ἡ δὲ ὑποτυχοῦσα ἔφη· « Ἀλλ’, ὦ οὗτος, οὕτω ταῦτα πράττε ὡς ἐγγὺς τὰ αὐτὰ πεισόμενος. »</p>
           <p><milestone unit="epimythiumprose"/>Τοῦτο εἰκότως εἴποι ἄν τις πρὸς τὸν ἤδη ἄρχοντα ὁ μετ’ ἐκεῖνον μέλλων, εἰ πλημμελές τι πάσχοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 222 Pf 127 Me 164 Mf 136.</p>
+          <bibl>Codd. Pa 222 Pf 127 Me 164 Mf 136.</bibl>
           <p><milestone unit="traduction"/>Les hyènes, dit-on, changent de nature chaque année et deviennent alternativement mâles et femelles. Or un jour une hyène mâle prit à l’égard d’une hyène femelle une posture contre nature. Celle-ci répondit : « Si tu fais cela, camarade, songe que tu subiras bientôt le même traitement ? »</p>
           <p><milestone unit="traduction"/>C’est ce que pourrait dire au magistrat en charge celui qui doit lui succéder, s’il avait à souffrir de lui quelque indignité.</p>
         </div>
@@ -9314,7 +9313,7 @@
           <l><milestone unit="recitvers"/>εἰπεῖν· « Ὦ φίλε, μέμνησο πρόσθεν τόδε,</l>
           <l><milestone unit="recitvers"/>αὖθις τὸν αὐτόν ποτε ἀρρενωθῆναι. »</l>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος τοὺς ἄρξαντας ἐπὶ χρόνον τινὰ ἐδίδαξεν ὅτι κριθέντες ἄνθρωποί ποτε ὕστερον ἔκριναν τοὺς πάλαι διδασκάλους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 213.</p>
+          <bibl>Cod. Mb 213.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-341">
@@ -9323,7 +9322,7 @@
         <pb ed="perry" n="P242"/>
         <p><milestone unit="recitprose"/>Τὰς ὑαίνας φασί, παρ’ ἐνιαυτὸν ἀλλασσομένης αὐτῶν τῆς φύσεως, ποτὲ μὲν ἄρσενας, ποτὲ δὲ θηλείας γίνεσθαι. Καὶ δὴ ὕαινα θεασαμένη ἀλώπεκα ἐμέμφετο αὐτὴν ὅτι φίλην θέλουσαν αὐτῇ γενέσθαι οὐ προσίεται. Κἀκείνη ὑποτυχοῦσα εἶπεν· « Ἀλλ’ ἐμὲ μὴ μέμφου, τὴν δὲ σὴν φύσιν, δι’ ἣν ἀγνοῶ πότερον ὡς φίλῃ ἢ ὡς φίλῳ σοι χρήσομαι. »</p>
         <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα ἀμφίϐολον.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pf 128 Me 165 Pe 68.</p>
+        <bibl>Codd. Pf 128 Me 165 Pe 68.</bibl>
         <p><milestone unit="traduction"/>On dit que les hyènes changent de nature tous les ans et deviennent alternativement mâles et femelles. Or une hyène, apercevant un renard, lui reprochait de la repousser, alors qu’elle voulait devenir son amie. « Ce n’est pas à moi qu’il faut t’en prendre, repartit le renard, mais à ta nature, qui fait que j’ignore si j’aurai en toi une amie ou un ami. »</p>
         <p><milestone unit="traduction"/>Ceci vise l’homme ambigu.</p>
       </div>
@@ -9335,7 +9334,7 @@
           <pb ed="perry" n="P222"/>
           <p><milestone unit="recitprose"/>Ὗς καὶ κύων πρὸς ἀλλήλας διεφέροντο. Τῆς δὲ ὑὸς ὀμνυούσης τὴν Ἀφροδίτην, ἐὰν μὴ παύσηται, τοῖς ὀδοῦσιν αὐτὴν ἀνατεμεῖν, ἡ κύων ἔλεγε καὶ κατ’ αὐτὸ τοῦτο αὐτὴν ἀγνωμονεῖν, εἴγε Ἀφροδίτη μισεῖ, ὥστε καὶ ἐὰν φάγῃ τις ὑὸς κρέα, τοῦτον οὐκ ἐᾷ εἰς τὸ ἱερὸν αὐτῆς εἰσιέναι. Καὶ ἡ ὗς ὑποτυχοῦσα ἔφη· « Ἀλλὰ τοῦτό γε οὐ στυγοῦσά με ποιεῖ, προνοουμένη δέ, ἵνα μηδείς με θύῃ. »</p>
           <p><milestone unit="epimythiumprose"/>Οὕτως οἱ φρόνιμοι τῶν ῥητόρων πολλάκις καὶ τὰ ὑπὸ τῶν ἐχθρῶν προσφερόμενα ὀνείδη εἰς ἐπαίνους μετασχηματίζουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 227 Pb 220 Pc 118 Pf 133 Mb 211 Me 170 Mf 141.</p>
+          <bibl>Codd. Pa 227 Pb 220 Pc 118 Pf 133 Mb 211 Me 170 Mf 141.</bibl>
         </div>
         <div>
           <head>Chambry 342.2</head>
@@ -9343,7 +9342,7 @@
           <pb ed="perry" n="P222"/>
           <p><milestone unit="recitprose"/>Σῦς καὶ κύων ἀλλήλαις διελοιδοροῦντο. Καὶ ἡ μὲν σῦς ὤμνυε κατὰ τῆς Ἀφροδίτης ἦ μὴν τοῖς ὀδοῦσιν ἀναρρήξειν τὴν κύνα. Ἡ δὲ κύων πρὸς ταῦτα εἰρωνικῶς εἶπε· « Καλῶς κατὰ τῆς Ἀφροδίτης ἡμῖν ὀμνύεις· δηλοῖς γὰρ ὑπ’ αὐτῆς ὅτι μάλιστα φιλεῖσθαι, ἣ τὸν τῶν σῶν ἀκαθάρτων σαρκῶν γευόμενον οὐδ’ ὅλως εἰς ἱερὸν προσίεται. » Καὶ ἡ σῦς· « Διὰ τοῦτο μὲν οὖν μᾶλλον δήλη ἐστὶν ἡ θεὸς στέργουσά με· τὸν γὰρ κτείναντα ἢ ἄλλως λυμαινόμενον παντάπασιν ἀποστρέφεται· σὺ μέντοι κακῶς ὄζεις καὶ ζῶσα καὶ τεθνηκυῖα. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ φρόνιμοι τῶν ῥητόρων τὰ ὑπὸ τῶν ἐχθρῶν ὀνείδη εὐμεθόδως εἰς ἔπαινον μετασχηματίζουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 69 Lb 122 Le 122 Lf 69 Md 123 Me 163 Mg 145 Mi 97 Mj 143 Ml 147 Mm 132.</p>
+          <bibl>Codd. La 69 Lb 122 Le 122 Lf 69 Md 123 Me 163 Mg 145 Mi 97 Mj 143 Ml 147 Mm 132.</bibl>
           <p><milestone unit="traduction"/>La truie et la chienne faisaient assaut d’injures. La truie jurait par Aphrodite qu’elle déchirerait la chienne à belles dents. La chienne lui répondit ironiquement : « C’est bien fait à toi de nous jurer par Aphrodite : il apparaît bien qu’elle t’aime de toute sa tendresse, elle qui refuse absolument d’admettre dans son temple celui qui a goûté à ta chair impure. – Cela même est une preuve de plus que la déesse me chérit, puisqu’elle repousse absolument quiconque me tue ou me maltraite de quelque façon que ce soit. Quant à toi, tu sens mauvais, aussi bien de ton vivant qu’après ta mort. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que les orateurs avisés tournent adroitement à leur éloge les injures de leurs ennemis.</p>
         </div>
@@ -9356,7 +9355,7 @@
           <pb ed="perry" n="P223"/>
           <p><milestone unit="recitprose"/>Ὗς καὶ κύων περὶ εὐτοκίας ἤριζον. Τῆς δὲ κυνὸς εἰπούσης ὅτι μόνη τῶν τετραπόδων ταχέως ἀποκύει, ἡ ὗς ὑποτυχοῦσα εἶπεν· « Ἀλλ’, ὅταν τοῦτο φράζῃ, γίνωσκε ὅτι τυφλὰ τίκτεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐκ ἐν τῷ τάχει τὰ πράγματα, ἐν δὲ τῇ τελειότητι κρίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 228 Pb 221 Pc 119 Pe 70 Pf 134 Pg 143 Ma 136 Mb 212 Me 171 Ca 186 Ce 117 Cf 125.</p>
+          <bibl>Codd. Pa 228 Pb 221 Pc 119 Pe 70 Pf 134 Pg 143 Ma 136 Mb 212 Me 171 Ca 186 Ce 117 Cf 125.</bibl>
           <p><milestone unit="traduction"/>La truie et la chienne disputaient de fécondité. La chienne prétendait que, seule de tous les quadrupèdes, elle avait des portées courtes. « Quand tu dis cela, répartit la truie, reconnais que tu n’enfantes que des aveugles. »</p>
           <p><milestone unit="traduction"/>Cette fable montre qu’une œuvre se juge, non sur la vitesse, mais sur la perfection de l’exécution.</p>
         </div>
@@ -9366,7 +9365,7 @@
           <pb ed="perry" n="P223"/>
           <p><milestone unit="recitprose"/>Ὗς καὶ κύων περὶ εὐτοκίας ἤριζον. Ἔφη δ’ ἡ κύων εὔτοκος εἶναι μάλιστα πάντων τῶν πεζῶν ζῴων. Καὶ ἡ ὗς ὑποτυχοῦσα πρὸς ταῦτα φησίν· « Ἀλλ’, ὅταν τοῦτο λέγῃς, ἴσθι ὅτι καὶ τυφλοὺς τοὺς σαυτῆς σκύλακας τίκτεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐκ ἐν τῷ τάχει τὰ πράγματα, ἀλλ’ ἐν τῇ τελειότητι κρίνεται.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 70 Lb 123 Le 123 Lf 70 Lh 70 Md 124 Me 171 Mf 142 Mg 148 Mi 98 Mj 144 Ml 148 Mm 133.</p>
+          <bibl>Codd. La 70 Lb 123 Le 123 Lf 70 Lh 70 Md 124 Me 171 Mf 142 Mg 148 Mi 98 Mj 144 Ml 148 Mm 133.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-344">
@@ -9375,7 +9374,7 @@
         <pb ed="perry" n="P375"/>
         <p><milestone unit="recitprose"/>Φαλακρός τις τρίχας ξένας τῇ ἑαυτοῦ κορυφῇ περιθεὶς ἵππευεν. Ἄνεμος δέ φυσήσας ἀφείλετο ταύτας· γέλως πλατὺς δὲ τοὺς παρεστῶτας εἶχεν. Κἀκεῖνος εἶπε τοῦ δρόμου παύσας· « Τὰς οὐκ ἐμὰς τρίχας τί ξένον φεύγειν με, αἳ καὶ τὸν ἔχοντα ταύτας, μεθ’ οὗ καὶ ἐγεννήθησαν, κατέλιπον ; »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι μηδεὶς λυπείσθω ἐπὶ συμφορᾷ ἐπελθούσῃ· ὃ γὰρ γεννηθεὶς οὐκ ἔσχεν ἐκ φύσεως, τοῦτο οὐδὲ παραμένει· γυμνοὶ γὰρ ἤλθομεν, γυμνοὶ καὶ ἀπελευσόμεθα.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 141 Bb 86 Mb 218 Mc 96 Md 107 Mh 93 Mi 23 Mm 134 Mn 33.</p>
+        <bibl>Codd. Ba 141 Bb 86 Mb 218 Mc 96 Md 107 Mh 93 Mi 23 Mm 134 Mn 33.</bibl>
         <p><milestone unit="traduction"/>Un homme chauve qui portait perruque cheminait à cheval. Le vent, s’étant mis à souffler, lui enleva ses faux cheveux, et les témoins de sa mésaventure se mirent à rire aux éclats. Alors le cavalier, arrêtant son cheval, dit : « Qu’y a-t-il d’étrange à ce que des cheveux qui ne sont pas les miens me quittent, eux qui ont abandonné même leur vrai propriétaire, avec qui la nature les a fait naître ? »</p>
         <p><milestone unit="traduction"/>Il ne faut pas nous affliger des accidents qui nous surviennent : ce qu’on ne tient pas de sa nature dès sa naissance, on ne saurait le garder : nus nous sommes venus, nus nous partirons.</p>
       </div>
@@ -9387,7 +9386,7 @@
           <pb ed="perry" n="P225"/>
           <p><milestone unit="recitprose"/>Φιλάργυρός τις τὴν οὐσίαν ἐξαργυρισάμενος βῶλον χρυσοῦν ὠνήσατο καὶ τοῦτον πρὸ τοῦ τείχους κατορύξας διετέλει συνεχῶς ἐρχόμενος καὶ ἐπισκεπτόμενος. Τῶν δὲ περὶ τὸν τόπον ἐργατῶν τις παρατηρησάμενος αὐτοῦ τὰς ἀφίξεις καὶ ὑπονοήσας τὸ ἀληθές, ἀπαλλαγέντος αὐτοῦ, τὸ χρυσίον ἀνείλατο. Ὁ δέ, ὡς ἐπανελθὼν εὗρε τὸν τόπον κενόν, ἔκλαιε καὶ τὰς τρίχας ἐσπάρασσεν. Ἰδὼν δέ τις αὐτὸν ὑπερπαθοῦντα καὶ μαθὼν τὴν αἰτίαν ἔφη πρὸς αὐτόν· « Μὴ λυποῦ, λαϐὼν δὲ λίθον κατάθες ἐν τῷ αὐτῷ τόπῳ καὶ νόμιζε τὸ χρυσίον κεῖσθαι· οὐδὲ γάρ, ὅτε ἦν, ἐχρῶ αὐτῷ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι τὸ μηδέν ἑστιν ἡ κτῆσις, ἐὰν μὴ καὶ ἡ χρῆσις παρῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 229 Pb 223 Pc 120 Pe 71 Pf 135 Pg 144 Ma 137 Mb 217 Ca 188.</p>
+          <bibl>Codd. Pa 229 Pb 223 Pc 120 Pe 71 Pf 135 Pg 144 Ma 137 Mb 217 Ca 188.</bibl>
         </div>
         <div>
           <head>Chambry 345.2</head>
@@ -9395,7 +9394,7 @@
           <pb ed="perry" n="P225"/>
           <p><milestone unit="recitprose"/>Φιλάργυρός τις τὴν οὐσίαν αὐτοῦ ἅπασαν ἐξαργυρωσάμενος καὶ βῶλον χρυσοῦν ποιήσας καὶ τοῦτον ἔν τινι τοίχῳ κατορύξας, καθ’ ἑκάστην ἐρχόμενος ἑώρα αὐτόν. Καὶ δὴ τῶν ἐργατῶν τις παρατηρήσας, καταλαϐὼν τὸν τόπον καὶ τὸ χρυσίον εὑρὼν ἀνείλατο. Μετὰ μικρὸν δὲ ἐλθὼν ὁ ἴδιος δεσπότης καὶ μὴ εὑρὼν αὐτὸ ἤρξατο κλαίειν καὶ τίλλειν τὰς τρίχας αὐτοῦ. Ἰδὼν δέ τις αὐτὸν οὕτως ὀλοφυρόμενον ἐπυνθάνετο τὴν αἰτίαν καὶ μαθὼν ἔφη αὐτῷ· « Ὦ οὗτος, μὴ λυποῦ, ἀλλὰ λαϐὼν λίθον, θὲς ἀντ’ αὐτοῦ καὶ νόμιζε τὸ χρυσίον εἶναι· ὡς γὰρ ὁρῶ, οὐδὲ ὅτε ἦν, ἔχρῃζες αὐτοῦ.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδέν ἐστιν ἡ κτῆσις, ἐὰν μὴ ἡ χρῆσις παρῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 125 Cb 102 Cd 118 Mc 95.</p>
+          <bibl>Codd. Ch 125 Cb 102 Cd 118 Mc 95.</bibl>
         </div>
         <div>
           <head>Chambry 345.3</head>
@@ -9403,7 +9402,7 @@
           <pb ed="perry" n="P225"/>
           <p><milestone unit="recitprose"/>Φιλάργυρός τις τὴν οὐσίαν αὐτοῦ πᾶσαν ἐξαργυρώσας ὠὸν χρυσοῦν ὠνήσατο, καὶ τοῦτο πρὸς τὸ τεῖχος ὀρύξας κατέθετο, συνεχῶς πρὸς ἐπίσκεψιν ἐρχόμενος. Εἷς δέ τις παρατηρήσας τὰς ἀφίξεις καὶ καταλαϐὼν τὸ χρυσίον ἀφείλατο. Ὁ δέ, ὡς ἐπανελθὼν κενὸν εὗρε τὸν τόπον, κλαίων τὰς τρίχας ἔτιλεν. Ἰδὼν δέ τις αὐτὸν οὕτως πάσχοντα καὶ μαθὼν τὴν αἰτίαν ἔφη· « Μὴ λυποῦ· λαϐὼν γὰρ λίθον κατάθες ἐν τῷ αὐτῷ τόπῳ καὶ νόμιζε τὸ χρυσίον κεῖσθαι· οὐδὲ γάρ, ὅτε ἦν, ἔχαιρες αὐτῷ. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι εἰς οὐδέν ἐστιν ἡ κτῆσις, ἐὰν μὴ ἡ χρῆσις παρῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 118 Cf 126.</p>
+          <bibl>Codd. Ce 118 Cf 126.</bibl>
         </div>
         <div>
           <head>Chambry 345.4</head>
@@ -9411,7 +9410,7 @@
           <pb ed="perry" n="P225"/>
           <p><milestone unit="recitprose"/>Φιλάργυρός τις, ἅπασαν αὐτοῦ τὴν οὐσίαν ἐξαργυρισάμενος καὶ χρυσοῦν βῶλον ποιήσας, ἔν τινι τόπῳ κατώρυξε συγκατορύξας ἐκεῖ καὶ τὴν ψυχὴν ἑαυτοῦ καὶ τὸν νοῦν, καὶ καθ’ ἡμέραν ἐρχόμενος αὐτὸν ἔϐλεπε. Τῶν δὲ ἐργατῶν τις αὐτὸν παρατηρήσας καὶ τὸ γεγονὸς συννοήσας, ἀνορύξας τὸν βῶλον ἀνείλετο. Μετὰ δὲ ταῦτα κἀκεῖνος ἐλθὼν καὶ κενὸν τὸν τόπον ἰδὼν θρηνεῖν ἤρξατο καὶ τίλλειν τὰς τρίχας. Τοῦτον δέ τις ὀλοφυρόμενον οὕτως ἰδὼν καὶ τὴν αἰτίαν πυθόμενος· « Μὴ οὕτως, εἶπεν, ὦ οὗτος, ἀθύμει· οὐδὲ γὰρ ἔχων τὸν χρυσὸν εἶχες. Λίθον οὖν ἀντὶ χρυσοῦ λαϐὼν θὲς καὶ νόμιζέ σοι τὸν χρυσὸν εἶναι· τὴν αὐτὴν γάρ σοι πληρώσει χρείαν· ὡς ὁρῶ γάρ, οὐδ’, ὅτε ὁ χρυσὸς ἦν, ἐν χρήσει ἦσθα τοῦ κτήματος. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οὐδὲν ἡ κτῆσις, ἐὰν μὴ ἡ χρῆσις προσῇ.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 59 Lb 124 Lc 48 Le 124 Lf 59 Lg 48 Lh 71 Md 108 Me 172 Mf 143 Mg 150 Mi 24 Mj 145 Ml 151 Mm 135.</p>
+          <bibl>Codd. La 59 Lb 124 Lc 48 Le 124 Lf 59 Lg 48 Lh 71 Md 108 Me 172 Mf 143 Mg 150 Mi 24 Mj 145 Ml 151 Mm 135.</bibl>
           <p><milestone unit="traduction"/>Un avare convertit en or toute sa fortune, en fit un lingot et l’enfouit en un certain endroit, où il enfouit du même coup son cœur et son esprit. Tous les jours il venait voir son trésor. Or un ouvrier l’observa, devina ce qu’il en était, et, déterrant le lingot, l’emporta. Quelque temps après, l’avare vint aussi, et, trouvant la place vide, il se mit à gémir et à s’arracher les cheveux. Un quidam l’ayant vu se lamenter ainsi, et s’étant informé du motif, lui dit : « Ne te désespère pas ainsi, l’ami ; car, tout en ayant de l’or, tu n’en avais pas. Prends donc une pierre, mets-la à la place de l’or, et figure-toi que c’est ton or ; il remplira pour toi le même office ; car à ce que je vois, même au temps où l’or était là, tu ne faisais pas usage de ton bien. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que la possession n’est rien, si la jouissance ne s’y joint.</p>
         </div>
@@ -9434,7 +9433,7 @@
           <l><milestone unit="recitvers"/>ὅταν δὲ πάλιν τοὺς ὀδόντας κινήσω,</l>
           <l><milestone unit="recitvers"/>εὐθὺς ἐγείρῃ καὶ τὴν κέρκον μοι σείεις. »</l>
           <p><milestone unit="epimythiumprose"/>Τοὺς ὑπνώδεις καὶ ἀργοὺς τοὺς ἐξ ἀλλοτρίων πόνων ἐφιεμένους ἐσθίειν ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 58 Ca 82 Cb 51 Cd 48 Cf 57 Ma 167 Mb 223 Mc 50 Md 55 Mh 50 Mi 90 Mm 71.</p>
+          <bibl>Codd. Ch 58 Ca 82 Cb 51 Cd 48 Cf 57 Ma 167 Mb 223 Mc 50 Md 55 Mh 50 Mi 90 Mm 71.</bibl>
         </div>
         <div>
           <head>Chambry 346.2</head>
@@ -9442,7 +9441,7 @@
           <pb ed="perry" n="P415"/>
           <p><milestone unit="recitprose"/>Ἦν τις χαλκεὺς κυνάριον ἔχων. Χαλκεύων δέ, τὸ κυνάριον ἐκοιμᾶτο· ὅταν δὲ τράπεζα παρετίθετο, εὐθὺς ὁ κύων ἕτοιμος εἰς παράστασιν σείων τὸ οὐραῖον ἐφαίνετο. Μιᾷ γοῦν τῶν ἡμερῶν παρεσθηκὼς τῷ χαλκεῖ, ἔρριψεν ὁ χαλκεὺς αὐτῷ ὀστοῦν λέγων· « Ὦ ταλαίπωρε κύων, ὑπνῶδες καὶ ὀκνηρέ, τί σοι ποιήσω ; τὸ γὰρ ἀκμόνιον προσκεκρουκώς, εὐθὺς ἐπανακλίνεις σαυτὸν ἐπὶ κραϐϐάτου, μὴ θέλοντός σου ἀναστῆναι· ὅταν δὲ τοὺς ὀδόντας μου πρὸς τροφὴν κινήσω, εὐθὺς ἕτοιμος τὴν κέρκον μοι ἐπισείεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος [δηλοῖ ὅτι] τοὺς ὑπνώδεις καὶ ἀργοὺς ὁ τῶν ἀλλοτρίων πόνος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ce 53.</p>
+          <bibl>Cod. Ce 53.</bibl>
         </div>
         <div>
           <head>Chambry 346.3</head>
@@ -9450,7 +9449,7 @@
           <pb ed="perry" n="P415"/>
           <p><milestone unit="recitprose"/>Ἦν τις χαλκεὺς ἔχων κύνα. Οὗτος οὖν χαλκεύων τὸν κύνα ἔϐλεπε κοιμώμενον· πάλιν ἐσθίων ἑώρα παριστάμενον. Τότε λοιπὸν εἶπε πρὸς αὐτόν· « Ὦ ταλαίπωρε κύων ὑπνῶδες, τί σοι ποιήσω ὕπνῳ κατεχομένῳ ; τῷ γὰρ ἄκμονί μου προσκρούοντος τῇ σφυρᾷ, αὐτὸς ἐπανακλίνεις σαυτὸν ὡς ἐπὶ κραϐϐάτῳ· ὅταν δ’ ἐσθίω, εὐθὺς ἐπεγείρῃ καὶ τὴν κέρκον μοι σείεις. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι τοὺς ὑπνώδεις καὶ ἀργοὺς τοὺς ἐξ ἀλλοτρίων πόνων ἐλπίζοντας χρὴ ἀποδιώκειν.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mk 54.</p>
+          <bibl>Cod. Mk 54.</bibl>
         </div>
         <div>
           <head>Chambry 346.4</head>
@@ -9458,7 +9457,7 @@
           <pb ed="perry" n="P415"/>
           <p><milestone unit="recitprose"/>Χαλκεὺς εἶχε κύνα, καὶ ὅτε μὲν ἐχάλκευεν, ὁ κύων ἐκοιμᾶτο· ὅτε δὲ ἤσθιεν, παρίστατο αὐτῷ. Ὁ δὲ ὀστοῦν ῥίψας αὐτῷ εἶπεν· « Ταλαίπωρε, ὑπνῶδες, ὅταν μὲν τὸν ἄκμονα κρούω, ὑπνοῖς· ὅταν δὲ τοῦς ὀδόντας κινήσω, εὐθὺς ἐγείρῃ. »</p>
           <p><milestone unit="epimythiumprose"/>[Ὅτι] τοὺς ὑπνώδεις καὶ ἀργοὺς καὶ ἐξ ἀλλοτρίων πόνων τρεφομένους ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 143 Bb 87.</p>
+          <bibl>Codd. Ba 143 Bb 87.</bibl>
           <p><milestone unit="traduction"/>Un forgeron avait un chien. Quand il forgeait, le chien dormait ; mais quand il se mettait à manger, le chien venait se mettre à ses côtés. Le forgeron, lui ayant jeté un os, lui dit : « Malheureuse bête, toujours endormie, quand je frappe mon enclume, tu dors ; mais quand je remue les mâchoires, aussitôt tu t’éveilles. »</p>
           <p><milestone unit="traduction"/>Les gens endormis et paresseux qui vivent du travail d’autrui se reconnaîtront en cette fable.</p>
         </div>
@@ -9468,7 +9467,7 @@
         <head type="sub">Χειμὼν καὶ ἔαρ — L’hiver et le printemps.</head>
         <pb ed="perry" n="P271"/>
         <p><milestone unit="recitprose"/>Χειμὼν ἔσκωψε εἰς τὸ ἔαρ καὶ αὐτὸ ὠνείδισεν ὅτι εὐθὺς φανέντος ἡσυχίαν ἄγει ἔτι οὐδείς, ἀλλ’ ὁ μέν τις ἐπὶ λειμῶνας καὶ ἄλση γίνεται, ὅτῳ ἄρα φίλον δρέπεσθαι ἀνθέων καὶ κρίνων, ἢ καὶ ῥόδον τι περιαγαγεῖν τε τοῖς ἑαυτοῦ ὄμμασιν, καὶ παραθέσθαι [ἢ] παρὰ τὴν κόμην· ὁ δὲ ἐπιϐὰς νεὼς καὶ διαϐαίνων πέλαγος, ἂν τύχῃ, παρ’ ἄλλους ἤδη ἀνθρώπους ἔρχεται· καὶ ὅτι ἅπαντες ἀνέμων ἢ πολλοῦ ἐξ ὄμϐρων ὕδατος ἔχουσι φροντίδα οὐκέτι. « Ἐγώ, ἔφη, ἄρχοντι καὶ αὐτοδεσπότῃ ἔοικα, καὶ οὐδὲ εἰς οὐρανόν, ἀλλὰ κάτω που καὶ εἰς τὴν γῆν ἐπιτάττω βλέπειν καὶ δεδιέναι καὶ τρέμειν καὶ ἀγαπητῶς διημερεύειν ἔστιν ὅτε οἶκοι ἠνάγκασα. – Τοιγαροῦν, ἔφη τὸ ἔαρ, σοῦ μὲν κἂν ἀπαλλαγεῖεν ἄνθρωποι ἀσμένως· ἐμοῦ δὲ αὐτοῖς καλὸν καὶ αὐτὸ εἶναι δοκεῖ τοὔνομα, καὶ νὴ μὰ Δία γε ὀνομάτων κάλλιστον, ὥστε καὶ ἀπόντος μέμνηνται καὶ φανέντος ἐπαγάλλονται. »</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 221.</p>
+        <bibl>Cod. Mb 221.</bibl>
         <p><milestone unit="traduction"/>L’Hiver un jour se moqua du Printemps et le chargea de reproches. Aussitôt qu’il paraissait, personne ne restait plus en repos ; l’un allait aux prés ou aux bois, se plaisant à cueillir des fleurs, des lis et des roses, à les faire tourner devant ses yeux et à les mettre dans ses cheveux ; l’autre s’embarquait, et, à l’occasion, traversait la mer pour aller voir d’autres hommes ; personne ne prenait plus souci des vents ni des averses épaisses. « Moi, ajoutait-il, je ressemble à un chef et à un monarque absolu. Je veux qu’on tourne ses yeux, non pas vers le ciel, mais en bas vers la terre, et je force les gens à craindre et à trembler, et à se résigner parfois à garder le logis toute la journée. — C’est pour cela, répondit le Printemps, que les hommes ont plaisir à être délivrés de ta présence. De moi, au contraire, le nom même leur semble beau, le plus beau, par Zeus, de tous les noms. Aussi, quand j’ai disparu, ils gardent mon souvenir, et, dès que j’ai paru, ils sont pleins d’allégresse. »</p>
       </div>
       <div type="poem" xml:id="chambry-348">
@@ -9479,7 +9478,7 @@
           <pb ed="perry" n="P227"/>
           <p><milestone unit="recitprose"/>Χελιδὼν ἔν τινι δικαστηρίῳ νεοττοποιησαμένη ἐξέπτη· δράκων δὲ προσερπύσας κατέφαγεν αὐτῆς τοὺς νεοττούς. Ἡ δὲ ἐπανελθοῦσα καὶ τὴν καλιὰν κενὴν εὑροῦσα ὑπερπαθῶς ἔστενεν. Ἑτέρας δὲ χελιδόνος παρηγορεῖν αὐτὴν πειρωμένης καὶ λεγούσης &lt;ὅτι&gt; οὐ μόνον αὐτὴν τέκνα ἀποϐαλεῖν συμϐέϐηκεν, ὑποτυχοῦσα εἶπεν· « Ἀλλ’ ἔγωγε οὐ τοσοῦτον ἐπὶ τοῖς τέκνοις κλαίω ὅσον ὅτι ἐν τούτῳ τῷ τόπῳ ἠδίκημαι ἐν ᾧ οἱ ἀδικούμενοι βοηθείας τυγχάνουσιν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλάκις χαλεπώτεραι γίνονται τοῖς πάσχουσιν αἱ συμφοραί, ὅταν ὑφ’ ὧν ἥκιστα προσεδόκησαν ὑφίστωνται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 231 Pb 225 Pc 123 Pg 147 Mb 228 Ca 190 Ce 119 Cf 127.</p>
+          <bibl>Codd. Pa 231 Pb 225 Pc 123 Pg 147 Mb 228 Ca 190 Ce 119 Cf 127.</bibl>
           <p><milestone unit="traduction"/>Une hirondelle qui avait fait son nid dans un tribunal était sortie, quand un dragon vint en rampant dévorer ses petits. A son retour, trouvant le nid vide, elle gémit, outrée de douleur. Une autre hirondelle, pour la consoler, lui dit qu’elle n’était pas la seule qui eût le malheur de perdre ses petits. « Ah ! répondit-elle, je me désole moins d’avoir perdu mes enfants que parce que je suis victime d’un crime en un lieu où les victimes de la violence trouvent assistance. »</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent les malheurs sont plus pénibles à supporter, quand ils viennent de ceux dont on les attendait le moins.</p>
         </div>
@@ -9489,7 +9488,7 @@
           <pb ed="perry" n="P227"/>
           <p><milestone unit="recitprose"/>Ξένη χελιδὼν ἡ τοῖς ἀνθρώποις συνοικοῦσα ἐν δικαστηρίῳ τὴν καλιὰν ἑαυτῆς ἔπηξεν ἐν τοίχῳ, κἀκεῖσε νεοττῶν ἕπτα γίνεται μήτηρ. Ὄφις δὲ ἐκ τρώγλης συρεὶς πάντας κατέφαγεν. Ἡ δὲ χελιδὼν θρηνοῦσα· « Οἴμοι, ἔλεγεν, ὅτι ἔνθα πάντες δικαιοῦνται, ἐγὼ ἠδικήθην. »</p>
           <p><milestone unit="epimythiumprose"/>Τοὺς ἀδίκῳ γνώμῃ τυραννοῦντας τοὺς πέλας ἐν παραϐάσει νόμου ὁ μῦθος ἐλέγχει.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 96 Bb 60 Ma 185 Md 86 Mh 78 Mi 2 Mm 104.</p>
+          <bibl>Codd. Ba 96 Bb 60 Ma 185 Md 86 Mh 78 Mi 2 Mm 104.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-349">
@@ -9498,7 +9497,7 @@
         <pb ed="perry" n="P229"/>
         <p><milestone unit="recitprose"/>Χελιδὼν καὶ κορώνη περὶ κάλλους ἐφιλονείκουν· ὑποτυχοῦσα δὲ ἡ κορώνη πρὸς αὐτὴν εἶπεν· « Ἀλλὰ τὸ μὲν σὸν κάλλος τὴν ἐαρινὴν ὥραν ἀνθεῖ, τὸ δὲ ἐμὸν σῶμα καὶ χειμῶνι παρατείνεται. »</p>
         <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι ἡ τοῦ σώματος παράτασις εὐπρεπείας καλλίων.</p>
-        <p><milestone unit="manuscrits"/>Codd. Pb 228 Pe 74 Pf 138 Ma 140 Mb 225 Me 175 Mf 146 Ca 192 La 80 Lb 128 Le 128 Lf 80 Lh 74 Md 133 Mg 154 Mi 107 Mj 149 Ml 155 Mm 138.</p>
+        <bibl>Codd. Pb 228 Pe 74 Pf 138 Ma 140 Mb 225 Me 175 Mf 146 Ca 192 La 80 Lb 128 Le 128 Lf 80 Lh 74 Md 133 Mg 154 Mi 107 Mj 149 Ml 155 Mm 138.</bibl>
         <p><milestone unit="traduction"/>L’hirondelle et la corneille disputaient de leur beauté. Aux raisons de l’hirondelle la corneille répliqua : « Ta beauté ne fleurit que pendant la saison du printemps, tandis que moi, j’ai un corps qui défie même l’hiver. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’il vaut mieux prolonger sa vie que d’être beau.</p>
       </div>
@@ -9510,7 +9509,7 @@
           <pb ed="perry" n="P39"/>
           <p><milestone unit="recitprose"/>Ἄρτι τοῦ ἰξοῦ φυομένου, χελιδὼν αἰσθομένη τὸν ἐνιστάμενον τοῖς πετεινοῖς κίνδυνον, συναθροίσασα πάντα τὰ ὄρνεα, συνεϐούλευσεν αὐτοῖς μάλιστα μὲν ταῖς ἰξοφόροις δρυσὶν ἐκκόψαι· εἰ δ’ ἄρα τοῦτο αὐτοῖς ἀδύνατον, ἐπὶ τοὺς ἀνθρώπους καταφυγεῖν καὶ τούτους ἱκετεῦσαι, ὅπως μὴ χρησάμενοι τῇ τοῦ ἰξοῦ ἐνεργείᾳ συλλαμϐάνωσιν αὐτά. Τῶν δὲ γελασάντων αὐτὴν ὡς ματαιολογοῦσαν, αὐτὴ παραγενομένη ἱκέτις τῶν ἀνθρώπων ἐγένετο. Οἱ δὲ ἀποδεξάμενοι αὐτὴν ἐπὶ τῇ συνέσει καὶ σύνοικον αὐτὴν προσελάϐοντο. Οὕτως συνέϐη τὰ μὲν λοιπὰ ἀγρευόμενα ὑπὸ τῶν ἀνθρώπων κατεσθίεσθαι, μόνην δὲ τὴν χελιδόνα ὡς πρόσφυγα καὶ ἐν ταῖς αὐτῶν οἰκίαις ἀδεῶς νεοττοποιεῖσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οἱ τὰ μέλλοντα προορώμενοι εἰκότως τοὺς κινδύνους διακρούονται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 40 Pb 39.</p>
+          <bibl>Codd. Pa 40 Pb 39.</bibl>
           <p><milestone unit="traduction"/>Comme le gui venait de pousser, l’hirondelle, sentant le danger qui menaçait les oiseaux, les assembla tous et leur conseilla avant tout de couper le gui aux chênes qui le portaient ; mais si cela leur était impossible, de se réfugier chez les hommes et de les supplier de ne pas recourir à l’effet de la glu pour les attraper. Les oiseaux se moquèrent d’elle, la traitant de radoteuse. Alors elle se rendit chez les hommes et se présenta en suppliante. Ceux-ci lui firent accueil à cause de son intelligence et lui donnèrent place dans leurs demeures. Il arriva ainsi que les autres oiseaux furent pris et mangés par les hommes, et que seule, l’hirondelle, leur protégée, nicha même sans crainte dans leurs maisons.</p>
           <p><milestone unit="traduction"/>Cette fable montre que, quand on prévoit l’avenir, on échappe naturellement aux dangers.</p>
         </div>
@@ -9520,14 +9519,14 @@
           <pb ed="perry" n="P39"/>
           <p><milestone unit="recitprose"/>Χελιδὼν ἐκκλησίαν τῶν ὀρνέων συναθροίσασα παρῄνει, φάσκουσα κράτιστον εἶναι τὸ μὴ προσκόπτειν ἀνθρώποις, ἀλλὰ φιλίαν συνθεμένους οἰκείως διακεῖσθαι πρὸς αὐτούς. Τῶν δὲ ὀρνέων τις τὰ ἐναντία τῇ χελιδόνι ἔλεγεν· « Ἀλλὰ τὸ σπέρμα τοῦ λίνου μᾶλλον κατεσθίοντες ἀναλίσκωμεν καὶ ἀφανὲς ποιῶμεν, ἵνα μηκέτι ἔχωσι πλέκειν δίκτυα καθ’ ἡμῶν. » Ἡ μὲν οὖν χελιδὼν ἀρίστην γνώμην ἔχουσα ἀκίνδυνος ἐγένετο ἐν ταῖς πόλεσι διατρίϐουσα, καὶ ἐν ταῖς οἰκίαις τίκτουσα παρ’ ἀνθρώποις οὐδὲν ὑπ’ αὐτῶν πάσχει κακόν. Τὰ δὲ λοιπὰ ὄρνεα, ὡς μᾶλλον ὑπομείναντα κατεσθίειν τὸ σπέρμα, ὡς πάντων ὄντος τοῦ λίνου κακῶν αἰτίου, συμϐαίνει λιπαρὰ γενέσθαι καὶ μάλα δικαίως ὑπὸ τῶν ἀνθρώπων συλλαμϐανόμενα δαπανᾶσθαι. Οὕτως τε ταύτην τὴν κακογνωμοσύνην ὑπομείναντα, μετενόησε μὴ μετ’ ἀνθρώπων μένειν, ἀλλ’ ἐν ἀέρι πέτεσθαι.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων ὅσοι ἐν τοῖς βιωτικοῖς πράγμασι τῷ τῆς ἀγχινοίας βουλεύματι ἐχρήσαντο ἀκίνδυνοι διεφυλάχθησαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 139 Pc 122 Pe 75 Pg 146 Mb 227 Me 176 Mf 147.</p>
+          <bibl>Codd. Pf 139 Pc 122 Pe 75 Pg 146 Mb 227 Me 176 Mf 147.</bibl>
         </div>
         <div>
           <head>Chambry 350.3</head>
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P39"/>
           <p><milestone unit="recitprose"/>Ὅτε δρῦς ἰξὸν ἔφυε, βλάϐην ὀρνέων, ἡ φρονιμωτάτη χελιδὼν εἶπε πᾶσιν ὀρνέοις τοῦτο κωλύειν. Τὰ δὲ ὡς οὐδὲν φρονοῦσαν ταύτην παρελογίσαντο καὶ ἠμέλησαν. Τότε ἡ χελιδὼν ἱκέτευσε τοὺς ἀνθρώπους σύνοικον αὐτὴν εἰσδέξασθαι. Διὰ τοῦτο μόνης αὐτῆς τοῖς πτεροῖς ἰξὸς οὐδέποτε ἐκολλήθη.</p>
-          <p><milestone unit="manuscrits"/>Cod. Ba 114.</p>
+          <bibl>Cod. Ba 114.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-351">
@@ -9538,7 +9537,7 @@
           <pb ed="perry" n="P377"/>
           <p><milestone unit="recitprose"/>Ἡ χελιδὼν ἔφη πρὸς τὴν κορώνην· « Ἐγὼ παρθένος καὶ Ἀθηναία καὶ βασίλισσα καὶ βασιλέως τῶν Ἀθηνῶν θυγάτηρ &lt;εἰμί&gt;, » καὶ προσέθηκε καὶ τὸν Τηρέα καὶ τὴν βίαν καὶ τὴν ἀποκοπὴν τῆς γλώττης. Καὶ ἡ κορώνη· « Τί ἄν, ἔφη, ἐποίησας, εἰ τὴν γλῶτταν εἶχες, ὅπου, τμηθείσης, τοσαῦτα λαλεῖς ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ ἀλαζόνες διὰ τοῦ λόγου ψευδολογοῦντες αὐτοὶ ἑαυτοῖς ἔλεγχος καθίστανται.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 45 Bb 29 Mb 226.</p>
+          <bibl>Codd. Ba 45 Bb 29 Mb 226.</bibl>
           <p><milestone unit="traduction"/>L’hirondelle disait à la corneille : « Moi, je suis vierge, et athénienne, et princesse, et fille du roi d’Athènes », et elle raconta en outre comment Térée lui avait fait violence et lui avait coupé la langue. La corneille repartit : « Que serait-ce, si tu avais ta langue, alors que l’ayant perdue, tu fais tant de commérages ! »</p>
           <p><milestone unit="traduction"/>A force de mentir, les vantards témoignent contre eux-mêmes.</p>
         </div>
@@ -9547,7 +9546,7 @@
           <head type="sub">Aliter — Autre version.</head>
           <pb ed="perry" n="P377"/>
           <p><milestone unit="recitprose"/>Χελιδὼν πρὸς τὴν κορώνην ἐκόμπαζε λέγουσα· « Ἐγὼ παρθένος καὶ Ἀθηναίων βασιλέως θυγάτηρ εἰμί, » καὶ προσέθηκε τὸν Τηρέα καὶ τὴν παρ’ αὐτοῦ βίαν καὶ τὴν τῆς γλώττης ἀποκοπήν. Ἡ δὲ κορώνη ἔφη· « Εἰ οὕτω λαλεῖς, ἔχουσα ἀποκεκομμένην τὴν γλῶτταν, τί ἂν ἐποίησας, εἰ μὴ τετρημένην αὐτὴν εἶχες ; »</p>
-          <p><milestone unit="manuscrits"/>Cod. Bd 23.</p>
+          <bibl>Cod. Bd 23.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-352">
@@ -9558,7 +9557,7 @@
           <pb ed="perry" n="P230"/>
           <p><milestone unit="recitprose"/>Χελώνη θεασαμένη ἀετὸν πετόμενον ἐπεθύμησε καὶ αὐτὴ πέτεσθαι. Προσελθοῦσα δὲ τοῦτον παρεκάλει ἐφ’ ᾧ βούλεται μισθῷ διδάξαι αὐτήν. Τοῦ δὲ πείθοντος καὶ λέγοντος ἀδύνατον εἶναι, καὶ ἔτι αὐτῆς ἐπικειμένης καὶ ἀξιούσης, ἄρας αὐτὴν καὶ μετέωρος ἀναϐὰς ἀφῆκεν ἐπί τινος πέτρας, ὅθεν κατενεχθεῖσα ἀπερράγη καὶ τέθνηκεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλοὶ ἐν φιλονεικίαις τῶν φρονιμωτέρων παρακούσαντες ἑαυτοὺς ἔϐλαψαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pb 229 Pg 149 Ma 141 Mb 230 Ca 193.</p>
+          <bibl>Codd. Pb 229 Pg 149 Ma 141 Mb 230 Ca 193.</bibl>
         </div>
         <div>
           <head>Chambry 352.2</head>
@@ -9566,7 +9565,7 @@
           <pb ed="perry" n="P230"/>
           <p><milestone unit="recitprose"/>Χελώνη θεασαμένη ἀετὸν πετόμενον ἐπεθύμησεν καὶ αὐτὴ πέτεσθαι· καὶ προσελθοῦσα παρεκάλει αὐτὸν ἔφ’ ᾧ βούλεται μισθῷ διδάξαι αὐτήν. Τοῦ δὲ λέγοντος ἀδύνατον τοῦτο γενέσθαι, ἔτι ἐπέμενεν δυσωποῦσα αὐτὸν ἆραι πρὸς τὸ διδάξαι αὐτήν. Ὁ δὲ ἐκκακήσας ἦρεν αὐτὴν καὶ μετέωρος ἀρθεὶς ἀφῆκεν πέτεσθαι. Ἡ δὲ κατενεχθεῖσα ἐπί τινος πέτρας ἀπερράγη καὶ ἀπέθανεν.</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι οἱ τὰ ἀδύνατα ἐπιθυμοῦντες ἑαυτοῖς ἑκουσίως κίνδυνον ἐπιφέρουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pf 137 Pe 73 Me 174 Mf 145.</p>
+          <bibl>Codd. Pf 137 Pe 73 Me 174 Mf 145.</bibl>
         </div>
         <div>
           <head>Chambry 352.3</head>
@@ -9574,7 +9573,7 @@
           <pb ed="perry" n="P230"/>
           <p><milestone unit="recitprose"/>Χελώνη ἀετὸν θεασαμένη πετόμενον ἐπεθύμησε καὶ αὐτὴ πέτεσθαι. Προσελθοῦσα δὲ πρός τινα παρεκάλει αὐτὸν ἐπὶ μισθῷ διδάξαι αὐτὴν πέτεσθαι. Τοῦ δὲ λέγοντος ἀδύνατον εἶναι, ἐκεῖνος παρακούσας, ἀναϐὰς εἰς ὕψος ἀφῆκεν αὐτήν, καὶ παράχρημα ἐπὶ πέτρας πεσοῦσα διερράγη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ ἐν ταῖς φιλονεικίαις τῶν φρονιμωτέρων αὐτῶν παρακούσαντες ἑαυτοὺς κατέϐλαψαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 127 Cb 104 Mc 98.</p>
+          <bibl>Codd. Ch 127 Cb 104 Mc 98.</bibl>
         </div>
         <div>
           <head>Chambry 352.4</head>
@@ -9582,7 +9581,7 @@
           <pb ed="perry" n="P230"/>
           <p><milestone unit="recitprose"/>Χελώνη θεασαμένη ἀετὸν πετόμενον ἐπεθύμησε καὶ αὐτὴ πετασθῆναι. Προσελθοῦσα δὲ τοῦτον παρεκάλει ἐφ’ ᾧ βούλεται μισθῷ διδάξαι αὐτήν. Τοῦ δὲ λέγοντος ἀδύνατον εἶναι, ἐκείνη μᾶλλον τῇ δεήσει προσέκειτο. Λαϐὼν οὖν αὐτὴν τοῖς ὄνυξι καὶ εἰς ὕψος ἀναγαγοῦσα ἀφῆκεν· ἡ δὲ καταπεσοῦσα συνετρίϐη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι οἱ τοῖς ἀδυνάτοις ἐπιχειροῦντες κίνδυνον ἑαυτοῖς προξενοῦσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ce 121 Cf 130.</p>
+          <bibl>Codd. Ce 121 Cf 130.</bibl>
         </div>
         <div>
           <head>Chambry 352.5</head>
@@ -9590,7 +9589,7 @@
           <pb ed="perry" n="P230"/>
           <p><milestone unit="recitprose"/>Χελώνη ἀετοῦ ἐδεῖτο ἵπτασθαι αὐτὴν διδάξαι. Τοῦ δὲ παραινοῦντος πόρρω τοῦτο τῆς φύσεως αὐτῆς εἶναι, ἐκείνη μᾶλλον τῇ δεήσει προσέκειτο. Λαϐὼν οὖν αὐτὴν τοῖς ὄνυξι καὶ εἰς ὕψος ἀνενεγκὼν, εἶτ’ ἀφῆκεν. Ἡ δὲ κατὰ πετρῶν πεσοῦσα συνετρίϐη.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλοὶ ἐν φιλονεικίαις τῶν φρονιμωτέρων παρακούσαντες ἑαυτοὺς ἔϐλαψαν.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 61 Lb 127 Le 127 Lf 61 Lh 73 Md 111 Mg 153 Mi 27 Mj 148 Ml 154 Mm 137.</p>
+          <bibl>Codd. La 61 Lb 127 Le 127 Lf 61 Lh 73 Md 111 Mg 153 Mi 27 Mj 148 Ml 154 Mm 137.</bibl>
           <p><milestone unit="traduction"/>Une tortue pria un aigle de lui apprendre à voler. L’aigle lui remontrant qu’elle n’était pas faite pour le vol, loin de là ! elle n’en devint que plus pressante en sa prière. Alors il la prit dans ses serres, l’enleva en l’air, puis la lâcha. La tortue tomba sur des rochers et fut fracassée.</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent, en voulant rivaliser avec d’autres, en dépit des plus sages conseils, on se fait tort à soi-même.</p>
         </div>
@@ -9603,7 +9602,7 @@
           <pb ed="perry" n="P226"/>
           <p><milestone unit="recitprose"/>Χελώνη καὶ λαγωὸς περὶ ὀξύτητος ἤριζον. Καὶ δὴ προθεσμίαν στήσαντες καὶ τόπον ἀπηλλάγησαν. Ὁ μὲν οὖν λαγωὸς διὰ τὴν φυσικὴν ὠκύτητα ἀμελήσας τοῦ δρόμου, πεσὼν παρ’ ὁδὸν ἐκοιμᾶτο. Ἡ δὲ χελώνη συνειδυῖα ἑαυτῇ βραδύτητα, οὐ διέλιπε τρέχουσα, καὶ οὕτω κοιμώμενον τὸν λαγωὸν παραδραμοῦσα ἐπὶ τὸ βραδεῖον τῆς νίκης ἀφίκετο.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι πολλάκις φύσιν ἀμελοῦσαν πόνος ἐνίκησεν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 230 Pb 224 Pc 121 Pe 72 Pf 136 Pg 145 Ma 138 Me 173 Mf 144.</p>
+          <bibl>Codd. Pa 230 Pb 224 Pc 121 Pe 72 Pf 136 Pg 145 Ma 138 Me 173 Mf 144.</bibl>
           <p><milestone unit="traduction"/>La tortue et le lièvre disputaient qui était le plus vite. En conséquence ils fixèrent un jour et un endroit et se séparèrent. Or le lièvre, confiant dans sa vitesse naturelle, ne se pressa pas de partir ; il se coucha au bord de la route et s’endormit ; mais la tortue, qui avait conscience de sa lenteur, ne cessa de courir, et, prenant ainsi l’avance sur le lièvre endormi, elle arriva au but et gagna le prix.</p>
           <p><milestone unit="traduction"/>Cette fable montre que souvent le travail l’emporte sur les dons naturels, si on les néglige.</p>
         </div>
@@ -9628,7 +9627,7 @@
           <l><milestone unit="recitvers"/>δρομαῖος ἧκεν εἰς τὸν τόπον τοῦ ὅρου,</l>
           <l><milestone unit="recitvers"/>ὅστις καὶ εὗρε τὴν χελώνην ὑπνοῦσαν.</l>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι πολλαὶ φύσεις ἀνθρώπων εἰσὶν εὐφυεῖς, ἀλλ’ ἐκ ῥᾳθυμίας καὶ ὄκνου ἀπόλλυνται· ἐκ δὲ σπουδῆς καὶ μακροθυμίας πολλοὶ περιεγένοντο τῆς φύσεως.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ch 111 Cg 36 Ca 173 Cb 91 Cd 105.</p>
+          <bibl>Codd. Ch 111 Cg 36 Ca 173 Cb 91 Cd 105.</bibl>
         </div>
         <div>
           <head>Chambry 353.3</head>
@@ -9636,7 +9635,7 @@
           <pb ed="perry" n="P226"/>
           <p><milestone unit="recitprose"/>Ποδῶν χελώνης κατεγέλα λαγωός. Ἡ δὲ ἔφη· « Ἐγώ σε τὸν ταχύπουν νικήσω. » Ὁ δέ· « Λόγῳ μόνῳ λέγεις τοῦτο· ἀλλ’ ἔριζε καὶ γνῶθι. – Τίς δὲ τὸν τόπον ὁρίσει, ἔφη, καὶ βραϐεύσει τὴν νίκην ; — Ἀλώπηξ, ἔφη, ἡ δικαία καὶ σοφωτάτη. » Ἔταξε δὲ τὴν ἀρχὴν τὴς ὥρας τοῦ δρόμου. Ἡ δὲ χελώνη μὴ ῥᾳθυμήσασα ἤρξατο τῆς ὁδοῦ. Ὁ δὲ λαγωὸς τοῖς ποσὶ θαρρῶν ἐκοιμήθη. Ἐλθὼν δὲ ἐπὶ τὸν ὡρισμένον τόπον εὗρε τὴν χελώνην νικήσασαν. »</p>
           <p><milestone unit="epimythiumprose"/>Ὅτι πολλαὶ φύσεις ἀνθρώπων εὐφυεῖς εἰσιν, ἀλλ’ ἐκ τῆς ῥᾳθυμίας ἀπώλοντο, ἐκ δὲ νήψεως καὶ σπουδῆς καὶ μακροθυμίας τινὲς καὶ φύσεως ἀργῆς περιεγένοντο.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ba 129 Bb 77 Md 101 Mh 88 Mi 17 Mm 123.</p>
+          <bibl>Codd. Ba 129 Bb 77 Md 101 Mh 88 Mi 17 Mm 123.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-354">
@@ -9647,7 +9646,7 @@
           <pb ed="perry" n="P228"/>
           <p><milestone unit="recitprose"/>Χῆνες καὶ γέρανοι τὸν αὐτὸν λειμῶνα ἐνέμοντο. Ἐπιφανέντων δὲ αὐτοῖς θηρευτῶν, αἱ μὲν γέρανοι ἐλαφραὶ οὖσαι ἀπέπτησαν, οἱ δὲ χῆνες μείναντες διὰ τὸ βάρος τῶν σωμάτων συνελήφθησαν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ τῶν ἀνθρώπων, ἐπὰν πόλεμος ἐν πόλει γένηται, οἱ μὲν πένητες εὐπρόφοροι ὄντες, ῥᾳδίως ἀπὸ πόλεως εἰς ἑτέραν πόλιν διασῴζονται τῆς ἐλευθερίας μετέχοντες, οἱ δὲ πλούσιοι διὰ τὴν τῶν ὑπαρχόντων ὑπερϐολὴν μένοντες πολλάκις δουλεύουσιν.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 232 Pb 226 Pc 124 Pe 76 Pf 140 Ma 139 Mb 231 Me 177 Mf 148.</p>
+          <bibl>Codd. Pa 232 Pb 226 Pc 124 Pe 76 Pf 140 Ma 139 Mb 231 Me 177 Mf 148.</bibl>
           <p><milestone unit="traduction"/>Des oies et des grues picoraient dans la même prairie. Des chasseurs parurent : les grues, légères, s’envolèrent ; mais les oies, retardées par la pesanteur de leurs corps, furent prises.</p>
           <p><milestone unit="traduction"/>Il en est ainsi chez les hommes : quand une ville est en proie à la guerre, les pauvres se déplacent et se sauvent facilement d’un pays dans un autre et conservent leur liberté ; mais les riches retenus par le poids excessif de leurs richesses deviennent souvent esclaves.</p>
         </div>
@@ -9657,7 +9656,7 @@
           <pb ed="perry" n="P228"/>
           <p><milestone unit="recitprose"/>Χῆνες καὶ γέρανοι τὸν αὐτὸν λειμῶνα ἐνέμοντο. Ἐπιφανέντων δὲ αὐτοῖς θηρευτῶν, οἱ μὲν γέρανοι ἐλαφροὶ ὄντες ταχέως ἀπέπτησαν καὶ διεσώθησαν· αἱ δὲ χῆνες μείνασαι διὰ τὸ βάρος τῶν σωμάτων συνελήφθησαν.</p>
           <p><milestone unit="epimythiumprose"/>Οὕτω καὶ ἐπὶ τῶν ἀνθρώπων ἐπὶ ἐπαναστάσεσι πόλεων γίνεται· οἱ μὲν πένητες, διὰ τὸ ἀκτήμονες εἶναι, ῥᾳδίως μεταϐαίνουσιν ἀπὸ πόλεως εἰς πόλιν· οἱ δὲ πλούσιοι, διὰ τὴν τῶν ὑπαρχόντων ὑπερϐολὴν μένοντες, πολλάκις δουλεύουσι.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 191 Cb 103 Cd 119 Ce 120 Cf 128 Ch 126 Mc 97.</p>
+          <bibl>Codd. Ca 191 Cb 103 Cd 119 Ce 120 Cf 128 Ch 126 Mc 97.</bibl>
         </div>
         <div>
           <head>Chambry 354.3</head>
@@ -9665,7 +9664,7 @@
           <pb ed="perry" n="P228"/>
           <p><milestone unit="recitprose"/>Χῆνες καὶ γέρανοι ἐπὶ ταὐτοῦ λειμῶνος ἐνέμοντο. Τῶν δὲ θηρευτῶν ἐπιφανέντων, οἱ μὲν γέρανοι, κοῦφοι ὄντες, ταχέως ἀπέπτησαν, οἱ δὲ χῆνες, διὰ τὸ βάρος τῶν σωμάτων μείναντες, συνελήφθησαν.</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι καὶ ἐν ἁλώσει πόλεως οἱ μὲν ἀκτήμονες εὐχερῶς φεύγουσιν, οἱ δὲ πλούσιοι δουλεύουσιν ἁλισκόμενοι.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 60 Lc 28 Le 126 Lf 60 Lg 28 Md 110 Mg 152 Mi 26 Mj 147 Ml 153 Mm 136.</p>
+          <bibl>Codd. La 60 Lc 28 Le 126 Lf 60 Lg 28 Md 110 Mg 152 Mi 26 Mj 147 Ml 153 Mm 136.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-355">
@@ -9674,7 +9673,7 @@
         <pb ed="perry" n="P378"/>
         <p><milestone unit="recitprose"/>Χύτραν ὀστρακίνην καὶ χαλκῆν ποταμὸς κατέφερεν. Ἡ δὲ ὀστρακίνη τῇ χαλκῇ ἔλεγεν· « Μακρόθεν μου κολύμϐα, καὶ μὴ πλησίον· ἐὰν γάρ μοι σὺ προσψαύσῃς, κατακλῶμαι, κἂν ἐγὼ μὴ θέλουσα προσψαύσω. »</p>
         <p><milestone unit="epimythiumprose"/>Ὅτι ἐπισφαλής ἐστι βίος πένητι δυναστοῦ ἅρπαγος πλησίον παροικοῦντι.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ba 147 Bb 90 Mb 222.</p>
+        <bibl>Codd. Ba 147 Bb 90 Mb 222.</bibl>
         <p><milestone unit="traduction"/>Un pot de terre et un pot de cuivre étaient emportés par le courant d’une rivière. Le pot de terre dit au pot de cuivre : « Nage loin de moi, pas à mes côtés ; car si tu me touches, je vole en éclats, même si je m’approche de toi sans le vouloir. »</p>
         <p><milestone unit="traduction"/>La vie n’est pas sûre pour le pauvre qui a pour voisin un prince rapace.</p>
       </div>
@@ -9686,7 +9685,7 @@
           <pb ed="perry" n="P244"/>
           <p><milestone unit="recitprose"/>Ψιττακόν τις ἀγοράσας ἀφῆκεν ἐπὶ τῆς οἰκίας νέμεσθαι. Ὁ δὲ τῇ ἡμερότητι χρησάμενος, ἀναπηδήσας ἐπὶ τὴν ἑστίαν ἐκάθισε, κἀκεῖθεν τερπνὸν ἐκεκράγει. Γαλῆ δὲ θεασαμένη ἐπυνθάνετο αὐτοῦ τίς τέ ἐστι καὶ πόθεν ἦλθεν. Ὁ δὲ εἶπεν· « Ὁ δεσπότης με νεωστὶ ἐπρίατο. – Οὐκοῦν, ἰταμώτατε ζῴων, ἔφη, πρόσφατος ὢν τοιαῦτα βοᾷς, ὅτε ἐμοὶ τῇ οἰκογενεῖ οὐκ ἐπιτρέπουσιν οἱ δεσπόται, ἀλλ’ ἐάν ποτε τοῦτο πράξω, προσαγανακτοῦντες ἀπελαύνουσί με. » Ὁ δὲ ἀπεκρίνατο λέγων· « Οἰκοδέσποινα, ἀλλὰ σύ γε βάδιζε μακράν· οὐχ ὁμοίως γὰρ δυσχεραίνουσιν οἱ δεσπόται ἐπὶ τῇ ἐμῇ φωνῇ ὅσον ἐπὶ τῇ σῇ. »</p>
           <p><milestone unit="epimythiumprose"/>Πρὸς ἄνδρα πονηροψόγον ἑτέροις ἀεὶ αἰτίας προσάπτειν ἐπιχειροῦντα ὁ λόγος εὔκαιρος.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 234 Pf 142 Me 179 Mf 150 Ca 197.</p>
+          <bibl>Codd. Pa 234 Pf 142 Me 179 Mf 150 Ca 197.</bibl>
           <p><milestone unit="traduction"/>Un homme, ayant acheté un perroquet, le laissa libre en sa maison. Le perroquet, qui était apprivoisé, sauta et se percha sur le foyer, et de là se mit à caqueter d’une manière plaisante. Une chatte, l’ayant vu, lui demanda qui il était et d’où il venait. Il répondit : « Le maître vient de m’acheter. – Et tu oses, bête effrontée entre toutes, reprit la chatte, tu oses, tout nouveau venu, pousser de pareils cris, tandis qu’à moi, née à la maison, les maîtres m’interdisent de crier ! et si parfois cela m’arrive, ils se fâchent et me jettent à la porte. – Va te promener, ma belle dame ; il n’y a pas de comparaison à faire entre nous ; ma voix n’agace pas les maîtres comme la tienne. »</p>
           <p><milestone unit="traduction"/>Cette fable convient aux critiques malveillants toujours prêts à jeter le blâme sur les autres.</p>
         </div>
@@ -9707,7 +9706,7 @@
           <l><milestone unit="recitvers"/>Σὺ δ’ ἄρτι πῶς ὠνητός, ὡς λέγεις, ἥκων,</l>
           <l><milestone unit="recitvers"/>παρρησιάζῃ, φησί, καὶ κατακρώζεις ; »</l>
           <p><milestone unit="epimythiumprose"/>Πρόσφορος ὁ μῦθος πρὸς γέροντας εἰς τιμὴν προκριθέντας καὶ ὑπὸ τῶν αὐτῶν κατὰ φθόνον συνεγκλειομένους.</p>
-          <p><milestone unit="manuscrits"/>Cod. Mb 193.</p>
+          <bibl>Cod. Mb 193.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-357">
@@ -9718,7 +9717,7 @@
           <pb ed="perry" n="P231"/>
           <p><milestone unit="recitprose"/>Ψύλλα ποτὲ πηδήσασα ἐκάθισεν ἐπὶ ταρσοῦ ποδὸς ἀνδρὸς ἀθλητοῦ νοσοῦντος καὶ ἁλλομένη ἐνῆκε δῆγμα. Ὁ δ’ ἀκροχολήσας εὐτρεπίσας τοὺς ὄνυχας οἷός τε ἦν συνθλάσαι τὴν ψύλλαν. Ἡ δὲ ὑφ’ ὁρμῆς φυσικὸν πήδημα λαϐοῦσα ἀπέδρα τοῦ θανεῖν ἀπαλλαγεῖσα. Καὶ ὃς στενάξας εἶπεν· « Ὦ Ἡράκλεις, ὅταν πρὸς ψύλλαν οὕτω &lt;συμμαχῇς&gt;, πῶς ἐπὶ τοὺς ἀνταγωνιστὰς συνεργὸς ἔσῃ ; »</p>
           <p><milestone unit="epimythiumprose"/>Ἀταρ οὖν καὶ ἡμᾶς ὁ λόγος διδάσκει μὴ δεῖν ἐπὶ τὰ ἐλάχιστα καὶ ἀκίνδυνα πράγματα ἐπευθὺς τοὺς θεοὺς ἀνακαλεῖν, ἀλλ’ ἐπὶ τὰς μείζους ἀνάγκας.</p>
-          <p><milestone unit="manuscrits"/>Codd. Pa 233 Pf 141 Pg 150 Ma 142 Mb 234 Me 178 Mf 149.</p>
+          <bibl>Codd. Pa 233 Pf 141 Pg 150 Ma 142 Mb 234 Me 178 Mf 149.</bibl>
           <p><milestone unit="traduction"/>Un jour une puce alla d’un saut se poster sur un doigt de pied d’un athlète malade, et tout en sautant elle lui fit une morsure. L’athlète en colère préparait ses ongles pour l’écraser ; mais elle prit son élan, et d’un saut, un de ces sauts dont elle a l’habitude, elle lui échappa et évita la mort. Alors l’athlète dit en soupirant : « O Héraclès, si c’est ainsi que tu me secours contre une puce, quelle aide puis-je attendre de toi contre mes adversaires ? »</p>
           <p><milestone unit="traduction"/>Cette fable nous enseigne que nous aussi nous ne devons pas appeler tout de suite les dieux pour des bagatelles inoffensives, mais pour des nécessités plus pressantes.</p>
         </div>
@@ -9728,7 +9727,7 @@
           <pb ed="perry" n="P231"/>
           <p><milestone unit="recitprose"/>Ψύλλα ποτὲ πηδήσασα ἐκάθισεν ἐπὶ πόδα ἀνδρὸς ἀθλήτοῦ σοϐοῦντος, καὶ ἁλλομένη ἐνῆκε δῆγμα. Ὁ δὲ ἀκροκολήσας ηὐτρέπισε τοὺς ὄνυχας, ὅπως συνθλάσῃ ταύτην· ἡ δὲ ἐφ’ ὁρμῆς φυσικῆς πήδημα λαϐοῦσα ἀπέδρα, τοῦ θανεῖν ἀπαλλαγεῖσα. Καὶ ὃς στενάξας εἶπεν· « Ὦ Ἡράκλεις, διὰ τί ἐπὶ κακοὺς ἀνταγωνιστὰς οὐκ εἶ συνεργός ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ λόγος δηλοῖ ὅτι οὐ δεῖ ἐπὶ τὰ ἐλάχιστα καὶ ἀκίνδυνα πράγματα ἐπευθὺς τοὺς θεοὺς ἐπικαλεῖσθαι, ἀλλ’ ἐπὶ ταῖς μείζοσιν ἀνάγκαις καὶ συμφοραῖς.</p>
-          <p><milestone unit="manuscrits"/>Codd. Ca 194 Cb 106 Cd 120 Ch 129 Mc 100.</p>
+          <bibl>Codd. Ca 194 Cb 106 Cd 120 Ch 129 Mc 100.</bibl>
         </div>
         <div>
           <head>Chambry 357.3</head>
@@ -9736,7 +9735,7 @@
           <pb ed="perry" n="P231"/>
           <p><milestone unit="recitprose"/>Ψύλλα ποτὲ πηδήσασα ἐπὶ πόδα ἀνδρὸς ἐκάθισεν. Ὁ δὲ τὸν Ἡρακλῆν ἐπὶ συμμαχίαν ἐκάλει. Τῆς δὲ ἐκεῖθεν αὖθις ἀφαλομένης, στενάξας εἶπεν· « Ὦ Ἡράκλεις, εἰ ἐπὶ ψύλλῃ οὐ συνεμάχησας, πῶς ἐπὶ μείζοσιν ἀνταγωνισταῖς συνεργήσεις ; »</p>
           <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ μὴ δεῖν ἐπὶ τῶν ἐλαχίστων τοῦ θείου δεῖσθαι, ἀλλ’ ἐπὶ τῶν ἀναγκαίων.</p>
-          <p><milestone unit="manuscrits"/>Codd. La 62 Lb 129 Le 129 Lf 62 Lh 75 Md 112 Mg 156 Mi 28 Mj 150 Ml 156 Mm 139 Pb 230 Ce 122 Cf 131.</p>
+          <bibl>Codd. La 62 Lb 129 Le 129 Lf 62 Lh 75 Md 112 Mg 156 Mi 28 Mj 150 Ml 156 Mm 139 Pb 230 Ce 122 Cf 131.</bibl>
         </div>
       </div>
       <div type="poem" xml:id="chambry-358">
@@ -9754,7 +9753,7 @@
         <l><milestone unit="recitvers"/>ἅπαν γὰρ κακόν, οὐ μικρόν, οὐδὲ μέγα</l>
         <l><milestone unit="recitvers"/>οὐδ’ ὅλως πρέπει καθόλου που φυῆναι. »</l>
         <p><milestone unit="epimythiumprose"/>Ὁ μῦθος δηλοῖ ὅτι ὁ κακὸς οὐ πρέπει ἐλεηθῆναι, κἂν μέγας ᾖ, κἂν μικρός.</p>
-        <p><milestone unit="manuscrits"/>Codd. Ch 128 Ca 196 Cb 105 Mb 232 Mc 99.</p>
+        <bibl>Codd. Ch 128 Ca 196 Cb 105 Mb 232 Mc 99.</bibl>
         <p><milestone unit="traduction"/>Un jour une puce incommodait un homme sans relâche. Il l’attrapa et lui dit : « Qui es-tu, toi qui t’es repue de tous mes membres, en me piquant à tort et à travers ? » Elle répondit : « C’est notre façon de vivre ; ne ma tue pas ; car je ne puis pas faire grand mal. » L’homme se mit à rire et lui dit : « Tu vas mourir tout de suite, et de ma propre main ; car quel que soit le mal, petit ou grand, il faut absolument l’empêcher de se produire. »</p>
         <p><milestone unit="traduction"/>Cette fable montre qu’il ne faut pas avoir pitié d’un méchant, quel qu’il soit, fort ou faible.</p>
       </div>
@@ -9774,7 +9773,7 @@
         <l><milestone unit="recitvers"/>ἡ σοὶ φίλη τρίψις οἴκτιστος &lt;δὴ&gt; μόρος,</l>
         <l><milestone unit="recitvers"/>ὅτε καὶ τύχῃ συμϐαίνει &lt;μοι ἁλῶναι&gt;.</l>
         <p><milestone unit="epimythiumprose"/>Ὅτι οἱ διὰ τοῦ λόγου ἀλαζόνες καὶ ὑπὸ τοῦ εὐτελοῦς ἡττῶνται.</p>
-        <p><milestone unit="manuscrits"/>Cod. Mb 235.</p>
+        <bibl>Cod. Mb 235.</bibl>
         <p><milestone unit="traduction"/>Un jour la puce faisait au bœuf cette question : « Que t’a donc fait l’homme pour que tu les serves tous les jours, et cela, grand et brave comme tu l’es ? Moi, au contraire, je déchire impitoyablement sa chair et je bois son sang à pleine bouche. » Le bœuf répondit : « J’ai de la reconnaissance à la race des hommes ; car ils m’aiment et me chérissent, et me frottent souvent le front et les épaules. Hélas ! reprit la puce, pour moi ce frottement qui te plaît est le pire des malheurs, quand il m’arrive par hasard d’être prise entre leurs mains. »</p>
         <p><milestone unit="traduction"/>Les fanfarons de paroles se laissent confondre même par un homme simple.</p>
       </div>

--- a/xml/avianus_fabulae.xml
+++ b/xml/avianus_fabulae.xml
@@ -8,7 +8,8 @@
       <!-- encodage provisoire des types et des promythium/epimythium en milestone -->
       <titleStmt>
         <title>Fabvlae Aviani</title>
-        <author key="Avianus, Flavius (03..-04..)">Flavius Avianus</author>
+        <author key="Avianus, Flavius (03..-04..)"
+          ref="https://data.bnf.fr/fr/11889657/flavius_avianus/">Flavius Avianus</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -22,16 +23,26 @@
         </respStmt>
       </editionStmt>
       <publicationStmt>
-        <publisher>Université Paris-Sorbonne, LABEX OBVIL</publisher>
+        <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2015"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/la-fontaine_fables-I-VI/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/la-fontaine_fables-I-VI/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
-            <p>Copyright © 2015 Université Paris-Sorbonne, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
-            <p>Cette ressource électronique protégée par le code de la propriété intellectuelle sur les bases de données (L341-1) est mise à disposition de la communauté scientifique internationale par l’OBVIL, selon les termes de la licence Creative Commons : « Attribution - Pas d’Utilisation Commerciale - Pas de Modification 3.0 France (CC BY-NC-ND 3.0 FR) ».</p>
-            <p>Attribution : afin de référencer la source, toute utilisation ou publication dérivée de cette ressource électroniques comportera le nom de l’OBVIL et surtout l’adresse Internet de la ressource.</p>
-            <p>Pas d’Utilisation Commerciale : dans l’intérêt de la communauté scientifique, toute utilisation commerciale est interdite.</p>
-            <p>Pas de Modification : l’OBVIL s’engage à améliorer et à corriger cette ressource électronique, notamment en intégrant toutes les contributions extérieures, la diffusion de versions modifiées de cette ressource n’est pas souhaitable.</p> 
+            <p>Copyright © 2015 Université Paris-Sorbonne, agissant pour le Laboratoire d’Excellence
+              « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
+            <p>Cette ressource électronique protégée par le code de la propriété intellectuelle sur
+              les bases de données (L341-1) est mise à disposition de la communauté scientifique
+              internationale par l’OBVIL, selon les termes de la licence Creative Commons : «
+              Attribution - Pas d’Utilisation Commerciale - Pas de Modification 3.0 France (CC
+              BY-NC-ND 3.0 FR) ».</p>
+            <p>Attribution : afin de référencer la source, toute utilisation ou publication dérivée
+              de cette ressource électroniques comportera le nom de l’OBVIL et surtout l’adresse
+              Internet de la ressource.</p>
+            <p>Pas d’Utilisation Commerciale : dans l’intérêt de la communauté scientifique, toute
+              utilisation commerciale est interdite.</p>
+            <p>Pas de Modification : l’OBVIL s’engage à améliorer et à corriger cette ressource
+              électronique, notamment en intégrant toutes les contributions extérieures, la
+              diffusion de versions modifiées de cette ressource n’est pas souhaitable.</p>
           </licence>
         </availability>
       </publicationStmt>
@@ -44,7 +55,7 @@
         <date when="0400"/>
       </creation>
       <langUsage>
-        <language ident="fr"/>
+        <language ident="fre"/>
       </langUsage>
     </profileDesc>
   </teiHeader>
@@ -55,7 +66,9 @@
         <byline><docAuthor>A. Biscéré</docAuthor>, 21 mai 2015</byline>
         <div>
           <head>Biographie</head>
-          <p>Fabuliste romain de l’antiquité tardive (<num>iv<hi rend="sup">e</hi></num>-<num>v<hi rend="sup">e</hi></num> s.), Flavius Avianus est l’auteur d’un recueil de quarante-deux fables composées en distiques élégiaques.</p>
+          <p>Fabuliste romain de l’antiquité tardive (<num>iv<hi rend="sup">e</hi></num>-<num>v<hi
+                rend="sup">e</hi></num> s.), Flavius Avianus est l’auteur d’un recueil de
+            quarante-deux fables composées en distiques élégiaques.</p>
         </div>
         <div>
           <head>Bibliographie</head>
@@ -88,55 +101,123 @@
             <row rend="sup">
               <cell rend="b">Contenu</cell>
               <cell/>
-              <cell><hi rend="b">1.</hi> Épître dédicatoire « Ad Theodosium » ; <hi rend="b">2.</hi> Quarante-deux fables en distiques élégiaques.</cell>
+              <cell><hi rend="b">1.</hi> Épître dédicatoire « Ad Theodosium » ; <hi rend="b"
+                >2.</hi> Quarante-deux fables en distiques élégiaques.</cell>
             </row>
           </table>
           <div>
             <head>Tradition manuscrite</head>
             <list type="ul">
-              <item>137 manuscrits recensés. Voir la liste établie <ref target="http://www1.uni-hamburg.de/disticha-catonis/homepage/avian-hss.html">(en ligne)</ref> par Michael Baldzuhn.</item>
+              <item>137 manuscrits recensés. Voir la liste établie <ref
+                  target="http://www1.uni-hamburg.de/disticha-catonis/homepage/avian-hss.html">(en
+                  ligne)</ref> par Michael Baldzuhn.</item>
             </list>
           </div>
           <div>
-            <head>Éditions modernes (<num>xv<hi rend="sup">e</hi></num>-<num>xviii<hi rend="sup">e</hi></num> s., sélection – par ordre chronologique)</head>
+            <head>Éditions modernes (<num>xv<hi rend="sup">e</hi></num>-<num>xviii<hi rend="sup"
+                  >e</hi></num> s., sélection – par ordre chronologique)</head>
             <list type="ul">
-              <item>Ca. 1476-1477 – Steinhöwel, Heinrich, [<hi rend="i">Buch und Leben des hochberühmten Fabeldichters Esopi</hi>], Ulm, J. Zainer (<hi rend="i">GW</hi> <ref target="http://www.gesamtkatalogderwiegendrucke.de/docs/GW00351.htm">351</ref>). Édition <hi rend="i">princeps</hi> d’une sélection de vingt-sept fables d’Avianus (n<hi rend="sup">os</hi> 1-3, 5-9, 11, 13-15, 17- 20, 22, 25-29, 31, 33, 35 et 41-42).</item>
-              <item>1494 – <hi rend="i">Apologus Aviani civis Romani adolescentulis ad mores et latinum sermonem capescendos utilissimus</hi>, s. l. [Cologne, Heinrich Quentell], 1494.09.10 (<hi rend="i">GW</hi> <ref target="http://www.gesamtkatalogderwiegendrucke.de/docs/GW03110.htm">3110</ref>). Ex. : Munich, BSB [4 Inc.s.a. 360 a#Beibd.2] <ref target="http://daten.digitale-sammlungen.de/~db/0002/bsb00025326/images/">(en ligne)</ref> ; autres ex. : <hi rend="i">cf. ISTC</hi> nº <ref target="http://istc.bl.uk/search/search.html?operation=record&amp;rsid=200496&amp;q=0">ia01414000</ref>. Édition du recueil complet (édition <hi rend="i">princeps</hi> des n<hi rend="sup">os</hi> 4, 10, 12, 16, 21, 23-24, 30, 32, 34, 36-40).</item>
-              <item>1572 – Poelman, Theodor, <hi rend="i">Aviani aesopicarum fabularum liber a Theod. Pulmanno Craneburgio ex membranis in lucem editus</hi>, Anvers, Ch. Plantin, 1572.</item>
-              <item>1590 – Pithou, Pierre, <hi rend="i">Epigrammata et poematia vetera</hi>, Paris, D. Duvallius, 1590, p. 311‑334. Ex. : Munich, BSB [A.lat.c.6] <ref target="http://reader.digitale-sammlungen.de/resolve/display/bsb10172454.html">(en ligne)</ref>.</item>
-              <item>1610 – Nevelet, Isaac-Nicolas, <hi rend="i">Mythologia Æsopica (…) Adjiciuntur insuper Phaedri, Avieni, Abstemii, fabulae (…)</hi>, Francfort, Nic. Hoffmannus, p. 453‑485 (fables n<hi rend="sup">os</hi> 1‑42) et 658‑667 (notes). Ex. : Vienne, ÖNB [38.L.30] <ref target="http://search.obvsg.at/primo_library/libweb/action/display.do?tabs=detailsTab&amp;ct=display&amp;fn=search&amp;doc=ONB_aleph_acc003639198&amp;indx=1&amp;recIds=ONB_aleph_acc003639198&amp;recIdxs=0&amp;elementId=0&amp;renderMode=poppedOut&amp;displayMode=full&amp;frbrVersion=&amp;dscnt=0&amp;vl(1UI0)=contains&amp;scp.scps=scope%3A%28%22ONB%22%29&amp;frbg=&amp;tab=default_tab&amp;dstmp=1423036066164&amp;srt=rank&amp;mode=Basic&amp;&amp;dum=true&amp;tb=t&amp;vl(freeText0)=nevelet%20mythologia&amp;vid=ONB">(en ligne)</ref>.</item>
-              <item>1731 – Cannegieter, Hendrik, <hi rend="i">Flavii Aviani fabulae cum commentariis selectis Albini scholiastae veteris, notisque integris Isaaci Nicolai Neveletii et Caspariis Barthii, quibus animadversiones suas adjecit Henricus Cannegieter. Accedit ejusdem dissertatio de aetate et stilo Flavii Aviani</hi>, Amsterdam, M. Schagen, 1731 [<hi rend="i">reprint</hi> Osnabrück, 1976].</item>
+              <item>Ca. 1476-1477 – Steinhöwel, Heinrich, [<hi rend="i">Buch und Leben des
+                  hochberühmten Fabeldichters Esopi</hi>], Ulm, J. Zainer (<hi rend="i">GW</hi>
+                <ref target="http://www.gesamtkatalogderwiegendrucke.de/docs/GW00351.htm"
+                >351</ref>). Édition <hi rend="i">princeps</hi> d’une sélection de vingt-sept fables
+                d’Avianus (n<hi rend="sup">os</hi> 1-3, 5-9, 11, 13-15, 17- 20, 22, 25-29, 31, 33,
+                35 et 41-42).</item>
+              <item>1494 – <hi rend="i">Apologus Aviani civis Romani adolescentulis ad mores et
+                  latinum sermonem capescendos utilissimus</hi>, s. l. [Cologne, Heinrich Quentell],
+                1494.09.10 (<hi rend="i">GW</hi>
+                <ref target="http://www.gesamtkatalogderwiegendrucke.de/docs/GW03110.htm"
+                >3110</ref>). Ex. : Munich, BSB [4 Inc.s.a. 360 a#Beibd.2] <ref
+                  target="http://daten.digitale-sammlungen.de/~db/0002/bsb00025326/images/">(en
+                  ligne)</ref> ; autres ex. : <hi rend="i">cf. ISTC</hi> nº <ref
+                  target="http://istc.bl.uk/search/search.html?operation=record&amp;rsid=200496&amp;q=0"
+                  >ia01414000</ref>. Édition du recueil complet (édition <hi rend="i">princeps</hi>
+                des n<hi rend="sup">os</hi> 4, 10, 12, 16, 21, 23-24, 30, 32, 34, 36-40).</item>
+              <item>1572 – Poelman, Theodor, <hi rend="i">Aviani aesopicarum fabularum liber a
+                  Theod. Pulmanno Craneburgio ex membranis in lucem editus</hi>, Anvers,
+                Ch. Plantin, 1572.</item>
+              <item>1590 – Pithou, Pierre, <hi rend="i">Epigrammata et poematia vetera</hi>, Paris,
+                D. Duvallius, 1590, p. 311‑334. Ex. : Munich, BSB [A.lat.c.6] <ref
+                  target="http://reader.digitale-sammlungen.de/resolve/display/bsb10172454.html">(en
+                  ligne)</ref>.</item>
+              <item>1610 – Nevelet, Isaac-Nicolas, <hi rend="i">Mythologia Æsopica (…) Adjiciuntur
+                  insuper Phaedri, Avieni, Abstemii, fabulae (…)</hi>, Francfort, Nic. Hoffmannus,
+                p. 453‑485 (fables n<hi rend="sup">os</hi> 1‑42) et 658‑667 (notes). Ex. : Vienne,
+                ÖNB [38.L.30] <ref
+                  target="http://search.obvsg.at/primo_library/libweb/action/display.do?tabs=detailsTab&amp;ct=display&amp;fn=search&amp;doc=ONB_aleph_acc003639198&amp;indx=1&amp;recIds=ONB_aleph_acc003639198&amp;recIdxs=0&amp;elementId=0&amp;renderMode=poppedOut&amp;displayMode=full&amp;frbrVersion=&amp;dscnt=0&amp;vl(1UI0)=contains&amp;scp.scps=scope%3A%28%22ONB%22%29&amp;frbg=&amp;tab=default_tab&amp;dstmp=1423036066164&amp;srt=rank&amp;mode=Basic&amp;&amp;dum=true&amp;tb=t&amp;vl(freeText0)=nevelet%20mythologia&amp;vid=ONB"
+                  >(en ligne)</ref>.</item>
+              <item>1731 – Cannegieter, Hendrik, <hi rend="i">Flavii Aviani fabulae cum commentariis
+                  selectis Albini scholiastae veteris, notisque integris Isaaci Nicolai Neveletii et
+                  Caspariis Barthii, quibus animadversiones suas adjecit Henricus Cannegieter.
+                  Accedit ejusdem dissertatio de aetate et stilo Flavii Aviani</hi>, Amsterdam,
+                M. Schagen, 1731 [<hi rend="i">reprint</hi> Osnabrück, 1976].</item>
             </list>
-            <p>Pour un recensement (incomplet) des éditions modernes du recueil d’Avianus, voir aussi L. Hervieux, <hi rend="i">Les fabulistes latins</hi>…, t. III : <hi rend="i">Avianus et ses anciens imitateurs, op. cit</hi>., p. 123‑144 (inventaire de trente-sept éditions entre 1494 et la fin du <num>xvii<hi rend="sup">e</hi></num> s.).</p>
+            <p>Pour un recensement (incomplet) des éditions modernes du recueil d’Avianus, voir
+              aussi L. Hervieux, <hi rend="i">Les fabulistes latins</hi>…, t. III : <hi rend="i"
+                >Avianus et ses anciens imitateurs, op. cit</hi>., p. 123‑144 (inventaire de
+              trente-sept éditions entre 1494 et la fin du <num>xvii<hi rend="sup"
+              >e</hi></num> s.).</p>
           </div>
           <div>
             <head>Illustration (enluminures, gravures – par ordre chronologique)</head>
             <list type="ul">
-              <item><num>x<hi rend="sup">e</hi></num> s. – Paris, BnF [Ms. lat. nouv. acq. 1132]. <hi rend="i">Cf</hi>. <hi rend="sc">Omont</hi> 1922 ; <hi rend="sc">Goldschmidt</hi> 1947.</item>
-              <item>Trèves, Stadtbibliothek Trier, [1108/55 4°]. <hi rend="i">Cf</hi>. <hi rend="sc">Embach</hi> 2008.</item>
+              <item><num>x<hi rend="sup">e</hi></num> s. – Paris, BnF [Ms. lat. nouv. acq. 1132].
+                  <hi rend="i">Cf</hi>. <hi rend="sc">Omont</hi> 1922 ; <hi rend="sc"
+                  >Goldschmidt</hi> 1947.</item>
+              <item>Trèves, Stadtbibliothek Trier, [1108/55 4°]. <hi rend="i">Cf</hi>. <hi rend="sc"
+                  >Embach</hi> 2008.</item>
               <item>Ca. 1476-1477 – Gravures sur bois du recueil de H. Steinhöwel.</item>
             </list>
           </div>
           <div>
-            <head>Éditions contemporaines (<num>xix<hi rend="sup">e</hi></num>-<num>xxi<hi rend="sup">e</hi></num> s.) et traductions (sélection – par ordre chronologique rétrograde)</head>
+            <head>Éditions contemporaines (<num>xix<hi rend="sup">e</hi></num>-<num>xxi<hi
+                  rend="sup">e</hi></num> s.) et traductions (sélection – par ordre chronologique
+              rétrograde)</head>
             <list type="ul">
-              <item>1980 – <hi rend="sc">Gaide</hi>, Françoise (éd. &amp; trad. fr.), <hi rend="i">Avianus. Fables</hi>, Paris, Les Belles Lettres, « Collection des Universités de France », 1980.</item>
+              <item>1980 – <hi rend="sc">Gaide</hi>, Françoise (éd. &amp; trad. fr.), <hi rend="i"
+                  >Avianus. Fables</hi>, Paris, Les Belles Lettres, « Collection des Universités de
+                France », 1980.</item>
             </list>
             <p>C.R. : J. Küppers, <hi rend="i">Gnomon</hi>, nº 53, 1981, p. 239‑245.</p>
             <list type="ul">
-              <item>1968 – <hi rend="sc">Herrmann</hi>, Léon (éd. &amp; trad. fr.), <hi rend="i">Caius Laetus Avianus. Œuvres</hi>, Bruxelles, Latomus, « Latomus (96) », 1968. 177 p.</item>
-              <item>1958 – <hi rend="sc">Guaglianone</hi>, Antonio (éd.), <hi rend="i">Aviani Fabulae</hi>, Turin, Paravia, « Corpus Scriptorum Latinorum Paravianum », 1958. <num>lxiv</num>‑122 p.</item>
+              <item>1968 – <hi rend="sc">Herrmann</hi>, Léon (éd. &amp; trad. fr.), <hi rend="i"
+                  >Caius Laetus Avianus. Œuvres</hi>, Bruxelles, Latomus, « Latomus (96) », 1968.
+                177 p.</item>
+              <item>1958 – <hi rend="sc">Guaglianone</hi>, Antonio (éd.), <hi rend="i">Aviani
+                  Fabulae</hi>, Turin, Paravia, « Corpus Scriptorum Latinorum Paravianum », 1958.
+                  <num>lxiv</num>‑122 p.</item>
             </list>
-            <p>C.R. : Jean G. Préaux, <hi rend="i">L’Antiquité classique</hi>, vol. 28 (nº 2), 1959, p. 435‑437 <ref target="http://www.persee.fr/web/revues/home/prescript/article/antiq_0770-2817_1959_num_28_2_3386_t1_0435_0000_3">(Persée)</ref>.</p>
+            <p>C.R. : Jean G. Préaux, <hi rend="i">L’Antiquité classique</hi>, vol. 28 (nº 2), 1959,
+              p. 435‑437 <ref
+                target="http://www.persee.fr/web/revues/home/prescript/article/antiq_0770-2817_1959_num_28_2_3386_t1_0435_0000_3"
+                >(Persée)</ref>.</p>
             <list type="ul">
-              <item>(1934) 1961 – <hi rend="sc">Duff</hi>, John Wight, &amp; <hi rend="sc">Duff</hi>, Arnold Mackay (éd. &amp; trad. angl.), « Avianus. Fables », [<hi rend="i">in</hi>] <hi rend="i">Minor Latin Poets</hi>, Cambridge (Mass.), Harvard University Press, « Classical Library », (1934) 1961, p. 667-749.</item>
-              <item>1894 – <hi rend="sc">Hervieux</hi>, Léopold (éd.), <hi rend="i">Les fabulistes latins depuis le siècle d’Auguste jusqu’à la fin du Moyen Âge</hi>, t. III : <hi rend="i">Avianus et ses anciens imitateurs</hi>, Paris, Firmin‑Didot, 1894 [<hi rend="i">reprint</hi> Hildesheim/New York, G. Olms, 1970]. <num>iii</num>‑530 p.</item>
-              <item>1887 – <hi rend="sc">Ellis</hi>, Robinson (éd.), <hi rend="i">The Fables of Avianus, Edited with Prolegomena, Critical Apparatus, Commentary, Excursus and Index</hi>, Oxford, Clarendon Press, 1887 [<hi rend="i">reprint</hi> Hildesheim, Olms, 1966]. <num>xvii</num>-151 p.</item>
+              <item>(1934) 1961 – <hi rend="sc">Duff</hi>, John Wight, &amp; <hi rend="sc"
+                >Duff</hi>, Arnold Mackay (éd. &amp; trad. angl.), « Avianus. Fables », [<hi
+                  rend="i">in</hi>] <hi rend="i">Minor Latin Poets</hi>, Cambridge (Mass.), Harvard
+                University Press, « Classical Library », (1934) 1961, p. 667-749.</item>
+              <item>1894 – <hi rend="sc">Hervieux</hi>, Léopold (éd.), <hi rend="i">Les fabulistes
+                  latins depuis le siècle d’Auguste jusqu’à la fin du Moyen Âge</hi>, t. III : <hi
+                  rend="i">Avianus et ses anciens imitateurs</hi>, Paris, Firmin‑Didot, 1894 [<hi
+                  rend="i">reprint</hi> Hildesheim/New York, G. Olms, 1970].
+                <num>iii</num>‑530 p.</item>
+              <item>1887 – <hi rend="sc">Ellis</hi>, Robinson (éd.), <hi rend="i">The Fables of
+                  Avianus, Edited with Prolegomena, Critical Apparatus, Commentary, Excursus and
+                  Index</hi>, Oxford, Clarendon Press, 1887 [<hi rend="i">reprint</hi> Hildesheim,
+                Olms, 1966]. <num>xvii</num>-151 p.</item>
             </list>
-            <p>C.R. : John E. B. Mayor, <hi rend="i">The Classical Review</hi>, vol. 1 (nº 7), 1887, p. 188‑193 ; Walter Ashburner, <hi rend="i">The American Journal of Philology</hi>, vol. 9 (n<hi rend="sup">o</hi> 3), 1888, p. 359‑362 ; O. Crusius, <hi rend="i">Jahrbücher für classische Philologie</hi>, nº 139, 1889, p. 641‑656.</p>
+            <p>C.R. : John E. B. Mayor, <hi rend="i">The Classical Review</hi>, vol. 1 (nº 7), 1887,
+              p. 188‑193 ; Walter Ashburner, <hi rend="i">The American Journal of Philology</hi>,
+              vol. 9 (n<hi rend="sup">o</hi> 3), 1888, p. 359‑362 ; O. Crusius, <hi rend="i"
+                >Jahrbücher für classische Philologie</hi>, nº 139, 1889, p. 641‑656.</p>
             <list type="ul">
-              <item>1883 – <hi rend="sc">Bährens</hi>, Emil (éd.), « Aviani fabulae », [<hi rend="i">in</hi>] <hi rend="i">P</hi><anchor xml:id="_GoBack"/><hi rend="i">oetae latini minores censuit et emendavit Aemilius Baehrens</hi>, Leipzig, Teubner, « Bibliotheca Teubneriana », vol. 5, 1883, p. 31-70.</item>
-              <item>1862 – <hi rend="sc">Fröhner</hi>, Wilhelm (éd.), <hi rend="i">Aviani Fabulae XXXXII ad Theodosium. Ex recensione et cum instrumento critico Guilelmi Froehner</hi>, Leipzig, Teubner, 1862.</item>
+              <item>1883 – <hi rend="sc">Bährens</hi>, Emil (éd.), « Aviani fabulae », [<hi rend="i"
+                  >in</hi>] <hi rend="i">P</hi><anchor xml:id="_GoBack"/><hi rend="i">oetae latini
+                  minores censuit et emendavit Aemilius Baehrens</hi>, Leipzig, Teubner,
+                « Bibliotheca Teubneriana », vol. 5, 1883, p. 31-70.</item>
+              <item>1862 – <hi rend="sc">Fröhner</hi>, Wilhelm (éd.), <hi rend="i">Aviani Fabulae
+                  XXXXII ad Theodosium. Ex recensione et cum instrumento critico Guilelmi
+                  Froehner</hi>, Leipzig, Teubner, 1862.</item>
             </list>
           </div>
           <div>
@@ -362,143 +443,649 @@
           <div>
             <head>Remaniements et adaptations (par ordre chronologique)</head>
             <list type="ul">
-              <item>Ca. 1100 – Poète d’Asti, <hi rend="i">Novus Avianus Astensis</hi> (adaptation en distiques élégiaques léonins des 42 fables d’Avianus)</item>
-              <item>Fin <num>xi<hi rend="sup">e</hi></num> s.-déb.<num>xii<hi rend="sup">e</hi></num> s. – <hi rend="i">Novus Avianus</hi> de Venise (latin)</item>
-              <item><num>xii<hi rend="sup">e</hi></num> s. – <hi rend="i">Novus Avianus</hi> de Vienne (latin)</item>
-              <item>Fin<num> xii<hi rend="sup">e</hi></num> s. – Alexandre Neckam, <hi rend="i">Novus Avianus</hi> (remaniements latins des 6 premières fables d’Avianus, dont une sous trois formes différentes)</item>
-              <item>Fin<num> xii<hi rend="sup">e</hi></num> s.-déb. <num>xiii<hi rend="sup">e</hi></num> s. – <hi rend="i">Anti-Avianus</hi> (latin)</item>
-              <item>Fin <num>xii<hi rend="sup">e</hi></num> s. – <hi rend="i">Avionnet de York</hi> (adaptation française de 8 fables d’Avianus)</item>
-              <item><num>xii<hi rend="sup">e</hi></num> s.-<num>xiii<hi rend="sup">e</hi></num> s. – <hi rend="i">Novus Avianus</hi> de Darmstadt (latin)</item>
-              <item><num>xiii<hi rend="sup">e</hi></num> s. – <hi rend="i">Isopet-Avionnet</hi> de Milan (comporte une adaptation franco-italienne de 30 moralités d’Avianus)</item>
-              <item>Ca. 1300-1350 – <hi rend="i">Isopet I-Avionnet</hi> (comporte une adaptation française de 18 fables d’Avianus)</item>
-              <item>Ca. 1350 – Ulrich Boner, <hi rend="i">Der Edelstein</hi> (comporte une adaptation allemande de 22 fables d’Avianus)</item>
-              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Avianicae fabulae</hi> (adaptation en prose de 38 fables d’Avianus)</item>
-              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Apologi Aviani</hi> (paraphrase en prose latine des 42 fables d’Avianus)</item>
-              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Super Aviani fabulis rhythmicae moralisationes</hi> (remaniements des fables d’Avianus en quatrains de vers rythmiques latins)</item>
-              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Super Aviani fabulis metricae moralisationes</hi> (remaniements des fables d’Avianus en quatrains de distiques élégiaques léonins)</item>
-              <item>Ca. 1476-1477 – H. Steinhöwel (comporte une adaptation allemande de 17 fables d’Avianus) et ses dérivés européens (Macho, Caxton, Leeu, Biernat de Lublin…).</item>
-              <item>1508 – Érasme, <hi rend="i">Adagiorum Chiliades tres</hi>, Venise, A. Manuce, 1508, I, 729 (« <hi rend="i">Ex eodem ore calidum et frigidum efflare</hi> »), f. 86r (éd. <hi rend="i">A.S.D</hi>., nº 730) : « <hi rend="i">Natum ex Apologo quopiam Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i">fabulatoris…</hi> ». Paraphrase en prose latine de la fable nº 29/42, reprise sous le titre « <hi rend="i">De satyro et rustico Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i">fabula, Erasmo quoque interprete</hi> » dans la plupart des éditions de l’<hi rend="i">Æsopus Dorpii</hi> à partir de 1513 (« <hi rend="i">Apologi ex Chiliadibus adagiorum Erasmi desumpti</hi> », nº 9/9) et dans le recueil de Camerarius à partir de 1538 (« <hi rend="i">Erasmicæ fabulæ</hi> » ou « <hi rend="i">Erasmi fabulæ</hi> », nº 9/9).</item>
-              <item>Avant 1509, éd. 1513 – Guillaume Hermans de Gouda, « <hi rend="i">Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i">fabulae Guielmo Hermanno</hi> (…) <hi rend="i">interprete</hi> » (remaniements en prose néolatine de 38 fables d’Avianus)</item>
-              <item>1512 – Adriaan van Baarland (Barlandus), « <hi rend="i">Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i">fabulae Hadriano Barlando interprete</hi> » (remaniements en prose néolatine de 9 fables d’Avianus, dont 4 seulement seront reprises en 1513 et dans les éditions ultérieures).</item>
+              <item>Ca. 1100 – Poète d’Asti, <hi rend="i">Novus Avianus Astensis</hi> (adaptation en
+                distiques élégiaques léonins des 42 fables d’Avianus)</item>
+              <item>Fin <num>xi<hi rend="sup">e</hi></num> s.-déb.<num>xii<hi rend="sup"
+                  >e</hi></num> s. – <hi rend="i">Novus Avianus</hi> de Venise (latin)</item>
+              <item><num>xii<hi rend="sup">e</hi></num> s. – <hi rend="i">Novus Avianus</hi> de
+                Vienne (latin)</item>
+              <item>Fin<num> xii<hi rend="sup">e</hi></num> s. – Alexandre Neckam, <hi rend="i"
+                  >Novus Avianus</hi> (remaniements latins des 6 premières fables d’Avianus, dont
+                une sous trois formes différentes)</item>
+              <item>Fin<num> xii<hi rend="sup">e</hi></num> s.-déb. <num>xiii<hi rend="sup"
+                  >e</hi></num> s. – <hi rend="i">Anti-Avianus</hi> (latin)</item>
+              <item>Fin <num>xii<hi rend="sup">e</hi></num> s. – <hi rend="i">Avionnet de York</hi>
+                (adaptation française de 8 fables d’Avianus)</item>
+              <item><num>xii<hi rend="sup">e</hi></num> s.-<num>xiii<hi rend="sup">e</hi></num> s.
+                  – <hi rend="i">Novus Avianus</hi> de Darmstadt (latin)</item>
+              <item><num>xiii<hi rend="sup">e</hi></num> s. – <hi rend="i">Isopet-Avionnet</hi> de
+                Milan (comporte une adaptation franco-italienne de 30 moralités d’Avianus)</item>
+              <item>Ca. 1300-1350 – <hi rend="i">Isopet I-Avionnet</hi> (comporte une adaptation
+                française de 18 fables d’Avianus)</item>
+              <item>Ca. 1350 – Ulrich Boner, <hi rend="i">Der Edelstein</hi> (comporte une
+                adaptation allemande de 22 fables d’Avianus)</item>
+              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Avianicae fabulae</hi>
+                (adaptation en prose de 38 fables d’Avianus)</item>
+              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Apologi Aviani</hi>
+                (paraphrase en prose latine des 42 fables d’Avianus)</item>
+              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Super Aviani fabulis
+                  rhythmicae moralisationes</hi> (remaniements des fables d’Avianus en quatrains de
+                vers rythmiques latins)</item>
+              <item><num>xiv<hi rend="sup">e</hi></num> s. – <hi rend="i">Super Aviani fabulis
+                  metricae moralisationes</hi> (remaniements des fables d’Avianus en quatrains de
+                distiques élégiaques léonins)</item>
+              <item>Ca. 1476-1477 – H. Steinhöwel (comporte une adaptation allemande de 17 fables
+                d’Avianus) et ses dérivés européens (Macho, Caxton, Leeu, Biernat de
+                Lublin…).</item>
+              <item>1508 – Érasme, <hi rend="i">Adagiorum Chiliades tres</hi>, Venise, A. Manuce,
+                1508, I, 729 (« <hi rend="i">Ex eodem ore calidum et frigidum efflare</hi> »),
+                f. 86r (éd. <hi rend="i">A.S.D</hi>., nº 730) : « <hi rend="i">Natum ex Apologo
+                  quopiam Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i">fabulatoris…</hi> ».
+                Paraphrase en prose latine de la fable nº 29/42, reprise sous le titre « <hi
+                  rend="i">De satyro et rustico Aniani</hi> [<hi rend="i">sic</hi>] <hi rend="i"
+                  >fabula, Erasmo quoque interprete</hi> » dans la plupart des éditions de l’<hi
+                  rend="i">Æsopus Dorpii</hi> à partir de 1513 (« <hi rend="i">Apologi ex
+                  Chiliadibus adagiorum Erasmi desumpti</hi> », nº 9/9) et dans le recueil de
+                Camerarius à partir de 1538 (« <hi rend="i">Erasmicæ fabulæ</hi> » ou « <hi rend="i"
+                  >Erasmi fabulæ</hi> », nº 9/9).</item>
+              <item>Avant 1509, éd. 1513 – Guillaume Hermans de Gouda, « <hi rend="i">Aniani</hi>
+                  [<hi rend="i">sic</hi>] <hi rend="i">fabulae Guielmo Hermanno</hi> (…) <hi
+                  rend="i">interprete</hi> » (remaniements en prose néolatine de 38 fables
+                d’Avianus)</item>
+              <item>1512 – Adriaan van Baarland (Barlandus), « <hi rend="i">Aniani</hi> [<hi
+                  rend="i">sic</hi>] <hi rend="i">fabulae Hadriano Barlando interprete</hi> »
+                (remaniements en prose néolatine de 9 fables d’Avianus, dont 4 seulement seront
+                reprises en 1513 et dans les éditions ultérieures).</item>
             </list>
           </div>
           <div>
-            <head>Études (bibliographie critique par ordre alphabétique d’auteurs, éventuellement subdivisée en sections thématiques)</head><p><milestone unit="bibliteration"/><hi rend="sc">Achelis</hi>, Thomas Otto, « Die Fabeln Avians in Steinhöwel’s Æsop », <hi rend="i">Münchener Museum für Philologie des Mittelalters und der Renaissance</hi>, nº 4, 1924, p. 195‑221.</p><p><milestone unit="analysebiblio"/>Lenghty discussion of the twenty-seven fables from the Avianus collection that Steinhöwel chose and translated for his 1476-1477 Ulm edition. Textual problems as well as the choice of fables are discussed with an analysis of those fabular motif in Avianus, which had already appeared in early sections of Steinhöwel’s collection. Tables of concordance and keys to Halm. Extensively discussed are P70 (« The Oak and the Reed » (A-T 28C ; TMI J832) and P525 « Bald Man and the Fly » (TMI J2102.3) (P.C.).</p><bibl><hi rend="sc">Bährens</hi>, Emil, « Ad Avianum », [<title>in</title>] <title>Miscellanea critica</title>, Groningen, in aedibus J. B. Woltersii, 1878, p. 176‑194.
-              <hi rend="sc">Baldzuhn</hi>, Michæl, « “<title>Quidquid placet</title>”. Stellung und Gebrauchsformen der <title>Fabulæ Auiani</title> im Schulunterricht des 15. Jahrhunderts », [<title>in</title>] <hi rend="sc">M. Kintzinger</hi>, <hi rend="sc">S. Lorenz</hi>, &amp; <hi rend="sc">M. Walter</hi> (dir.), <title>Schule und Schüler im Mittelalter. Beiträge zur europäischen Bildungsgeschichte des 9. bis 15. Jahrhunderts</title>, Cologne/Weimar/Vienne, Böhlau, 1996, p. 327‑383.</bibl><p><milestone unit="bibliteration"/>—, « Avian im Gebrauch. Zur Verwendung von Schulhandschriften im Unterricht », [<hi rend="i">in</hi>] <hi rend="sc">C. Meier</hi>, <hi rend="sc">D. Hüpper</hi>, &amp; <hi rend="sc">H. Keller</hi> (dir.), <hi rend="i">Der Codex im Gebrauch. Akten des Internationalen Kolloquiums (11.-13. Juni 1992)</hi>, Munich, W. Fink, 1996, p. 183-196, &amp; p. <hi rend="sc">xxxxiv‑xlv</hi>.</p><p><milestone unit="bibliteration"/>—, « Schriftliche Textauslegung und mündlicher Unterricht. Das Beispiel der älteren lateinisch und volkssprachlich glossierten Aviane (9.-11. Jahrhundert) », [<hi rend="i">in</hi>] <hi rend="sc">R. Bergmann</hi>, <hi rend="sc">E. Glaser</hi>, &amp; <hi rend="sc">C. Moulin-Fankhänel</hi> (dir.), <hi rend="i">Mittelalterliche volkssprachliche Glossen. Internationale Fachkonferenz des Zentrums für Mittelalterstudien der Otto-Friedrich-Universität Bamberg, 2. bis 4. August 1999</hi>, Heidelberg, Winter, 2001, p. 485‑512.</p><p><milestone unit="bibliteration"/>—, « Schulunterricht und Verschriftlichungsprozess. Forschungsansätze und Forschungsergebnisse », [<hi rend="i">in</hi>] <hi rend="sc">C. Meier</hi>, <hi rend="sc">V. Honemann</hi>, <hi rend="sc">H. Keller</hi>, &amp; <hi rend="sc">R. Suntrup</hi> (dir.), <hi rend="i">Pragmatische Dimensionen mittelalterlicher Schriftkultur. Akten des Internationalen Kolloquiums (26.-29. Mai 1999)</hi>, Munich, W. Fink, 2002, p. 161‑175.</p><p><milestone unit="bibliteration"/>—, art. « Avian », [<hi rend="i">in</hi>] <hi rend="sc">K. Ruh</hi>, &amp; <hi rend="sc">B. Wachinger</hi> (dir.), <hi rend="i">Die deutsche Literatur des Mittelalters. Verfasserlexikon (2. völlig neu bearbeitete Auflage)</hi>, Berlin, W. de Gruyter, 1977‑2008, vol. 11, 2004, col. 195‑204.</p><p><milestone unit="bibliteration"/>—, <hi rend="i">Schulbücher im Trivium des Mittelalters und der Frühen Neuzeit. Die Verschriftlichung von Unterricht in der Text- und Überlieferungsgeschichte der « Fabulæ » Avians und der deutschen « Disticha Catonis »</hi>, Berlin/New York, W. de Gruyter, « Quellen und Forschungen zur Literatur- und Kulturgeschichte (44/278) », 2009, 2 vol. <num>xiii</num>‑1128 p.</p><p><milestone unit="mentioncr"/>C.R. : <hi rend="sc">J. Knödler</hi>, <hi rend="i"><hi rend="sc">iasl</hi> online</hi> [en ligne], 26.09.2011. <hi rend="sc">url</hi> : <ref target="http://www.iaslonline.lmu.de/index.php?vorgang_id=3296">http://www.iaslonline.lmu.de/index.php?vorgang_id=3296</ref> (15.05.2013) ; Ch. <hi rend="sc">Roth</hi>, <hi rend="i">Zeitschrift für deutsches Altertum und deutsche Literatur</hi>, nº 140, 2011, p. 359‑363.</p><bibl><hi rend="sc">Bedrick</hi>, Theodore, <title>The Prose Adaptations of Avianus</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D. non-publiée), 1941. 219 p.</bibl><p><milestone unit="analysebiblio"/>The medieval rewritings and prose paraphrases of Avianus during the Middle Ages are discussed. The use of Avianus in schools as a medium for the instruction of Latin is highlighted (P.C.)</p><bibl><hi rend="sc">Bibring</hi>, Tovi, « Réécritures fabulistiques au Moyen Âge. Adaptations latine, vernaculaire et hébraïque d’une fable d’Avianus,  “<title>De Simia et Natis</title>” », [<title>in</title>] <hi rend="sc">N. Catellani-Dufrêne</hi>, &amp; <hi rend="sc">M. Perrin</hi> (dir.), <title>La lyre et la pourpre. Poésie latine et politique de l’Antiquité latine à la Renaissance</title>, Rennes, Presses universitaires de Rennes, 2012, p. 267‑280.</bibl><p><milestone unit="bibliteration"/>—, « On Heartlessness and Senselessness. An Inquiry on an Exemplary Theme : from the “Sick Lion” (the <hi rend="i">Panchatantra</hi>, Babrius, Marie de France) to the “Disobedient Boar” (Avianus, Berechiah Ha-Nakdan, <hi rend="i">Gesta romanorum</hi>) », dans M.‑Ch. <hi rend="sc">Bornes-Varol</hi>, &amp; M.‑<hi rend="sc">S. Ortola</hi> (dir.), <hi rend="i">Énoncés sapientiels et littérature exemplaire : une intertextualité complexe</hi>, Nancy, Presses universitaires de Nancy-Éditions universitaires de Lorraine, « Aliento (3) », 2013, p. 351‑384.</p><bibl><hi rend="sc">Bisanti</hi>, Armando, « La favola esopica nel Medioevo : un itinerario didattico fra teoria ed esemplificazione », [<title>in</title>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <title>La favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</title>, Assise, Accademia Properziana del Subasio, 1991, p. 161‑212.</bibl><p><milestone unit="bibliteration"/>—, « Pier Damiani e una favola di Aviano », <hi rend="i">Civiltà Classica e Cristiana</hi>, vol. 14 (nº 3), 1993, p. 313‑330.</p><p><milestone unit="bibliteration"/>—, &amp; <hi rend="sc">Zurli</hi>, Loriano (éd.), <hi rend="i">Astensis Poetae Novus Avianus</hi>, Gênes, <hi rend="sc">d.ar.fi.cl.et. «</hi> Francesco Della Corte », « Favolisti latini medievali e umanistici (5) », 1994. 236 p.</p><p><milestone unit="bibliteration"/>—, « Edizioni e studi sulla favolistica mediolatina », <hi rend="i">Schede Medievali. Rassegna dell’Officina di studi medievali</hi>, nº 40, 2002, p. 93‑142.</p><p><milestone unit="bibliteration"/>—, « Il <hi rend="i">Nouus Auianus</hi> di Alessandro Neckam nel quadro delle riscritture mediolatine di Aviano », <hi rend="i">Maia. Rivista di letterature classiche</hi>, vol. 54 (nº 2), 2002, p. 295‑350.</p><p><milestone unit="bibliteration"/>—, « Appunti sulla fortuna mediolatina e romanza dei <hi rend="i">Noui Auiani</hi> », <hi rend="i">Maia. Rivista di letterature classiche</hi>, vol. 56 (nº 1), 2004, p. 127‑138, repris sous une forme légèrement remaniée dans <hi rend="i">Mittellateinisches Jahrbuch</hi>, vol. 39 (nº 2), 2004, p. 207‑218.</p><p><milestone unit="bibliteration"/>—, « Il <hi rend="i">Nouus Avianus Astensis</hi> », <hi rend="i">Maia. Rivista di letterature classiche</hi>, vol. 58 (nº 1), 2006, p. 91‑118.</p><p><milestone unit="bibliteration"/>—, « Sull’edizione critica del <hi rend="i">Novus Avianus Vindobonensis</hi> », <hi rend="i">Schede Medievali. Rassegna dell’Officina di studi medievali</hi>, nº 47, 2009, p. 235‑249.</p><p><milestone unit="bibliteration"/>—, <hi rend="i">Le Favole di Aviano e la loro fortuna nel Medioevo</hi>, Florence, <hi rend="sc">S.i.s.m.e.l.</hi>/Edizioni del Galluzzo, « Millennio Medievale (85) » &amp; « Strumenti e studi (25) », 2010. <num>xii</num>‑190 p.</p><bibl><hi rend="sc">Boivin</hi>, Jeanne-Marie, <title>Naissance de la fable en français. L’Isopet de Lyon et l’Isopet I‑Avionnet</title>, Paris, H. Champion, « Essais sur le Moyen Âge (33) », 2006. 499 p. (voir notamment : « Avianus : la fable élégiaque », p. 53‑76 ; «  Table de concordance des fables de l’<title>Avionnet</title>, d’Avianus, de l’<title>Isopet de Chartres</title>, du <title>Fragment d’York</title>, de l’Ésope de Macho et de La Fontaine », p. 451 ; « Évolution de la taille des apologues (récits &amp; moralités) et de la prise de parole directe d’Avianus à l’<title>Avionnet</title> », p. 463 ; « Les différents types de moralités : d’Avianus à l’<title>Avionnet</title> », p. 466).</bibl><p><milestone unit="mentioncr"/>C.R. : <hi rend="sc">L. Brun</hi>, <hi rend="i">Cahiers de Recherches Médiévales et Humanistes</hi> (en ligne), 2006. <hi rend="sc">url</hi> : <ref target="http://crm.revues.org/2713">http://crm.revues.org/2713</ref> ; Ph. <hi rend="sc">Ménard</hi>, <hi rend="i">Zeitschrift für romanische Philologie</hi>, vol. 125 (nº 4), 2009, p. 743‑745.</p><bibl><hi rend="sc">Boretsky</hi>, M. I., « Das Problem des Names des römischen Fabeldichters Avian », <title>Pytanna klasysnoji filolohiji. Questions de philologie classique</title>, nº 14, 1977, p. 83‑90 [article en ukrainien avec résumés en allemand et en russe].</bibl><p><milestone unit="analysebiblio"/>Avianus is confirmed as the proper name of the fourth-century fable-poet, the carrier of the Babrian tradition, very popular during the Middle Ages. Fairly extensive analysis of the arguments for and against the name and reasons for the many variants of the name found in the manuscript tradition. Good bibliography (P.C.).</p><p><milestone unit="bibliteration"/>—, « Essay on the Utilization of a Lexical System for the Comparative Analysis of the Fables of Avianus and Babrius », <hi rend="i">Pytanna klasysnoji Filolohiji. Questions de philologie classique</hi>, nº 15, 1978, p. 55‑78 [article en russe avec résumés en anglais et en allemand].</p><p><milestone unit="analysebiblio"/>Comparative study of the use of various differing terms within specific semantic categories results in a very specific close relationship between the two poets. There can be no doubt of the influence of Babrius on Avianus, the author concludes although the exact nature of this influence is not yet definable (P.C.).</p><p><milestone unit="bibliteration"/>—, « The Artistic Universe and Lexical Frequency in Poetic Works (on the Example of the Classical Literary Fable) », <hi rend="i">Izvestija AN SSR. Ser. literatury i Jazyka</hi>, vol. 37 (nº 5), 1978, p. 453‑461.</p><p><milestone unit="analysebiblio"/>An attempt to reconstruct the social and artistic milieu for the classical fabulists : Phaedrus, Babrius, and Avianus by means of lexical frequency counts (P.C.).</p><p><milestone unit="bibliteration"/>—, &amp; <hi rend="sc">Kronik</hi>, A. A., « Opyt analiza nekotorkh storon sotsial’no-psikhologicheskoy atmosphery antichnoy literaturnoy basni », <hi rend="i">Vesnik Drevnej Istorii</hi>, nº 145, 1978, p. 157‑168.</p><p><milestone unit="analysebiblio"/>This article attempts to describe and evaluate the interpersonal relationships in the fables of Phaedrus, Babrius, and Avianus by means of a close analysis of the nouns used in the fables which describe or otherwise contain information about the nature of various relationships. A clear idea of the social-psychological atmosphere of each poet is determined by a construct of nine types of relationships among which the lexical items are distributed. The authors suggest that this work is potentially important for research in other Problems connected with these fabulists (P.C.).</p><bibl><hi rend="sc">Cameron</hi>, Alan, « Macrobius, Avienus and Avianus », <title>The Classical Quarterly</title>, vol. 17 (nº 2), déc. 1967, p. 385‑399.</bibl><p><milestone unit="analysebiblio"/>Dating Avianus is aided by Claudian’s <hi rend="i">De bello gildonico</hi> (398) : Theodosius identified with Macrobius. Cameron suggests that Avianus used a Latin translation of Babrius (by Julius Titianus), which solves many Problems. Contains a good survey of the cluster of problems of Avianus’ name and concludes that the proper form is Avienus. (P.C.)</p><bibl><hi rend="sc">Catanzaro</hi>, Giuseppe, &amp; <hi rend="sc">Santucci</hi>, Francesco (dir.), <title>La favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</title>, Assisi, Accademia properziana del Subasio, « Centro studi poesia latina in distici elegiaci (2) », 1991. 235 p. 
-                <hi rend="sc">Crusius,</hi> Otto, « Avian. XXVIII 7 », <title>Philologus. Zeitschrift für antike Literatur und ihre Rezeption</title>, vol. 47 (nº 3), 1889, p. 399.</bibl><p rend="noindent"><milestone unit="bibliteration"/>—, « The Fables of Avianus (Ellis) », <hi rend="i">Jahrbücher für classische Philologie</hi>, nº 139, 1889, p. 641‑656.</p><p><milestone unit="analysebiblio"/>Very comprehensive review of Ellis’ Oxford edition of Avianus. Crusius praises Ellis although he suggests that Ellis might have spent more time with the manuscripts and should have provided an overview on the comparative relationship between Avianus and Babrius. Crusius sees an intermediary of Titian’s Latin prose paraphrase between Avianus and Babrius. Long list of emendations, corrections. (P.C.)</p><p><milestone unit="bibliteration"/>—, « Zu den alten Fabeldichtern. I. Avian und die sogen. <hi rend="i">Apologi Aviani</hi> », <hi rend="i">Philologus. Zeitschrift für antike Literatur und ihre Rezeption</hi>, vol. 54 (nº 3), 1895, p. 474‑488.</p><p><milestone unit="analysebiblio"/>Treated Avianus and his dates and the « apologi » fables. The paraphrase of Avianus, for which Heidenhain had claimed a more complete text had been used, is demonstrated to be a relatively simple paraphrase of Avianus from a text that basically the same of our received text. Therefore we can learn little to help the Avianus tradition itself. Ends with a number of notes for the Avianus fables. (P.C.)</p><p><milestone unit="bibliteration"/>—, « Avianus », [<hi rend="i">in</hi>] <hi rend="sc">G. Wissowa</hi> (dir.),<hi rend="i"> Paulys Real-Encyclopädie der classischen Altertumswissenschaft. Neue Bearbeitung</hi>, Stuttgart, J. B. Metzler, vol. II (<hi rend="i">Apollon-Barbaroi</hi>), 1896, col. 2373‑2378.</p><p><milestone unit="analysebiblio"/>Various theories of the time and person of Avianus are discussed, including an extensive reviex of the ideas of Ellis and Cannegieter. The 42-fables Avianus collection is described in terms of its relationship to Babrius, followed by a summary of the life of the collection and its diffusion. (P.C.)</p><bibl><hi rend="sc">De Paulis</hi>, Guido, <title>Aviani Index et Lexicon</title>, Hidesheim/Zurich/New York, Olms-Weidmann, « Alpha-Omega. Reihe A. Lexika, Indizes, Konkordanzen zur klassischen Philologie (184) », 1997, <num>vi</num>-468 p.
-                  <hi rend="sc">Draheim</hi>, Johannes, « <title>De Aviani elegis</title> », <title>Jahrbücher für classische Philologie</title>, nº 143, 1891, p. 509-511.</bibl><p><milestone unit="analysebiblio"/>Various notes on the verse forms of Avianus’ fables as reconstructed in part from the corrupt received forms. (P.C.)</p><bibl><hi rend="sc">Embach</hi>, Michæl (éd.), <title>Der « Trierer Äsop » (StB Trier, Hs. 1108/55 4°). Eine illustrierte Fabelhandschrift im Kontext ihrer Überlieferung</title>, Trèves, Paulinus, « Kostbarkeiten der Stadtbibliothek Trier (3) », 2008. 100 p.</bibl><p><milestone unit="analysebiblio"/>Der dritte Band der « Kostbarkeiten der Stadtbibliothek Trier » stellt den « Trierer Äsop » vor, eine reichlich illustrierte Handschrift aus der Zeit um 1380. Der Kodex enthält illustrierte Ausgaben der Fabeln des Äsop und des Avian, jeweils in mittelalterlichen Bearbeitungen sowie ausgestattet mit knappen Auslegungen. Text und Illustrationen verweisen auf eine Verwendung im Bereich der Schule. Man vermutet, dass der Kodex im Unterricht der Trierer Abtei St. Matthias eingesetzt wurde, wo er auch entstanden sein könnte. Die Fabeln des Äsop gehören der Rezension des « Romulus » an. Sie repräsentieren den ältesten vollständig erhaltenen Überlieferungsträger dieser Rezension aus dem Mittelalter. Die Trierer Handschrift fällt in eine Phase starker Überlieferung des Äsop. Zahlreiche Handschriften und Inkunabeln aus Trierer Klöstern bezeugen eine intensive Rezeption des Textes im 14./15. Jahrhundert, sowohl in Versform wie in Prosa, kommentiert oder glossiert, als reine Textausgabe wie mit Illustrationen versehen. Darüber hinaus dokumentiert der « Trierer Äsop » exemplarisch die Transformation paganer Literatur in einen christlichen Verwendungszusammenhang (présentation d’un libraire).</p><bibl><hi rend="sc">Fröhner</hi>, Wilhelm, « Handschriftliches zum Avianus », <title>Philologus</title>, vol. 14 (n<hi rend="sup">os</hi> 1-4), 1859, p. 387.
-                    <hi rend="sc">Gaide</hi>, Françoise (éd.), <title>Avianus. Fables</title>, Paris, Les Belles Lettres, « <hi rend="sc">c.u.f.</hi> », 1980. 148 p.</bibl><p><milestone unit="mentioncr"/>C.R. : <hi rend="sc">J. Küppers</hi>, <hi rend="i">Gnomon</hi>, nº 53, 1981, p. 239‑245.</p><p><milestone unit="bibliteration"/><hi rend="i">—</hi>, « Avianus, ses ambitions, ses résultats », [<hi rend="i">in</hi>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <hi rend="i">La favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</hi>, Assisi, Accademia properziana del Subasio, p. 45‑61.</p><bibl><hi rend="sc">Giurdanella-Fusci</hi>, Giuseppe (éd.), <title>Babrio. Le sue favole e il loro rapporto con le esopiane e con quelle di Fedro e di Aviano</title>, Modica, C. Papa, 1910. 141 p.</bibl><p><milestone unit="analysebiblio"/>Investigates the sources of Babrius and his relationship to Aesopic tradition. Babrius’ connection to Phaedrus and to Avianus is outlined. Now superseded by Perry and Küppers (P.C.).</p><bibl><hi rend="sc">Goldschmidt</hi>, Adolph, <title>An Early Manuscript of the Æsop Fables of Avianus and Related Manuscripts</title>, Princeton, Princeton University Press, « Studies in Manuscript Illumination (1) », 1947. <num>vii</num>‑63 p.</bibl>
-            <p><milestone unit="mentioncr"/>C.R. : J. Hammer, <hi rend="i">Scriptorium</hi>, nº 3, 1949, p. 331‑332.</p>
-            <p><milestone unit="analysebiblio"/>A study of a Carolingian manuscript (Ms. lat. nouv. acq. 1132 in the BN) used as the basis for the study of various illumination techniques for fables from the fifth through the fifteenth centuries. The manuscript itself is described in detail : 40 folios, written in Carolingian miniscule, with a seventeenth- or eighteenth-century binding, unknown earlier history. Full illustrations in facsimile and Goldschmidt has added headings to facilitate study with comparisons drawn from various illuminated manuscripts and the Bayeux Tapestry. (P.C.)</p>
-            <bibl><hi rend="sc">Gottschick</hi>, Reinhold, « Avians Benutzung durch Boner », <title>Zeitschrift für deutsche Philologie</title>, nº 7, 1876, p. 237‑241.</bibl> 
-            <p><milestone unit="analysebiblio"/>Discusses the twenty-two Avianus fables in Boner to demonstrate that, in opposition to Schönbach, Boner did not depend upon the prose paraphrases, the <hi rend="i">Apologi Aviani</hi>, rather used the fables in the received form (P.C.)</p>
-            <bibl><hi rend="sc">Gruber</hi>, Joachim, art. « Avianus », [<title>in</title>] <title>Lexikon des Mittelalters</title>, Munich/Zurich, Artemis, vol. I, 1980, col. 1298.
-              <hi rend="sc">Guaglianone</hi>, Antonio, « Gli “Epimythia” di Aviano », <title>Atti dell’Accademia Pontaniana</title>, nº 5, 1956, p. 353‑377.</bibl>
-            <p><milestone unit="analysebiblio"/>An edition of the epimythia of Avianus with extensive commentary and notes in an attempt to determine their authenticity. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « La tradizione manoscritta di Aviano », <hi rend="i">Rendiconti dell’Accademia di Archeologia, Lettere e Belle Arti di Napoli</hi>, nº 32, 1957, p. 5‑30.</p>
-            <p><milestone unit="analysebiblio"/>This essay begins with a survey of the direct tradition and the quoted and paraphrased tradition of Avianus’ fables and therewith establishes the existence of two separate recensions of the fables. These two traditions, however, show a tendency to recombine in the late Middle Ages. Guaglianone provides a list of the known manuscripts in two categories, according to the recension to which they belong. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « Alcuni codici illustrati e parziali di Aviani », <hi rend="i">Giornale italiano di filologia</hi>, nº 10, 1957, p. 225‑229.</p>
-            <p><milestone unit="analysebiblio"/>A note on the relationships among the Bruxelles 11193, BM Add. 33781, and Parisinus Lat. 1594 manuscripts of Avianus. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>— (éd.), <hi rend="i">Aviani Fabulæ</hi>, Turin, J. B. Paravia, « Corpus Scriptorum Latinorum Paravianum », 1958. <num>lxiv</num>‑122 p.</p>
-            <p><milestone unit="bibliteration"/>—, <hi rend="i">Corpus epimythiorum in Aviani fabulas inde a saec. <num>x</num> exaratorum, iterum recensuit et italice reddidit</hi>, Naples, Armanni, 1959. 39 p.</p>
-            <p><milestone unit="bibliteration"/>—, <hi rend="i">I favolisti latini</hi>, Naples, Giannini, 2000. 603 p.</p>
-            <p><milestone unit="mentioncr"/>C.R. : <hi rend="sc">F. Ficca</hi>, <hi rend="i">Bollettino di Studi Latini</hi>, vol. 30 (n<hi rend="sup">o</hi> 2), juil.-déc. 2000, p. 687‑689.</p>
-            <bibl><hi rend="sc">Heidenhain</hi>, Friedrich, <title>Zu den Apologi Aviani (Wissenschftliche Beilage zum Programm des Königlichen Gymnasiums zu Strasburg, Ostern 1894)</title>, Strasbourg, A. Fuhrich, 1894. 15 p.</bibl> 
-            <p><milestone unit="analysebiblio"/>The <hi rend="i">apologi Aviani</hi> are prose reworkings of the fables of Avianus, found in two manuscripts of the Bibliothèque Nationale (Cod. Lat. 347 A and B) without nos. 19, 25, 26 and 38. Often the paraphrases are somewhat better motivated than the originals. Heidenhain feels he has found an older tradition than the verse fables in the received tradition. Avianus 9, P65 « Travelers and the Bear » (A-T 179 ; TMI J1488), for example, has a lion in the paraphrase, which is taken as evidence of an earlier tradition (P.C.).</p>
-            <p><milestone unit="bibliteration"/>—, « Zur Rettung des Avianus. Weitere Bemerkungen über die <hi rend="i">Apologi Aviani</hi> », <hi rend="i">Neue Jahrbücher für classische Philologie und Pädagogik</hi>, n<hi rend="sup">o</hi> 151, 1895, p. 837-855.</p>
-            <p><milestone unit="analysebiblio"/>Assumes that Avianus used a text as his source that was fundamentally the same as that we have today and deduces from that that a more « complete » text of Avianus lies at the basis of the text we have received. The author uses Greek loan words and seemed to know the « Romulus » tradition, having used the latter at the end of P230 « Turtle and the Eagle » (A-T 225A; TMI J512, J657.2). (P.C.)</p>
-            <bibl><hi rend="sc">Herrmann</hi>, Léon,  « Notes sur deux manuscrits anversois des fables d’Avianus », <title>Latomus</title>, nº 3, 1939, p. 119-125.</bibl> 
-            <p><milestone unit="analysebiblio"/>Collation of MSS 340 and 140 of the Musée Plantin-Movetus (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « L’auteur du <hi rend="i">Querolus</hi> », <hi rend="i">Revue belge de philologie et d’histoire</hi>, n<hi rend="sup">o</hi>  26, 1948, p. 538-540.</p>
-            <p><milestone unit="analysebiblio"/>The comedy of Querolus is supposed to be the last work by the fabulist Avianus (P.C.)</p>
-            <p><milestone unit="bibliteration"/>— (éd.), <hi rend="i">Avianus. Œuvres</hi>, Bruxelles, Latomus, « Latomus (96) », 1968. 177 p.</p>
-            <p><milestone unit="analysebiblio"/>The « Œuvres » of Avianus consist not only of the fables but also of the comedy <hi rend="i">Querolus</hi> and some poems. The fables are discussed in detail in the introduction in which the authenticity of the morals is also dealt with. (P.C.)</p>
-            <p>—, « Notes sur le texte d’Avianus », <hi rend="i">Latomus</hi>, nº 28, 1969, p. 669-680.</p>
-            <p><milestone unit="analysebiblio"/>A series of notes to his edition of Avianus. The first section comprises various textual notes to the fables; the second on the putative authorship of <hi rend="i">Querolus</hi> ; and the third on the « poems » of Avianus (P.C.).</p>
-            <bibl><hi rend="sc">Holder</hi>, Alfred, « Zu Avianus », <title>Philologus</title>, nº 65, 1906, p. 91-96.</bibl> 
-            <p><milestone unit="analysebiblio"/>Avianus’ Preface and some twenty-nine fables are found in Karlsruh Codex LXXIII from the tenth Century. The manuscript appears to have no new variant readings, but the collation has value for determining the family tree of a group of manuscripts. (P.C.)</p>
-            <bibl><hi rend="sc">Huemer</hi>, Johannes, « Zu Avian », <title>Wiener Studien. Zeitschrift für klassische Philologie, Patristik und lateinische Tradition</title>, nº 2, 1880, p. 158‑160.</bibl> 
-            <p><milestone unit="analysebiblio"/>Presents variant readings of distiches from Avianus 22, 10-16; 21, 22; 31 and 32. (P.C.)</p>
-            <bibl><hi rend="sc">IJsewijn</hi>, Jozef, « <title>Avianus Titiani fabulas num retractauerit</title> ? », <title>Latinitas</title>, nº 29, 1981, p. 42‑43.
-              <hi rend="sc">Jenkinson</hi>, F., « The Fables of Avian », <title>The Academy</title>, nº 45, 1894, p. 129.
-              <hi rend="sc">Jones</hi>, Edith C., <title>Avianus in the Middle Ages. Manuscripts and other Evidences of Nachleben</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D. non-publiée), 1944. 230 p.</bibl>
-            <p><milestone unit="bibliteration"/>—, « Avianus », <hi rend="i">Lexikon der Alten Welt</hi>, Zurich / Stuttgart, Artemis, 1965, col. 420 <hi rend="i">sqq</hi>.</p>
-            <bibl><hi rend="sc">Jones</hi>, William Robert, <title>The Text Tradition of Avianus</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D. non-publiée), 1940. 44 p.</bibl>
-            <p><milestone unit="analysebiblio"/>Works out a complex classification scheme to categorize and evaluate the known manuscripts of Avianus. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « Thomas Nast and the Æsopic fables of Avianus », <hi rend="i">Classical Bulletin</hi>, nº 18, 1941, p. 18-19.</p>
-            <p><milestone unit="bibliteration"/>—, « Avianus, Flavianus, Theodosius, and Macrobius », [<hi rend="i">in</hi>] <hi rend="i">Classical Studies Presented to Ben Edwin Perry by his Students and Colleagues at the University of Illinois, 1924-1960</hi>, Urbana, University of Illinois Press, « Illinois Studies in Language and Literature (58) », 1969, p. 203‑209.</p>
-            <p><milestone unit="analysebiblio"/>Suggests the possible identification of Avianus with Flavianus, who was supposedly in favor with the Emperor Theodosius, to whom the fables of Avianus appear to have been dedicated. (P.C.)</p>
-            <bibl><hi rend="sc">Klein</hi>, Thomas (éd.), « Alexander Neckam <title>Nouus Avianus</title> », [<title>in</title>] <hi rend="sc">F. Bertini</hi> (dir.), <title>Favolisti latini medievali e umanistici VII</title>, Gênes, <hi rend="sc">d.ar.fi.cl.et. «</hi> Francesco Della Corte », « Favolisti latini medievali e umanistici (7) », 1998, p. 99‑136.
-              <hi rend="sc">Küppers</hi>, Jochem, <title>Die Fabeln Avians. Studien zu Darstellung und Erzählweise spätantiker Fabeldichtung</title>, Bonn, R. Habelt, « Habelts Dissertationsdrucke. Reihe Klassische Philologie (26) », 1977. 252 p.</bibl>
-            <p><milestone unit="mentioncr"/>C.R. : John <hi rend="sc">Henderson</hi>, <hi rend="i">The Classical Review</hi>, vol. 29 (nº 2), oct. 1979, p. 312‑313.</p>
-            <p><milestone unit="analysebiblio"/>Küppers spends much energy in reordering Avianus research by setting aside the previous work of Ellis and Herrmann especially, and to a lesser extent, Crusius and Cameron, as well as Jones and Thraede. Küppers deals with all the major issues : the name of the poet, the Theodosio problem, and the origin of the fables themselves. Küppers deals with the divergences from the Babrian original as Avianus’ own artistic contribution and argues for Avianus’ translation as Coming directly out of the Greek, rather than through a Latin intermediary. Full and useful bibliographies and indices. (P.C.)</p>
-            <bibl><hi rend="sc">Lachmann</hi>, Karl, <title>De Aviani Fabulis 4, 2, 23, 27 (Prooemium indicis lectionum aestivarum a. 1845)</title>, Berolini, 1845 (4 p.) ; repris sous le titre « De Aviani fabulis » dans <title>Kleinere Schriften zur classischen Philologie</title>, Berlin G. Heimer, t. 2, 1876, p. 51-56.
-              <hi rend="sc">Lee</hi>, A. G., « Avianus, fabula XXI, 12 », <title>Proceedings of the Cambridge Philological Society</title>, nº 181, 1950-1951, p. 3‑4.</bibl> 
-            <p><milestone unit="analysebiblio"/>Textual notes to P325 « Lark and Farmer » (A-T 93; TMI J1031). (P.C.)</p>
-            <bibl><hi rend="sc">Luzzatto</hi>, Maria Jogada, « Note su Aviano e sulle raccolte esopiche greco‑latine », <title>Prometheus</title>, nº 10, 1984, p. 75‑94.
-              <hi rend="sc">Malein</hi>, A., « Fragments de manuscrits d’Avianus au Musée de paléographie », <title>Comptes rendus de l’Académie des sciences de l’URSS</title>, 1926, p. 85‑87.</bibl>
+            <head>Études (bibliographie critique par ordre alphabétique d’auteurs, éventuellement
+              subdivisée en sections thématiques)</head>
+            <bibl><hi rend="sc">Achelis</hi>, Thomas Otto, « Die Fabeln Avians in Steinhöwel’s
+              Æsop », <hi rend="i">Münchener Museum für Philologie des Mittelalters und der
+                Renaissance</hi>, nº 4, 1924, p. 195‑221.</bibl>
+            <quote type="comment">Lenghty discussion of the twenty-seven fables from the Avianus
+              collection that Steinhöwel chose and translated for his 1476-1477 Ulm edition. Textual
+              problems as well as the choice of fables are discussed with an analysis of those
+              fabular motif in Avianus, which had already appeared in early sections of Steinhöwel’s
+              collection. Tables of concordance and keys to Halm. Extensively discussed are P70
+              (« The Oak and the Reed » (A-T 28C ; TMI J832) and P525 « Bald Man and the Fly » (TMI
+              J2102.3) (P.C.).</quote>
+            <bibl><hi rend="sc">Bährens</hi>, Emil, « Ad Avianum », [<hi rend="i">in</hi>]
+                <title>Miscellanea critica</title>, Groningen, in aedibus J. B. Woltersii, 1878,
+              p. 176‑194. <hi rend="sc">Baldzuhn</hi>, Michæl, « “<title>Quidquid placet</title>”.
+              Stellung und Gebrauchsformen der <title>Fabulæ Auiani</title> im Schulunterricht des
+              15. Jahrhunderts », [<hi rend="i">in</hi>] <hi rend="sc">M. Kintzinger</hi>, <hi
+                rend="sc">S. Lorenz</hi>, &amp; <hi rend="sc">M. Walter</hi> (dir.), <title>Schule
+                und Schüler im Mittelalter. Beiträge zur europäischen Bildungsgeschichte des 9. bis
+                15. Jahrhunderts</title>, Cologne/Weimar/Vienne, Böhlau, 1996, p. 327‑383.</bibl>
+            <bibl>—, « Avian im Gebrauch. Zur Verwendung von Schulhandschriften im Unterricht »,
+                [<hi rend="i">in</hi>] <hi rend="sc">C. Meier</hi>, <hi rend="sc">D. Hüpper</hi>,
+              &amp; <hi rend="sc">H. Keller</hi> (dir.), <hi rend="i">Der Codex im Gebrauch. Akten
+                des Internationalen Kolloquiums (11.-13. Juni 1992)</hi>, Munich, W. Fink, 1996,
+              p. 183-196, &amp; p. <hi rend="sc">xxxxiv‑xlv</hi>.</bibl>
+            <bibl>—, « Schriftliche Textauslegung und mündlicher Unterricht. Das Beispiel der
+              älteren lateinisch und volkssprachlich glossierten Aviane (9.-11. Jahrhundert) », [<hi
+                rend="i">in</hi>] <hi rend="sc">R. Bergmann</hi>, <hi rend="sc">E. Glaser</hi>,
+              &amp; <hi rend="sc">C. Moulin-Fankhänel</hi> (dir.), <hi rend="i">Mittelalterliche
+                volkssprachliche Glossen. Internationale Fachkonferenz des Zentrums für
+                Mittelalterstudien der Otto-Friedrich-Universität Bamberg, 2. bis 4. August
+                1999</hi>, Heidelberg, Winter, 2001, p. 485‑512.</bibl>
+            <bibl>—, « Schulunterricht und Verschriftlichungsprozess. Forschungsansätze und
+              Forschungsergebnisse », [<hi rend="i">in</hi>] <hi rend="sc">C. Meier</hi>, <hi
+                rend="sc">V. Honemann</hi>, <hi rend="sc">H. Keller</hi>, &amp; <hi rend="sc"
+                >R. Suntrup</hi> (dir.), <hi rend="i">Pragmatische Dimensionen mittelalterlicher
+                Schriftkultur. Akten des Internationalen Kolloquiums (26.-29. Mai 1999)</hi>,
+              Munich, W. Fink, 2002, p. 161‑175.</bibl>
+            <bibl>—, art. « Avian », [<hi rend="i">in</hi>] <hi rend="sc">K. Ruh</hi>, &amp; <hi
+                rend="sc">B. Wachinger</hi> (dir.), <hi rend="i">Die deutsche Literatur des
+                Mittelalters. Verfasserlexikon (2. völlig neu bearbeitete Auflage)</hi>, Berlin, W.
+              de Gruyter, 1977‑2008, vol. 11, 2004, col. 195‑204.</bibl>
+            <bibl>—, <hi rend="i">Schulbücher im Trivium des Mittelalters und der Frühen Neuzeit.
+                Die Verschriftlichung von Unterricht in der Text- und Überlieferungsgeschichte der
+                « Fabulæ » Avians und der deutschen « Disticha Catonis »</hi>, Berlin/New York,
+              W. de Gruyter, « Quellen und Forschungen zur Literatur- und
+              Kulturgeschichte (44/278) », 2009, 2 vol. <num>xiii</num>‑1128 p. C.R. : <hi rend="sc"
+                >J. Knödler</hi>, <hi rend="i"><hi rend="sc">iasl</hi> online</hi> [en ligne],
+              26.09.2011. <hi rend="sc">url</hi> : <ref
+                target="http://www.iaslonline.lmu.de/index.php?vorgang_id=3296"
+                >http://www.iaslonline.lmu.de/index.php?vorgang_id=3296</ref> (15.05.2013) ; Ch. <hi
+                rend="sc">Roth</hi>, <hi rend="i">Zeitschrift für deutsches Altertum und deutsche
+                Literatur</hi>, nº 140, 2011, p. 359‑363.</bibl>
+            <bibl><hi rend="sc">Bedrick</hi>, Theodore, <title>The Prose Adaptations of
+                Avianus</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D.
+              non-publiée), 1941. 219 p.</bibl>
+            <quote type="comment">The medieval rewritings and prose paraphrases of Avianus during
+              the Middle Ages are discussed. The use of Avianus in schools as a medium for the
+              instruction of Latin is highlighted (P.C.)</quote>
+            <bibl><hi rend="sc">Bibring</hi>, Tovi, « Réécritures fabulistiques au Moyen Âge.
+              Adaptations latine, vernaculaire et hébraïque d’une fable d’Avianus, “<title>De Simia
+                et Natis</title>” », [<hi rend="i">in</hi>] <hi rend="sc">N. Catellani-Dufrêne</hi>,
+              &amp; <hi rend="sc">M. Perrin</hi> (dir.), <title>La lyre et la pourpre. Poésie latine
+                et politique de l’Antiquité latine à la Renaissance</title>, Rennes, Presses
+              universitaires de Rennes, 2012, p. 267‑280.</bibl>
+            <bibl>—, « On Heartlessness and Senselessness. An Inquiry on an Exemplary Theme : from
+              the “Sick Lion” (the <hi rend="i">Panchatantra</hi>, Babrius, Marie de France) to the
+              “Disobedient Boar” (Avianus, Berechiah Ha-Nakdan, <hi rend="i">Gesta
+              romanorum</hi>) », dans M.‑Ch. <hi rend="sc">Bornes-Varol</hi>, &amp; M.‑<hi rend="sc"
+                >S. Ortola</hi> (dir.), <hi rend="i">Énoncés sapientiels et littérature exemplaire :
+                une intertextualité complexe</hi>, Nancy, Presses universitaires de Nancy-Éditions
+              universitaires de Lorraine, « Aliento (3) », 2013, p. 351‑384.</bibl>
+            <bibl><hi rend="sc">Bisanti</hi>, Armando, « La favola esopica nel Medioevo : un
+              itinerario didattico fra teoria ed esemplificazione », [<hi rend="i">in</hi>] <hi
+                rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <title>La
+                favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi,
+                26-28 ottobre 1990)</title>, Assise, Accademia Properziana del Subasio, 1991,
+              p. 161‑212.</bibl>
+            <bibl>—, « Pier Damiani e una favola di Aviano », <hi rend="i">Civiltà Classica e
+                Cristiana</hi>, vol. 14 (nº 3), 1993, p. 313‑330.</bibl>
+            <bibl>—, &amp; <hi rend="sc">Zurli</hi>, Loriano (éd.), <hi rend="i">Astensis Poetae
+                Novus Avianus</hi>, Gênes, <hi rend="sc">d.ar.fi.cl.et. «</hi> Francesco Della
+              Corte », « Favolisti latini medievali e umanistici (5) », 1994. 236 p.</bibl>
+            <bibl>—, « Edizioni e studi sulla favolistica mediolatina », <hi rend="i">Schede
+                Medievali. Rassegna dell’Officina di studi medievali</hi>, nº 40, 2002,
+              p. 93‑142.</bibl>
+            <bibl>—, « Il <hi rend="i">Nouus Auianus</hi> di Alessandro Neckam nel quadro delle
+              riscritture mediolatine di Aviano », <hi rend="i">Maia. Rivista di letterature
+                classiche</hi>, vol. 54 (nº 2), 2002, p. 295‑350.</bibl>
+            <bibl>—, « Appunti sulla fortuna mediolatina e romanza dei <hi rend="i">Noui
+              Auiani</hi> », <hi rend="i">Maia. Rivista di letterature classiche</hi>, vol. 56
+              (nº 1), 2004, p. 127‑138, repris sous une forme légèrement remaniée dans <hi rend="i"
+                >Mittellateinisches Jahrbuch</hi>, vol. 39 (nº 2), 2004, p. 207‑218.</bibl>
+            <bibl>—, « Il <hi rend="i">Nouus Avianus Astensis</hi> », <hi rend="i">Maia. Rivista di
+                letterature classiche</hi>, vol. 58 (nº 1), 2006, p. 91‑118.</bibl>
+            <bibl>—, « Sull’edizione critica del <hi rend="i">Novus Avianus Vindobonensis</hi> »,
+                <hi rend="i">Schede Medievali. Rassegna dell’Officina di studi medievali</hi>,
+              nº 47, 2009, p. 235‑249.</bibl>
+            <bibl>—, <hi rend="i">Le Favole di Aviano e la loro fortuna nel Medioevo</hi>, Florence,
+                <hi rend="sc">S.i.s.m.e.l.</hi>/Edizioni del Galluzzo, « Millennio Medievale (85) »
+              &amp; « Strumenti e studi (25) », 2010. <num>xii</num>‑190 p.</bibl>
+            <bibl><hi rend="sc">Boivin</hi>, Jeanne-Marie, <title>Naissance de la fable en français.
+                L’Isopet de Lyon et l’Isopet I‑Avionnet</title>, Paris, H. Champion, « Essais sur le
+              Moyen Âge (33) », 2006. 499 p. (voir notamment : « Avianus : la fable élégiaque »,
+              p. 53‑76 ; «  Table de concordance des fables de l’<title>Avionnet</title>, d’Avianus,
+              de l’<title>Isopet de Chartres</title>, du <title>Fragment d’York</title>, de l’Ésope
+              de Macho et de La Fontaine », p. 451 ; « Évolution de la taille des apologues (récits
+              &amp; moralités) et de la prise de parole directe d’Avianus à
+                l’<title>Avionnet</title> », p. 463 ; « Les différents types de moralités :
+              d’Avianus à l’<title>Avionnet</title> », p. 466). C.R. : <hi rend="sc">L. Brun</hi>,
+                <hi rend="i">Cahiers de Recherches Médiévales et Humanistes</hi> (en ligne), 2006.
+                <hi rend="sc">url</hi> : <ref target="http://crm.revues.org/2713"
+                >http://crm.revues.org/2713</ref> ; Ph. <hi rend="sc">Ménard</hi>, <hi rend="i"
+                >Zeitschrift für romanische Philologie</hi>, vol. 125 (nº 4), 2009,
+              p. 743‑745.</bibl>
+            <bibl><hi rend="sc">Boretsky</hi>, M. I., « Das Problem des Names des römischen
+              Fabeldichters Avian », <title>Pytanna klasysnoji filolohiji. Questions de philologie
+                classique</title>, nº 14, 1977, p. 83‑90 [article en ukrainien avec résumés en
+              allemand et en russe].</bibl>
+            <quote type="comment">Avianus is confirmed as the proper name of the fourth-century
+              fable-poet, the carrier of the Babrian tradition, very popular during the Middle Ages.
+              Fairly extensive analysis of the arguments for and against the name and reasons for
+              the many variants of the name found in the manuscript tradition. Good bibliography
+              (P.C.).</quote>
+            <bibl>—, « Essay on the Utilization of a Lexical System for the Comparative Analysis of
+              the Fables of Avianus and Babrius », <hi rend="i">Pytanna klasysnoji Filolohiji.
+                Questions de philologie classique</hi>, nº 15, 1978, p. 55‑78 [article en russe avec
+              résumés en anglais et en allemand].</bibl>
+            <quote type="comment">Comparative study of the use of various differing terms within
+              specific semantic categories results in a very specific close relationship between the
+              two poets. There can be no doubt of the influence of Babrius on Avianus, the author
+              concludes although the exact nature of this influence is not yet definable
+              (P.C.).</quote>
+            <bibl>—, « The Artistic Universe and Lexical Frequency in Poetic Works (on the Example
+              of the Classical Literary Fable) », <hi rend="i">Izvestija AN SSR. Ser. literatury i
+                Jazyka</hi>, vol. 37 (nº 5), 1978, p. 453‑461.</bibl>
+            <quote type="comment">An attempt to reconstruct the social and artistic milieu for the
+              classical fabulists : Phaedrus, Babrius, and Avianus by means of lexical frequency
+              counts (P.C.).</quote>
+            <bibl>—, &amp; <hi rend="sc">Kronik</hi>, A. A., « Opyt analiza nekotorkh storon
+              sotsial’no-psikhologicheskoy atmosphery antichnoy literaturnoy basni », <hi rend="i"
+                >Vesnik Drevnej Istorii</hi>, nº 145, 1978, p. 157‑168.</bibl>
+            <quote type="comment">This article attempts to describe and evaluate the interpersonal
+              relationships in the fables of Phaedrus, Babrius, and Avianus by means of a close
+              analysis of the nouns used in the fables which describe or otherwise contain
+              information about the nature of various relationships. A clear idea of the
+              social-psychological atmosphere of each poet is determined by a construct of nine
+              types of relationships among which the lexical items are distributed. The authors
+              suggest that this work is potentially important for research in other Problems
+              connected with these fabulists (P.C.).</quote>
+            <bibl><hi rend="sc">Cameron</hi>, Alan, « Macrobius, Avienus and Avianus », <title>The
+                Classical Quarterly</title>, vol. 17 (nº 2), déc. 1967, p. 385‑399.</bibl>
+            <quote type="comment">Dating Avianus is aided by Claudian’s <hi rend="i">De bello
+                gildonico</hi> (398) : Theodosius identified with Macrobius. Cameron suggests that
+              Avianus used a Latin translation of Babrius (by Julius Titianus), which solves many
+              Problems. Contains a good survey of the cluster of problems of Avianus’ name and
+              concludes that the proper form is Avienus. (P.C.)</quote>
+            <bibl><hi rend="sc">Catanzaro</hi>, Giuseppe, &amp; <hi rend="sc">Santucci</hi>,
+              Francesco (dir.), <title>La favolistica latina in distici elegiaci. Atti del convegno
+                internazionale (Assisi, 26-28 ottobre 1990)</title>, Assisi, Accademia properziana
+              del Subasio, « Centro studi poesia latina in distici elegiaci (2) », 1991. 235 p. <hi
+                rend="sc">Crusius,</hi> Otto, « Avian. XXVIII 7 », <title>Philologus. Zeitschrift
+                für antike Literatur und ihre Rezeption</title>, vol. 47 (nº 3), 1889,
+              p. 399.</bibl>
+            <bibl>—, « The Fables of Avianus (Ellis) », <hi rend="i">Jahrbücher für classische
+                Philologie</hi>, nº 139, 1889, p. 641‑656.</bibl>
+            <quote type="comment">Very comprehensive review of Ellis’ Oxford edition of Avianus.
+              Crusius praises Ellis although he suggests that Ellis might have spent more time with
+              the manuscripts and should have provided an overview on the comparative relationship
+              between Avianus and Babrius. Crusius sees an intermediary of Titian’s Latin prose
+              paraphrase between Avianus and Babrius. Long list of emendations, corrections.
+              (P.C.)</quote>
+            <bibl>—, « Zu den alten Fabeldichtern. I. Avian und die sogen. <hi rend="i">Apologi
+                Aviani</hi> », <hi rend="i">Philologus. Zeitschrift für antike Literatur und ihre
+                Rezeption</hi>, vol. 54 (nº 3), 1895, p. 474‑488.</bibl>
+            <quote type="comment">Treated Avianus and his dates and the « apologi » fables. The
+              paraphrase of Avianus, for which Heidenhain had claimed a more complete text had been
+              used, is demonstrated to be a relatively simple paraphrase of Avianus from a text that
+              basically the same of our received text. Therefore we can learn little to help the
+              Avianus tradition itself. Ends with a number of notes for the Avianus fables.
+              (P.C.)</quote>
+            <bibl>—, « Avianus », [<hi rend="i">in</hi>] <hi rend="sc">G. Wissowa</hi> (dir.),<hi
+                rend="i"> Paulys Real-Encyclopädie der classischen Altertumswissenschaft. Neue
+                Bearbeitung</hi>, Stuttgart, J. B. Metzler, vol. II (<hi rend="i"
+                >Apollon-Barbaroi</hi>), 1896, col. 2373‑2378.</bibl>
+            <quote type="comment">Various theories of the time and person of Avianus are discussed,
+              including an extensive reviex of the ideas of Ellis and Cannegieter. The 42-fables
+              Avianus collection is described in terms of its relationship to Babrius, followed by a
+              summary of the life of the collection and its diffusion. (P.C.)</quote>
+            <bibl><hi rend="sc">De Paulis</hi>, Guido, <title>Aviani Index et Lexicon</title>,
+              Hidesheim/Zurich/New York, Olms-Weidmann, « Alpha-Omega. Reihe A. Lexika, Indizes,
+              Konkordanzen zur klassischen Philologie (184) », 1997, <num>vi</num>-468 p. <hi
+                rend="sc">Draheim</hi>, Johannes, « <title>De Aviani elegis</title> »,
+                <title>Jahrbücher für classische Philologie</title>, nº 143, 1891,
+              p. 509-511.</bibl>
+            <quote type="comment">Various notes on the verse forms of Avianus’ fables as
+              reconstructed in part from the corrupt received forms. (P.C.)</quote>
+            <bibl><hi rend="sc">Embach</hi>, Michæl (éd.), <title>Der « Trierer Äsop » (StB Trier,
+                Hs. 1108/55 4°). Eine illustrierte Fabelhandschrift im Kontext ihrer
+                Überlieferung</title>, Trèves, Paulinus, « Kostbarkeiten der Stadtbibliothek Trier
+              (3) », 2008. 100 p.</bibl>
+            <quote type="comment">Der dritte Band der « Kostbarkeiten der Stadtbibliothek Trier »
+              stellt den « Trierer Äsop » vor, eine reichlich illustrierte Handschrift aus der Zeit
+              um 1380. Der Kodex enthält illustrierte Ausgaben der Fabeln des Äsop und des Avian,
+              jeweils in mittelalterlichen Bearbeitungen sowie ausgestattet mit knappen Auslegungen.
+              Text und Illustrationen verweisen auf eine Verwendung im Bereich der Schule. Man
+              vermutet, dass der Kodex im Unterricht der Trierer Abtei St. Matthias eingesetzt
+              wurde, wo er auch entstanden sein könnte. Die Fabeln des Äsop gehören der Rezension
+              des « Romulus » an. Sie repräsentieren den ältesten vollständig erhaltenen
+              Überlieferungsträger dieser Rezension aus dem Mittelalter. Die Trierer Handschrift
+              fällt in eine Phase starker Überlieferung des Äsop. Zahlreiche Handschriften und
+              Inkunabeln aus Trierer Klöstern bezeugen eine intensive Rezeption des Textes im
+              14./15. Jahrhundert, sowohl in Versform wie in Prosa, kommentiert oder glossiert, als
+              reine Textausgabe wie mit Illustrationen versehen. Darüber hinaus dokumentiert der
+              « Trierer Äsop » exemplarisch die Transformation paganer Literatur in einen
+              christlichen Verwendungszusammenhang (présentation d’un libraire).</quote>
+            <bibl><hi rend="sc">Fröhner</hi>, Wilhelm, « Handschriftliches zum Avianus »,
+                <title>Philologus</title>, vol. 14 (n<hi rend="sup">os</hi> 1-4), 1859, p. 387. <hi
+                rend="sc">Gaide</hi>, Françoise (éd.), <title>Avianus. Fables</title>, Paris, Les
+              Belles Lettres, « <hi rend="sc">c.u.f.</hi> », 1980. 148 p. C.R. : <hi rend="sc"
+                >J. Küppers</hi>, <hi rend="i">Gnomon</hi>, nº 53, 1981, p. 239‑245.</bibl>
+            <bibl><hi rend="i">—</hi>, « Avianus, ses ambitions, ses résultats », [<hi rend="i"
+                >in</hi>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi>
+              (dir.), <hi rend="i">La favolistica latina in distici elegiaci. Atti del convegno
+                internazionale (Assisi, 26-28 ottobre 1990)</hi>, Assisi, Accademia properziana del
+              Subasio, p. 45‑61.</bibl>
+            <bibl><hi rend="sc">Giurdanella-Fusci</hi>, Giuseppe (éd.), <title>Babrio. Le sue favole
+                e il loro rapporto con le esopiane e con quelle di Fedro e di Aviano</title>,
+              Modica, C. Papa, 1910. 141 p.</bibl>
+            <quote type="comment">Investigates the sources of Babrius and his relationship to
+              Aesopic tradition. Babrius’ connection to Phaedrus and to Avianus is outlined. Now
+              superseded by Perry and Küppers (P.C.).</quote>
+            <bibl><hi rend="sc">Goldschmidt</hi>, Adolph, <title>An Early Manuscript of the Æsop
+                Fables of Avianus and Related Manuscripts</title>, Princeton, Princeton University
+              Press, « Studies in Manuscript Illumination (1) », 1947. <num>vii</num>‑63 p. C.R. :
+              J. Hammer, <hi rend="i">Scriptorium</hi>, nº 3, 1949, p. 331‑332.</bibl>
+            <quote type="comment">A study of a Carolingian manuscript (Ms. lat. nouv. acq. 1132 in
+              the BN) used as the basis for the study of various illumination techniques for fables
+              from the fifth through the fifteenth centuries. The manuscript itself is described in
+              detail : 40 folios, written in Carolingian miniscule, with a seventeenth- or
+              eighteenth-century binding, unknown earlier history. Full illustrations in facsimile
+              and Goldschmidt has added headings to facilitate study with comparisons drawn from
+              various illuminated manuscripts and the Bayeux Tapestry. (P.C.)</quote>
+            <bibl><hi rend="sc">Gottschick</hi>, Reinhold, « Avians Benutzung durch Boner »,
+                <title>Zeitschrift für deutsche Philologie</title>, nº 7, 1876, p. 237‑241.</bibl>
+            <quote type="comment">Discusses the twenty-two Avianus fables in Boner to demonstrate
+              that, in opposition to Schönbach, Boner did not depend upon the prose paraphrases, the
+                <hi rend="i">Apologi Aviani</hi>, rather used the fables in the received form
+              (P.C.)</quote>
+            <bibl><hi rend="sc">Gruber</hi>, Joachim, art. « Avianus », [<hi rend="i">in</hi>]
+                <title>Lexikon des Mittelalters</title>, Munich/Zurich, Artemis, vol. I, 1980, col.
+              1298. <hi rend="sc">Guaglianone</hi>, Antonio, « Gli “Epimythia” di Aviano »,
+                <title>Atti dell’Accademia Pontaniana</title>, nº 5, 1956, p. 353‑377.</bibl>
+            <quote type="comment">An edition of the epimythia of Avianus with extensive commentary
+              and notes in an attempt to determine their authenticity. (P.C.)</quote>
+            <bibl>—, « La tradizione manoscritta di Aviano », <hi rend="i">Rendiconti dell’Accademia
+                di Archeologia, Lettere e Belle Arti di Napoli</hi>, nº 32, 1957, p. 5‑30.</bibl>
+            <quote type="comment">This essay begins with a survey of the direct tradition and the
+              quoted and paraphrased tradition of Avianus’ fables and therewith establishes the
+              existence of two separate recensions of the fables. These two traditions, however,
+              show a tendency to recombine in the late Middle Ages. Guaglianone provides a list of
+              the known manuscripts in two categories, according to the recension to which they
+              belong. (P.C.)</quote>
+            <bibl>—, « Alcuni codici illustrati e parziali di Aviani », <hi rend="i">Giornale
+                italiano di filologia</hi>, nº 10, 1957, p. 225‑229.</bibl>
+            <quote type="comment">A note on the relationships among the Bruxelles 11193, BM Add.
+              33781, and Parisinus Lat. 1594 manuscripts of Avianus. (P.C.)</quote>
+            <bibl>— (éd.), <hi rend="i">Aviani Fabulæ</hi>, Turin, J. B. Paravia, « Corpus
+              Scriptorum Latinorum Paravianum », 1958. <num>lxiv</num>‑122 p.</bibl>
+            <bibl>—, <hi rend="i">Corpus epimythiorum in Aviani fabulas inde a saec. <num>x</num>
+                exaratorum, iterum recensuit et italice reddidit</hi>, Naples, Armanni,
+              1959. 39 p.</bibl>
+            <bibl>—, <hi rend="i">I favolisti latini</hi>, Naples, Giannini, 2000. 603 p. C.R. : <hi
+                rend="sc">F. Ficca</hi>, <hi rend="i">Bollettino di Studi Latini</hi>, vol. 30 (n<hi
+                rend="sup">o</hi> 2), juil.-déc. 2000, p. 687‑689.</bibl>
+            <bibl><hi rend="sc">Heidenhain</hi>, Friedrich, <title>Zu den Apologi Aviani
+                (Wissenschftliche Beilage zum Programm des Königlichen Gymnasiums zu Strasburg,
+                Ostern 1894)</title>, Strasbourg, A. Fuhrich, 1894. 15 p.</bibl>
+            <quote type="comment">The <hi rend="i">apologi Aviani</hi> are prose reworkings of the
+              fables of Avianus, found in two manuscripts of the Bibliothèque Nationale (Cod. Lat.
+              347 A and B) without nos. 19, 25, 26 and 38. Often the paraphrases are somewhat better
+              motivated than the originals. Heidenhain feels he has found an older tradition than
+              the verse fables in the received tradition. Avianus 9, P65 « Travelers and the Bear »
+              (A-T 179 ; TMI J1488), for example, has a lion in the paraphrase, which is taken as
+              evidence of an earlier tradition (P.C.).</quote>
+            <bibl>—, « Zur Rettung des Avianus. Weitere Bemerkungen über die <hi rend="i">Apologi
+                Aviani</hi> », <hi rend="i">Neue Jahrbücher für classische Philologie und
+                Pädagogik</hi>, n<hi rend="sup">o</hi> 151, 1895, p. 837-855.</bibl>
+            <quote type="comment">Assumes that Avianus used a text as his source that was
+              fundamentally the same as that we have today and deduces from that that a more
+              « complete » text of Avianus lies at the basis of the text we have received. The
+              author uses Greek loan words and seemed to know the « Romulus » tradition, having used
+              the latter at the end of P230 « Turtle and the Eagle » (A-T 225A; TMI J512, J657.2).
+              (P.C.)</quote>
+            <bibl><hi rend="sc">Herrmann</hi>, Léon, « Notes sur deux manuscrits anversois des
+              fables d’Avianus », <title>Latomus</title>, nº 3, 1939, p. 119-125.</bibl>
+            <quote type="comment">Collation of MSS 340 and 140 of the Musée Plantin-Movetus
+              (P.C.)</quote>
+            <bibl>—, « L’auteur du <hi rend="i">Querolus</hi> », <hi rend="i">Revue belge de
+                philologie et d’histoire</hi>, n<hi rend="sup">o</hi>  26, 1948, p. 538-540.</bibl>
+            <quote type="comment">The comedy of Querolus is supposed to be the last work by the
+              fabulist Avianus (P.C.)</quote>
+            <bibl>— (éd.), <hi rend="i">Avianus. Œuvres</hi>, Bruxelles, Latomus, « Latomus (96) »,
+              1968. 177 p.</bibl>
+            <quote type="comment">The « Œuvres » of Avianus consist not only of the fables but also
+              of the comedy <hi rend="i">Querolus</hi> and some poems. The fables are discussed in
+              detail in the introduction in which the authenticity of the morals is also dealt with.
+              (P.C.)</quote>
+            <p>—, « Notes sur le texte d’Avianus », <hi rend="i">Latomus</hi>, nº 28, 1969,
+              p. 669-680.</p>
+            <quote type="comment">A series of notes to his edition of Avianus. The first section
+              comprises various textual notes to the fables; the second on the putative authorship
+              of <hi rend="i">Querolus</hi> ; and the third on the « poems » of Avianus
+              (P.C.).</quote>
+            <bibl><hi rend="sc">Holder</hi>, Alfred, « Zu Avianus », <title>Philologus</title>,
+              nº 65, 1906, p. 91-96.</bibl>
+            <quote type="comment">Avianus’ Preface and some twenty-nine fables are found in Karlsruh
+              Codex LXXIII from the tenth Century. The manuscript appears to have no new variant
+              readings, but the collation has value for determining the family tree of a group of
+              manuscripts. (P.C.)</quote>
+            <bibl><hi rend="sc">Huemer</hi>, Johannes, « Zu Avian », <title>Wiener Studien.
+                Zeitschrift für klassische Philologie, Patristik und lateinische Tradition</title>,
+              nº 2, 1880, p. 158‑160.</bibl>
+            <quote type="comment">Presents variant readings of distiches from Avianus 22, 10-16; 21,
+              22; 31 and 32. (P.C.)</quote>
+            <bibl><hi rend="sc">IJsewijn</hi>, Jozef, « <title>Avianus Titiani fabulas num
+                retractauerit</title> ? », <title>Latinitas</title>, nº 29, 1981, p. 42‑43. <hi
+                rend="sc">Jenkinson</hi>, F., « The Fables of Avian », <title>The Academy</title>,
+              nº 45, 1894, p. 129. <hi rend="sc">Jones</hi>, Edith C., <title>Avianus in the Middle
+                Ages. Manuscripts and other Evidences of Nachleben</title>, Ann Arbor, University of
+              Illinois at Urbana-Champaign (Ph.D. non-publiée), 1944. 230 p.</bibl>
+            <bibl>—, « Avianus », <hi rend="i">Lexikon der Alten Welt</hi>, Zurich / Stuttgart,
+              Artemis, 1965, col. 420 <hi rend="i">sqq</hi>.</bibl>
+            <bibl><hi rend="sc">Jones</hi>, William Robert, <title>The Text Tradition of
+                Avianus</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D.
+              non-publiée), 1940. 44 p.</bibl>
+            <quote type="comment">Works out a complex classification scheme to categorize and
+              evaluate the known manuscripts of Avianus. (P.C.)</quote>
+            <bibl>—, « Thomas Nast and the Æsopic fables of Avianus », <hi rend="i">Classical
+                Bulletin</hi>, nº 18, 1941, p. 18-19.</bibl>
+            <bibl>—, « Avianus, Flavianus, Theodosius, and Macrobius », [<hi rend="i">in</hi>] <hi
+                rend="i">Classical Studies Presented to Ben Edwin Perry by his Students and
+                Colleagues at the University of Illinois, 1924-1960</hi>, Urbana, University of
+              Illinois Press, « Illinois Studies in Language and Literature (58) », 1969, p.
+              203‑209.</bibl>
+            <quote type="comment">Suggests the possible identification of Avianus with Flavianus,
+              who was supposedly in favor with the Emperor Theodosius, to whom the fables of Avianus
+              appear to have been dedicated. (P.C.)</quote>
+            <bibl><hi rend="sc">Klein</hi>, Thomas (éd.), « Alexander Neckam <title>Nouus
+                Avianus</title> », [<hi rend="i">in</hi>] <hi rend="sc">F. Bertini</hi> (dir.),
+                <title>Favolisti latini medievali e umanistici VII</title>, Gênes, <hi rend="sc"
+                >d.ar.fi.cl.et. «</hi> Francesco Della Corte », « Favolisti latini medievali e
+              umanistici (7) », 1998, p. 99‑136. <hi rend="sc">Küppers</hi>, Jochem, <title>Die
+                Fabeln Avians. Studien zu Darstellung und Erzählweise spätantiker
+                Fabeldichtung</title>, Bonn, R. Habelt, « Habelts Dissertationsdrucke. Reihe
+              Klassische Philologie (26) », 1977. 252 p. C.R. : John <hi rend="sc">Henderson</hi>,
+                <hi rend="i">The Classical Review</hi>, vol. 29 (nº 2), oct. 1979,
+              p. 312‑313.</bibl>
+            <quote type="comment">Küppers spends much energy in reordering Avianus research by
+              setting aside the previous work of Ellis and Herrmann especially, and to a lesser
+              extent, Crusius and Cameron, as well as Jones and Thraede. Küppers deals with all the
+              major issues : the name of the poet, the Theodosio problem, and the origin of the
+              fables themselves. Küppers deals with the divergences from the Babrian original as
+              Avianus’ own artistic contribution and argues for Avianus’ translation as Coming
+              directly out of the Greek, rather than through a Latin intermediary. Full and useful
+              bibliographies and indices. (P.C.)</quote>
+            <bibl><hi rend="sc">Lachmann</hi>, Karl, <title>De Aviani Fabulis 4, 2, 23, 27
+                (Prooemium indicis lectionum aestivarum a. 1845)</title>, Berolini, 1845 (4 p.) ;
+              repris sous le titre « De Aviani fabulis » dans <title>Kleinere Schriften zur
+                classischen Philologie</title>, Berlin G. Heimer, t. 2, 1876, p. 51-56. <hi
+                rend="sc">Lee</hi>, A. G., « Avianus, fabula XXI, 12 », <title>Proceedings of the
+                Cambridge Philological Society</title>, nº 181, 1950-1951, p. 3‑4.</bibl>
+            <quote type="comment">Textual notes to P325 « Lark and Farmer » (A-T 93; TMI J1031).
+              (P.C.)</quote>
+            <bibl><hi rend="sc">Luzzatto</hi>, Maria Jogada, « Note su Aviano e sulle raccolte
+              esopiche greco‑latine », <title>Prometheus</title>, nº 10, 1984, p. 75‑94. <hi
+                rend="sc">Malein</hi>, A., « Fragments de manuscrits d’Avianus au Musée de
+              paléographie », <title>Comptes rendus de l’Académie des sciences de l’URSS</title>,
+              1926, p. 85‑87.</bibl>
             <p/>
-            <bibl><hi rend="sc">Manitius</hi>, Maximilian, « Beiträge zur Geschichte römischer Dichter im Mittelalter. 9. Tibullus ; 10. Propertius ; 11. Serenus Sammonicus ; 12. Avianus », <title>Philologus</title>, vol. 51 (nº 3), 1892, p. 530‑535</bibl> 
-            <p><milestone unit="analysebiblio"/>Notes on various manuscripts of Avianus’ fables (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, <hi rend="i">Philologisches aus alten Bibliothekskatalogen (bis 1300)</hi>, Francfort-sur-le-Main, J. D. Sauerländer, « Rheinisches Museum für Philologie. Ergänzungsheft (47) », 1892. <num>viii</num>‑152 p.</p>
-            <p><milestone unit="analysebiblio"/>Contains, among much eise, an extensive listing of the manuscripts of Avianus and evaluates their availability at various times and places during the Middle Ages, especially the ninth Century. Lists and describes six manuscripts from the ninth Century, five from the tenth, seven from the eleventh, nine from the twelfth and seven from the thirteenth. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, <hi rend="i">Handschriften antiker Autoren in mittelalterlichen Bibliothekskatalogen</hi>, Leipzig, Harrassowitz, « Beiheft zum Zentralblatt für Bibliothekswesen (67) », 1935. <num>xi</num>‑357 p.</p>
-            <p><milestone unit="analysebiblio"/>This posthumously-appearing work lists those classical authors mentioned in library catalogs from the Middle Ages to 1933. Lists Phaedrus and « Aesopus » (<hi rend="i">i.e.</hi> the Romulus tradition), with special attention given to the very widespread Avianus tradition. (P.C.)</p>
-            <bibl><hi rend="sc">Merone</hi>, E., « Suflo e sufflo (a proposito di Aviano 29, 18) », <title>Giornale italiano di filologia</title>, nº 11, 1958, p. 45‑50.</bibl> 
-            <p><milestone unit="analysebiblio"/>Textual notes to a passage in Avianus; concludes that no reading is clearly indicated but that some are more difficult to support. (P.C.)</p>
-            <bibl><hi rend="sc">Mordeglia</hi>, Caterina (éd.), « Il <title>Nouus Auianus</title> di Venezia », [<title>in</title>] <title>Favolisti latini medievali e umanistici XI</title>, Gênes, <hi rend="sc">d.ar.fi.cl.et. «</hi> Francesco Della Corte », « Favolisti latini medievali e umanistici (11) », 2004, p. 7‑233.</bibl>
-            <p><milestone unit="mentioncr"/>C.R. : J.‑<hi rend="sc">L. Charlet</hi>, <hi rend="i">Revue des Études Latines</hi>, nº 82, 2004, p. 434‑435 ; Wouter <hi rend="sc">Bracke</hi>, <hi rend="i">L’antiquité classique</hi>, nº 75, 2006, p. 666‑667.</p>
-            <p><milestone unit="bibliteration"/>—, « Qualche riflessione sul testo delle favole di Aviano », <hi rend="i">Paideia</hi>, nº 62, 2007, p. 509‑530.</p>
-            <p><milestone unit="bibliteration"/>—, « La riscrittura come forma di interpretazione : il caso delle rielaborazioni mediolatine delle favole di Aviano »,  <hi rend="i">The Journal of Medieval Latin</hi>, nº 17, 2008, p. 159‑173.</p>
-            <p><milestone unit="bibliteration"/>— (éd.), <emph>Le favole di Aviano e il Nouus Auianus di Venezia, Gênes, Il Melangolo, « Università (119) », 2012. 282 p.</emph></p>
-            <bibl><hi rend="sc">Morel</hi>, W., « Some Emendations in Late Latin Texts. Avianus, <title>Fabulae</title>, 40. 2 », <title>Classical Quarterly</title>, vol. 35 (n<hi rend="sup">os</hi> 3‑4), 1941, p. 136‑138. 
-              <hi rend="sc">Oldfather</hi>, William Abbott, « New Manuscript Material for the Study of Avianus », <title>Transactions and Proceedings of the American Philological Association</title>, nº 42, 1911, p. 105‑121.</bibl> 
-            <p><milestone unit="analysebiblio"/>Traces the history of Avianus scholarship, with particular regard to the establishment of the corpus. Lists numerous manuscripts and the Heinrich Steinhöwel’s Esopus which contains twenty-seven fables from Avianus and which is the first known (partial) edition, as well as a number of <hi rend="i">florilgeia</hi> and other collections. Five newly noted medieval texts and introductions to Avianus are described as are six collections of imitations and paraphrases. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « Bibliographical Notes on the Fables of Avianus », <hi rend="i">Papers of the Bibliographical Association of America</hi>, vol. 15 (nº 2), 1921, p. 61-72.</p>
-            <p><milestone unit="analysebiblio"/>Lists materials not found in Hervieux or incompletely described there. Issues a cali for a systematic bibliography of Avianus, including all incunabula and prose re-workings during the Middle Ages. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « A Fleury Text of Avianus », <hi rend="i">Philological Quarterly</hi>, 5, 1926, p. 20-28.</p>
-            <p><milestone unit="analysebiblio"/>Builds on Rand’s assumption that the Codex Leidensis Vossianus Lat. Q 86 came from Fleury. Oldest known manuscript comes from St. Gallen from which emanate three branches in the manuscript tradition. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « An Angular Form of a Rare Abbreviation of –s », <hi rend="i">Speculum</hi>, vol. 1 (nº 4), 1926, p. 443‑444.</p>
-            <p><milestone unit="bibliteration"/>—, &amp; <hi rend="sc">McKenzie</hi>, Kenneth (éd.), <hi rend="i">Ysopet-Avionnet. The Latin and French Texts</hi>, Urbana, University of Illinois, « University of Illinois Studies in Language and Literature (<num>v</num>, 4) », 1919 (<hi rend="i">reprint</hi> New York/Londres, Johnson Reprint, 1967). 286 p.</p>
-            <p><milestone unit="analysebiblio"/>The author and editors present here the text of the Walter of England collection of sixty-five fables in Latin verse accompanied by a French translation from the fourteenth Century, presented in three clearly related manuscripts called Isopet I. That portion which stems from the Avianus tradition is treated separately and called the Avionnet. The collection dates ultimately from the twelfth Century. The lengthy introduction contains an extensive discussion of the history of the fables and their interrelationships as well as a description of the manuscripts and their illustrations. With tables of correspondences, an index of proper names, a Latin glossary, and a series of illustrations from the manuscripts. (P.C.)</p>
-            <bibl><hi rend="sc">Omont</hi>, Henri, « Manuscrit illustré des <title>Fables</title> d’Avianus, notice du ms. latin n. a. 1132, du <num>x</num>e siècle, récemment entré à la Bibliothèque nationale », <title>Bibliothèque de l’École des Chartes</title>, vol. 83, 1922, p. 5‑10 [avec la reproduction du frontispice et des dix miniatures du manuscrit].
-              <hi rend="sc">Pillolla</hi>, Maria Pasqualina, « Reminiscenze e aggettivazione allusiva in due favole di Aviano », [<title>in</title>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <title>La favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</title>, Assisi, Accademia properziana del Subasio, 1991, p. 215‑223. 
-              <hi rend="sc">Ranke</hi>, Kurt, &amp; <hi rend="sc">Weische</hi>, Alfons, art. « Avianus », [<title>in</title>] <hi rend="sc">R. W. Brednich</hi> (dir.), <title>Enzyklopädie des Märchens. Handwörterbuch zur historischen und vergleichenden Erzählforschung, begründet von Kurt Ranke</title>, Berlin, W. de Gruyter, t. I, 1975-1979, col. 1099‑1105.</bibl>
-            <p><milestone unit="analysebiblio"/>A concise survey of Avianus’ life and works insofar as these facts are known. Avianus’ forty-two fables are characterized as coming from Babrius. Bibliographical notes. The article is followed by a note by Kurt Ranke (P.C.)</p>
-            <bibl><hi rend="sc">Risse</hi>, Robert Gregory, <title>An Edition of the Commentary on the Fables of Avianus in Erfurt Ms., Amplon. Q.21. The Text and its Place in Medieval Literary Culture</title>, Saint-Louis (Missouri), Washington University (Ph.D. non-publiée), 1964. 248 p. [en ligne sur <hi rend="sc">p.q.d.t</hi>. à la date du 04.02.2015]</bibl>
-            <p><milestone unit="analysebiblio"/>The manuscript used for this edition was chosen as the best representative of the group of medieval Avianus commentaries, some 47 in number, that cannot be resolved to a single text. After statements of editorial principles, Avianus’ position in education and the intellectual life of the middle ages is discussed, as well as the specific uses of the fable in various medieval forms and by various authors. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « The Augustinian Paraphrase of Isaiah 14.13-14 in <hi rend="i">Piers Plowman</hi> and the commentary on the <hi rend="i">Fables</hi> of Avianus », <hi rend="i">Philological Quarterly</hi>, vol. 45 (nº 4), 1966, p. 712-717.</p>
-            <p><milestone unit="analysebiblio"/>Satan’s boast from Isaiah and <hi rend="i">Piers Plowman</hi> in paraphrase is also to be found in commentaries on Avianus, specifically on fables two and four, with the paraphrase found twenty-nine times. The use of the paraphrase is discussed in terms of the importance of Avianus in medieval culture. (P.C.)</p>
-            <bibl><hi rend="sc">Ritschl</hi>, F., « Zu Avianus », <title>Rheinisches Museum für Philologie</title>, nº 17, 1862, p. 474 (= <title>Opuscul. phil</title>., III, 1877, p. 811).
-              <hi rend="sc">Ryan</hi>, Eileen P., <title>The Verse Adaptations of Avianus. Part I : The Astensis and its Derivatives</title>, Ann Arbor, University of Illinois at Urbana-Champaign (Ph.D. non-publiée), 1940. 44 p.</bibl>
-            <p><milestone unit="analysebiblio"/>Text and commentary on the <hi rend="i">Apologi Aviani</hi> [<hi rend="i">sic</hi>], now for the most part superseded by Küppers and Gaide. (P.C.)</p>
-            <bibl><hi rend="sc">Scanzo</hi>, Roberto, « Aviano : I suoi modelli, le sue fonti », <title>Maia</title>, vol. 53 (nº 1), 2001, p. 51‑61.</bibl>
-            <p><milestone unit="bibliteration"/>—, « Arguzia e <hi rend="i">lusus</hi> nelle <hi rend="i">Fabulæ</hi> di Aviano : una nuova proposta di interpretazione », <hi rend="i">Maia</hi>, vol. 54 (nº 1), 2002, p. 71‑80.</p>
-            <p><milestone unit="bibliteration"/>—, « Il maiale avvertito. Le funzioni del “<hi rend="i">pervelle aurem</hi>” (con l’analisi delle vicende d’un suino della favolistica) », <hi rend="i">Maia</hi>, vol. 56 (nº 2), 2004, p. 1‑16.</p>
-            <bibl><hi rend="sc">Schanz</hi>, Martin, <hi rend="sc">Hosius</hi>, C., &amp; <hi rend="sc">Krüger</hi>, G., art. « Avianus », [<title>in</title>] <title>Römische Literaturgeschichte</title>, München, Beck, t. 4, 2<hi rend="sup">e</hi> partie, (1920) 1935, p. 32‑35.</bibl> 
-            <p><milestone unit="analysebiblio"/>On the poet’s name and time (suggested dates are not past the fourth Century) ; relationship between the fables of Babrius and Avianus. Reviews the textual Problems, the medieval paraphrases. Extensive bibliography. (P.C.)</p>
-            <bibl><hi rend="sc">Schenkl</hi>, K., « Beiträge zur Texteskritik der Fabulae des Avianus », <title>Zeitschrift für die österreichischen Gymnasien</title>, nº 16, 1865, p. 397‑413.
-              <hi rend="sc">Schulze-Busacker</hi>, Elisabeth, <title>La didactique profane au Moyen Âge</title>, Paris, Classiques Garnier, « Recherches littéraires médiévales (11) », 2012. 282 p.
-              <hi rend="sc">Shackleton Bailey</hi>, D. R., « Avianiana », <title>Harvard Studies in Classical Philology</title>, nº 82, 1978, p. 295‑301.</bibl> 
-            <p><milestone unit="analysebiblio"/>Textual notes on two fables in Avianus. (P.C.)</p>
-            <bibl><hi rend="sc">Solimano</hi>, Giannina (éd. &amp; trad. ital.), <title>Favole di Fedro e Aviano</title>, Turin, <hi rend="i">Unione Tipografico-Editrice</hi> Torinese, « Classici latini », 2005. 429 p.
-              <hi rend="sc">Soudée</hi>, Madeleine, <title>Quatre fabulistes : Phèdre, Avianus, Marie de France et La Fontaine</title>, Washington (DC), George Washington University (Ph.D. non-publiée), 1977. 285 p.</bibl> 
-            <p><milestone unit="analysebiblio"/>Sees a unifying consistency of theme and form for each of the four collections. Phaedrus used his fables for literary polemic; Avianus’ collection is seen as a program for an individual’s advance toward self-improvement. Marie de France is characterized as writing fables as court propaganda. La Fontaine’s collection as a whole comprises a « theater of the world » filled with constant surprise. (P.C.)</p>
-            <p><milestone unit="bibliteration"/>—, « Le dessein d’Avianus. Nouveau critère d’authenticité des fables », <hi rend="i">Échos du monde classique. Classical News and Views</hi>, nº 22, 1978, p. 63‑70.</p>
-            <p><milestone unit="analysebiblio"/>The Avianus collection as a whole forms a structure the design of which is revealed in the intellectual milieu in which they were produced. Neoplatonic, anti-Christian, but intellectual is the poet. (P.C.)</p>
-            <bibl><hi rend="sc">Suerbaum</hi>, Almut, « <title>Litterae et mores</title>. Zur Textgeschichte der mittelalterlichen Avian-Kommentare », [<title>in</title>] Klaus <hi rend="sc">Grubmüller</hi> (dir.), <title>Schulliteratur im späten Mittelalter</title>, Munich, W. Fink, « Münsterche Mittelalter-Schriften (69) », 2000, p. 383‑434.
-              <hi rend="sc">Tamanza</hi>, Simona (éd.), « <title>L’Anti‑Aviano</title> », [<title>in</title>] <hi rend="sc">F. Bertini</hi> (dir.), <title>Favolisti latini medievali e umanistici VII</title>, Gênes, D.AR.FI.CL.ET. « Francesco Della Corte », « Favolisti latini medievali e umanistici (7) », 1998, p. 137-193.</bibl>
-            <p><hi rend="sc">Unrein</hi>, Otto, <hi rend="i">De Aviani aetate. Dissertation</hi>, Universität Jena, 1885. 64 p.</p>
-            <p><milestone unit="analysebiblio"/>Unrein concludes that Avianus lived at the end of the fourth Century or the beginning of the fifth Century A.D. The most important evidence is Avianus’ relationship to Titianus, but linguistic evidence is evaluated as well. Excellent survey of critical literature up to his time. (P.C.)</p>
-            <bibl><hi rend="sc">Vendryes</hi>, J., « Gloses en vieux haut-allemand dans un manuscrit d’Avianus », <title>Mémoires de la Société linguistique de Paris</title>, vol. 22 (nº 6), 1922, p. 273‑276.
-              <hi rend="sc">Weitzmann</hi>, Kurt, « Æsopian Fable », [<title>in</title>] <title>Ancient Book Illumination</title>, Cambridge (Ma.), Harvard University Press, 1959, p. 111‑114.</bibl>
-            <p><milestone unit="analysebiblio"/>Aesop’s fables’ popularity as a subject for illustrations is here attributed to the popularity of the form itself and its “fitness to pictorialization.” The article provides a cursory overview of picture cycles that demonstrate illustrated Aesop manuscripts in classical antiquity. P1 « Fox and Eagle » (TMI K2295) and P158 « Wolf and Nurse » (TMI J2066.5) are shown in various illustrations. (P.C.)</p>
-            <bibl><hi rend="sc">Winterfeld</hi>, Paul von, « Zu Avianus », <title>Rheinisches Museum für Philologie</title>, nº 57, 1902, p. 167‑168.</bibl>
-            <p><milestone unit="analysebiblio"/>Suggests that Lachmann’s dating of Avianus ought to be put down. Earliest possible date seems to be the second half of the fourth Century because of the metrics the poet used. (P.C.)</p>
-            <bibl><hi rend="sc">Wright</hi>, Aaron Eugene/Tietjen, « “<title>Iste auctor ab aliis differt</title>”. Avianus and His Medieval Readers », [<title>in</title>] <hi rend="sc">W. Harms</hi>, <hi rend="sc">C.S. Jæger</hi>, &amp; <hi rend="sc">A. Stein (</hi>dir.), <title>Fremdes wahrnehmen-fremdes Wahrnehmen, Studien zur Geschichte der Wahrnehmung und zur Begegnung von Kulturen im Mittelalter und früher Neuzeit</title>, Stuttgart/Leipzig, Hirzel, 1997, p. 9‑19.  
-              <hi rend="sc">Ziolkowski</hi>, Jan M., <title>Talking Animals. Medieval Latin Beast Poetry (750‑1150)</title>, Philadelphie, University of Pennsylvania Press, « Middle Ages Series », 1993. <num>ix</num>‑354 p.
-              <hi rend="sc">Zurli</hi>, Loriano, « L’<title>Avianus Astensis</title> e l’<title>Avianus Vindobonensis</title>. Considerazioni sulla nazionalità dell’<title>Astensis</title> e sulla cronologia relativa », [<title>in</title>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <title>La favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</title>, Assisi, Accademia properziana del Subasio, 1991, p. 63‑77.</bibl>
-            <p><milestone unit="bibliteration"/>—, &amp; <hi rend="sc">Bisanti</hi>, Armando (éd.), <hi rend="i">Astensis Poetæ Nouus Avianus</hi>, Gênes, D.AR.FI.CL.ET. « Francesco Della Corte », « Favolisti latini medievali e umanistici (5) », 1994. 236 p.</p>
+            <bibl><hi rend="sc">Manitius</hi>, Maximilian, « Beiträge zur Geschichte römischer
+              Dichter im Mittelalter. 9. Tibullus ; 10. Propertius ; 11. Serenus Sammonicus ; 12.
+              Avianus », <title>Philologus</title>, vol. 51 (nº 3), 1892, p. 530‑535</bibl>
+            <quote type="comment">Notes on various manuscripts of Avianus’ fables (P.C.)</quote>
+            <bibl>—, <hi rend="i">Philologisches aus alten Bibliothekskatalogen (bis 1300)</hi>,
+              Francfort-sur-le-Main, J. D. Sauerländer, « Rheinisches Museum für Philologie.
+              Ergänzungsheft (47) », 1892. <num>viii</num>‑152 p.</bibl>
+            <quote type="comment">Contains, among much eise, an extensive listing of the manuscripts
+              of Avianus and evaluates their availability at various times and places during the
+              Middle Ages, especially the ninth Century. Lists and describes six manuscripts from
+              the ninth Century, five from the tenth, seven from the eleventh, nine from the twelfth
+              and seven from the thirteenth. (P.C.)</quote>
+            <bibl>—, <hi rend="i">Handschriften antiker Autoren in mittelalterlichen
+                Bibliothekskatalogen</hi>, Leipzig, Harrassowitz, « Beiheft zum Zentralblatt für
+              Bibliothekswesen (67) », 1935. <num>xi</num>‑357 p.</bibl>
+            <quote type="comment">This posthumously-appearing work lists those classical authors
+              mentioned in library catalogs from the Middle Ages to 1933. Lists Phaedrus and
+              « Aesopus » (<hi rend="i">i.e.</hi> the Romulus tradition), with special attention
+              given to the very widespread Avianus tradition. (P.C.)</quote>
+            <bibl><hi rend="sc">Merone</hi>, E., « Suflo e sufflo (a proposito di Aviano 29, 18) »,
+                <title>Giornale italiano di filologia</title>, nº 11, 1958, p. 45‑50.</bibl>
+            <quote type="comment">Textual notes to a passage in Avianus; concludes that no reading
+              is clearly indicated but that some are more difficult to support. (P.C.)</quote>
+            <bibl><hi rend="sc">Mordeglia</hi>, Caterina (éd.), « Il <title>Nouus Auianus</title> di
+              Venezia », [<hi rend="i">in</hi>] <title>Favolisti latini medievali e
+                umanistici XI</title>, Gênes, <hi rend="sc">d.ar.fi.cl.et. «</hi> Francesco Della
+              Corte », « Favolisti latini medievali e umanistici (11) », 2004, p. 7‑233. C.R. :
+                J.‑<hi rend="sc">L. Charlet</hi>, <hi rend="i">Revue des Études Latines</hi>, nº 82,
+              2004, p. 434‑435 ; Wouter <hi rend="sc">Bracke</hi>, <hi rend="i">L’antiquité
+                classique</hi>, nº 75, 2006, p. 666‑667.</bibl>
+            <bibl>—, « Qualche riflessione sul testo delle favole di Aviano », <hi rend="i"
+                >Paideia</hi>, nº 62, 2007, p. 509‑530.</bibl>
+            <bibl>—, « La riscrittura come forma di interpretazione : il caso delle rielaborazioni
+              mediolatine delle favole di Aviano », <hi rend="i">The Journal of Medieval Latin</hi>,
+              nº 17, 2008, p. 159‑173.</bibl>
+            <bibl>— (éd.), Le favole di Aviano e il Nouus Auianus di Venezia, Gênes, Il Melangolo,
+              « Università (119) », 2012. 282 p.</bibl>
+            <bibl><hi rend="sc">Morel</hi>, W., « Some Emendations in Late Latin Texts. Avianus,
+                <title>Fabulae</title>, 40. 2 », <title>Classical Quarterly</title>, vol. 35 (n<hi
+                rend="sup">os</hi> 3‑4), 1941, p. 136‑138. <hi rend="sc">Oldfather</hi>, William
+              Abbott, « New Manuscript Material for the Study of Avianus », <title>Transactions and
+                Proceedings of the American Philological Association</title>, nº 42, 1911,
+              p. 105‑121.</bibl>
+            <quote type="comment">Traces the history of Avianus scholarship, with particular regard
+              to the establishment of the corpus. Lists numerous manuscripts and the Heinrich
+              Steinhöwel’s Esopus which contains twenty-seven fables from Avianus and which is the
+              first known (partial) edition, as well as a number of <hi rend="i">florilgeia</hi> and
+              other collections. Five newly noted medieval texts and introductions to Avianus are
+              described as are six collections of imitations and paraphrases. (P.C.)</quote>
+            <bibl>—, « Bibliographical Notes on the Fables of Avianus », <hi rend="i">Papers of the
+                Bibliographical Association of America</hi>, vol. 15 (nº 2), 1921, p. 61-72.</bibl>
+            <quote type="comment">Lists materials not found in Hervieux or incompletely described
+              there. Issues a cali for a systematic bibliography of Avianus, including all
+              incunabula and prose re-workings during the Middle Ages. (P.C.)</quote>
+            <bibl>—, « A Fleury Text of Avianus », <hi rend="i">Philological Quarterly</hi>, 5,
+              1926, p. 20-28.</bibl>
+            <quote type="comment">Builds on Rand’s assumption that the Codex Leidensis Vossianus
+              Lat. Q 86 came from Fleury. Oldest known manuscript comes from St. Gallen from which
+              emanate three branches in the manuscript tradition. (P.C.)</quote>
+            <bibl>—, « An Angular Form of a Rare Abbreviation of –s », <hi rend="i">Speculum</hi>,
+              vol. 1 (nº 4), 1926, p. 443‑444.</bibl>
+            <bibl>—, &amp; <hi rend="sc">McKenzie</hi>, Kenneth (éd.), <hi rend="i"
+                >Ysopet-Avionnet. The Latin and French Texts</hi>, Urbana, University of Illinois,
+              « University of Illinois Studies in Language and Literature (<num>v</num>, 4) »,
+                1919 (<hi rend="i">reprint</hi> New York/Londres, Johnson Reprint,
+              1967). 286 p.</bibl>
+            <quote type="comment">The author and editors present here the text of the Walter of
+              England collection of sixty-five fables in Latin verse accompanied by a French
+              translation from the fourteenth Century, presented in three clearly related
+              manuscripts called Isopet I. That portion which stems from the Avianus tradition is
+              treated separately and called the Avionnet. The collection dates ultimately from the
+              twelfth Century. The lengthy introduction contains an extensive discussion of the
+              history of the fables and their interrelationships as well as a description of the
+              manuscripts and their illustrations. With tables of correspondences, an index of
+              proper names, a Latin glossary, and a series of illustrations from the manuscripts.
+              (P.C.)</quote>
+            <bibl><hi rend="sc">Omont</hi>, Henri, « Manuscrit illustré des <title>Fables</title>
+              d’Avianus, notice du ms. latin n. a. 1132, du <num>x</num>e siècle, récemment entré à
+              la Bibliothèque nationale », <title>Bibliothèque de l’École des Chartes</title>,
+              vol. 83, 1922, p. 5‑10 [avec la reproduction du frontispice et des dix miniatures du
+              manuscrit]. <hi rend="sc">Pillolla</hi>, Maria Pasqualina, « Reminiscenze e
+              aggettivazione allusiva in due favole di Aviano », [<hi rend="i">in</hi>] <hi
+                rend="sc">G. Catanzaro</hi>, &amp; <hi rend="sc">F. Santucci</hi> (dir.), <title>La
+                favolistica latina in distici elegiaci. Atti del convegno internazionale (Assisi,
+                26-28 ottobre 1990)</title>, Assisi, Accademia properziana del Subasio, 1991,
+              p. 215‑223. <hi rend="sc">Ranke</hi>, Kurt, &amp; <hi rend="sc">Weische</hi>, Alfons,
+              art. « Avianus », [<hi rend="i">in</hi>] <hi rend="sc">R. W. Brednich</hi> (dir.),
+                <title>Enzyklopädie des Märchens. Handwörterbuch zur historischen und vergleichenden
+                Erzählforschung, begründet von Kurt Ranke</title>, Berlin, W. de Gruyter, t. I,
+              1975-1979, col. 1099‑1105.</bibl>
+            <quote type="comment">A concise survey of Avianus’ life and works insofar as these facts
+              are known. Avianus’ forty-two fables are characterized as coming from Babrius.
+              Bibliographical notes. The article is followed by a note by Kurt Ranke (P.C.)</quote>
+            <bibl><hi rend="sc">Risse</hi>, Robert Gregory, <title>An Edition of the Commentary on
+                the Fables of Avianus in Erfurt Ms., Amplon. Q.21. The Text and its Place in
+                Medieval Literary Culture</title>, Saint-Louis (Missouri), Washington University
+              (Ph.D. non-publiée), 1964. 248 p. [en ligne sur <hi rend="sc">p.q.d.t</hi>. à la date
+              du 04.02.2015]</bibl>
+            <quote type="comment">The manuscript used for this edition was chosen as the best
+              representative of the group of medieval Avianus commentaries, some 47 in number, that
+              cannot be resolved to a single text. After statements of editorial principles,
+              Avianus’ position in education and the intellectual life of the middle ages is
+              discussed, as well as the specific uses of the fable in various medieval forms and by
+              various authors. (P.C.)</quote>
+            <bibl>—, « The Augustinian Paraphrase of Isaiah 14.13-14 in <hi rend="i">Piers
+                Plowman</hi> and the commentary on the <hi rend="i">Fables</hi> of Avianus », <hi
+                rend="i">Philological Quarterly</hi>, vol. 45 (nº 4), 1966, p. 712-717.</bibl>
+            <quote type="comment">Satan’s boast from Isaiah and <hi rend="i">Piers Plowman</hi> in
+              paraphrase is also to be found in commentaries on Avianus, specifically on fables two
+              and four, with the paraphrase found twenty-nine times. The use of the paraphrase is
+              discussed in terms of the importance of Avianus in medieval culture. (P.C.)</quote>
+            <bibl><hi rend="sc">Ritschl</hi>, F., « Zu Avianus », <title>Rheinisches Museum für
+                Philologie</title>, nº 17, 1862, p. 474 (= <title>Opuscul. phil</title>., III, 1877,
+              p. 811). <hi rend="sc">Ryan</hi>, Eileen P., <title>The Verse Adaptations of Avianus.
+                Part I : The Astensis and its Derivatives</title>, Ann Arbor, University of Illinois
+              at Urbana-Champaign (Ph.D. non-publiée), 1940. 44 p.</bibl>
+            <quote type="comment">Text and commentary on the <hi rend="i">Apologi Aviani</hi> [<hi
+                rend="i">sic</hi>], now for the most part superseded by Küppers and Gaide.
+              (P.C.)</quote>
+            <bibl><hi rend="sc">Scanzo</hi>, Roberto, « Aviano : I suoi modelli, le sue fonti »,
+                <title>Maia</title>, vol. 53 (nº 1), 2001, p. 51‑61.</bibl>
+            <bibl>—, « Arguzia e <hi rend="i">lusus</hi> nelle <hi rend="i">Fabulæ</hi> di Aviano :
+              una nuova proposta di interpretazione », <hi rend="i">Maia</hi>, vol. 54 (nº 1), 2002,
+              p. 71‑80.</bibl>
+            <bibl>—, « Il maiale avvertito. Le funzioni del “<hi rend="i">pervelle aurem</hi>” (con
+              l’analisi delle vicende d’un suino della favolistica) », <hi rend="i">Maia</hi>,
+              vol. 56 (nº 2), 2004, p. 1‑16.</bibl>
+            <bibl><hi rend="sc">Schanz</hi>, Martin, <hi rend="sc">Hosius</hi>, C., &amp; <hi
+                rend="sc">Krüger</hi>, G., art. « Avianus », [<hi rend="i">in</hi>] <title>Römische
+                Literaturgeschichte</title>, München, Beck, t. 4, 2<hi rend="sup">e</hi> partie,
+              (1920) 1935, p. 32‑35.</bibl>
+            <quote type="comment">On the poet’s name and time (suggested dates are not past the
+              fourth Century) ; relationship between the fables of Babrius and Avianus. Reviews the
+              textual Problems, the medieval paraphrases. Extensive bibliography. (P.C.)</quote>
+            <bibl><hi rend="sc">Schenkl</hi>, K., « Beiträge zur Texteskritik der Fabulae des
+              Avianus », <title>Zeitschrift für die österreichischen Gymnasien</title>, nº 16, 1865,
+              p. 397‑413. <hi rend="sc">Schulze-Busacker</hi>, Elisabeth, <title>La didactique
+                profane au Moyen Âge</title>, Paris, Classiques Garnier, « Recherches littéraires
+              médiévales (11) », 2012. 282 p. <hi rend="sc">Shackleton Bailey</hi>, D. R.,
+              « Avianiana », <title>Harvard Studies in Classical Philology</title>, nº 82, 1978,
+              p. 295‑301.</bibl>
+            <quote type="comment">Textual notes on two fables in Avianus. (P.C.)</quote>
+            <bibl><hi rend="sc">Solimano</hi>, Giannina (éd. &amp; trad. ital.), <title>Favole di
+                Fedro e Aviano</title>, Turin, <hi rend="i">Unione Tipografico-Editrice</hi>
+              Torinese, « Classici latini », 2005. 429 p. <hi rend="sc">Soudée</hi>, Madeleine,
+                <title>Quatre fabulistes : Phèdre, Avianus, Marie de France et La Fontaine</title>,
+              Washington (DC), George Washington University (Ph.D. non-publiée), 1977. 285 p.</bibl>
+            <quote type="comment">Sees a unifying consistency of theme and form for each of the four
+              collections. Phaedrus used his fables for literary polemic; Avianus’ collection is
+              seen as a program for an individual’s advance toward self-improvement. Marie de France
+              is characterized as writing fables as court propaganda. La Fontaine’s collection as a
+              whole comprises a « theater of the world » filled with constant surprise.
+              (P.C.)</quote>
+            <bibl>—, « Le dessein d’Avianus. Nouveau critère d’authenticité des fables », <hi
+                rend="i">Échos du monde classique. Classical News and Views</hi>, nº 22, 1978,
+              p. 63‑70.</bibl>
+            <quote type="comment">The Avianus collection as a whole forms a structure the design of
+              which is revealed in the intellectual milieu in which they were produced. Neoplatonic,
+              anti-Christian, but intellectual is the poet. (P.C.)</quote>
+            <bibl><hi rend="sc">Suerbaum</hi>, Almut, « <title>Litterae et mores</title>. Zur
+              Textgeschichte der mittelalterlichen Avian-Kommentare », [<hi rend="i">in</hi>] Klaus
+                <hi rend="sc">Grubmüller</hi> (dir.), <title>Schulliteratur im späten
+                Mittelalter</title>, Munich, W. Fink, « Münsterche Mittelalter-Schriften (69) »,
+              2000, p. 383‑434. <hi rend="sc">Tamanza</hi>, Simona (éd.),
+                « <title>L’Anti‑Aviano</title> », [<hi rend="i">in</hi>] <hi rend="sc"
+                >F. Bertini</hi> (dir.), <title>Favolisti latini medievali e umanistici VII</title>,
+              Gênes, D.AR.FI.CL.ET. « Francesco Della Corte », « Favolisti latini medievali e
+              umanistici (7) », 1998, p. 137-193.</bibl>
+            <p><hi rend="sc">Unrein</hi>, Otto, <hi rend="i">De Aviani aetate. Dissertation</hi>,
+              Universität Jena, 1885. 64 p.</p>
+            <quote type="comment">Unrein concludes that Avianus lived at the end of the fourth
+              Century or the beginning of the fifth Century A.D. The most important evidence is
+              Avianus’ relationship to Titianus, but linguistic evidence is evaluated as well.
+              Excellent survey of critical literature up to his time. (P.C.)</quote>
+            <bibl><hi rend="sc">Vendryes</hi>, J., « Gloses en vieux haut-allemand dans un manuscrit
+              d’Avianus », <title>Mémoires de la Société linguistique de Paris</title>, vol. 22
+              (nº 6), 1922, p. 273‑276. <hi rend="sc">Weitzmann</hi>, Kurt, « Æsopian Fable », [<hi
+                rend="i">in</hi>] <title>Ancient Book Illumination</title>, Cambridge (Ma.), Harvard
+              University Press, 1959, p. 111‑114.</bibl>
+            <quote type="comment">Aesop’s fables’ popularity as a subject for illustrations is here
+              attributed to the popularity of the form itself and its “fitness to pictorialization.”
+              The article provides a cursory overview of picture cycles that demonstrate illustrated
+              Aesop manuscripts in classical antiquity. P1 « Fox and Eagle » (TMI K2295) and P158
+              « Wolf and Nurse » (TMI J2066.5) are shown in various illustrations. (P.C.)</quote>
+            <bibl><hi rend="sc">Winterfeld</hi>, Paul von, « Zu Avianus », <title>Rheinisches Museum
+                für Philologie</title>, nº 57, 1902, p. 167‑168.</bibl>
+            <quote type="comment">Suggests that Lachmann’s dating of Avianus ought to be put down.
+              Earliest possible date seems to be the second half of the fourth Century because of
+              the metrics the poet used. (P.C.)</quote>
+            <bibl><hi rend="sc">Wright</hi>, Aaron Eugene/Tietjen, « “<title>Iste auctor ab aliis
+                differt</title>”. Avianus and His Medieval Readers », [<hi rend="i">in</hi>] <hi
+                rend="sc">W. Harms</hi>, <hi rend="sc">C.S. Jæger</hi>, &amp; <hi rend="sc">A. Stein
+                (</hi>dir.), <title>Fremdes wahrnehmen-fremdes Wahrnehmen, Studien zur Geschichte
+                der Wahrnehmung und zur Begegnung von Kulturen im Mittelalter und früher
+                Neuzeit</title>, Stuttgart/Leipzig, Hirzel, 1997, p. 9‑19. <hi rend="sc"
+                >Ziolkowski</hi>, Jan M., <title>Talking Animals. Medieval Latin Beast Poetry
+                (750‑1150)</title>, Philadelphie, University of Pennsylvania Press, « Middle Ages
+              Series », 1993. <num>ix</num>‑354 p. <hi rend="sc">Zurli</hi>, Loriano,
+                « L’<title>Avianus Astensis</title> e l’<title>Avianus Vindobonensis</title>.
+              Considerazioni sulla nazionalità dell’<title>Astensis</title> e sulla cronologia
+              relativa », [<hi rend="i">in</hi>] <hi rend="sc">G. Catanzaro</hi>, &amp; <hi
+                rend="sc">F. Santucci</hi> (dir.), <title>La favolistica latina in distici elegiaci.
+                Atti del convegno internazionale (Assisi, 26-28 ottobre 1990)</title>, Assisi,
+              Accademia properziana del Subasio, 1991, p. 63‑77.</bibl>
+            <bibl>—, &amp; <hi rend="sc">Bisanti</hi>, Armando (éd.), <hi rend="i">Astensis Poetæ
+                Nouus Avianus</hi>, Gênes, D.AR.FI.CL.ET. « Francesco Della Corte », « Favolisti
+              latini medievali e umanistici (5) », 1994. 236 p.</bibl>
           </div>
         </div>
       </div>
@@ -683,7 +1270,20 @@
     <body>
       <div type="poem">
         <head>AD THEODOSIUM</head>
-        <p>Dubitanti mihi, Theodosi optime, quonam litterarum titulo nostri nominis memoriam mandaremus, fabularum textus occurrit, quod in his urbane concepta falsitas deceat et non incumbat necessitas ueritatis. Nam quis tecum de oratione, quis de poemate loqueretur, cum in utroque litterarum genere et Atticos Graeca eruditione superes et latinitate Romanos ? Huius ergo materiae ducem nobis Aesopum noueris, qui responso Delphici Apollinis monitus ridicula orsus est, ut legenda firmaret. Verum has pro exemplo fabulas et Socrates diuinis operibus indidit et poemati suo Flaccus aptauit, quod in se sub iocorum communium specie uitae argumenta contineant. Quas Graecis iambis Babrius repetens in duo uolumina coartauit. Phaedrus etiam partem aliquam quinque in libellos resoluit. De his ergo ad quadraginta et duas in unum redactas fabulas dedi, quas rudi latinitate compositas elegis sum explicare conatus. Habes ergo opus quo animum oblectes, ingenium exerceas, sollicitudinem leues totumque uiuendi ordinem cautus agnoscas. Loqui uero arbores, feras cum hominibus gemere, uerbis certare uolucres, animalia ridere fecimus, ut pro singulorum necessitatibus uel ab ipsis [in]animis sententia proferatur.</p>
+        <p>Dubitanti mihi, Theodosi optime, quonam litterarum titulo nostri nominis memoriam
+          mandaremus, fabularum textus occurrit, quod in his urbane concepta falsitas deceat et non
+          incumbat necessitas ueritatis. Nam quis tecum de oratione, quis de poemate loqueretur, cum
+          in utroque litterarum genere et Atticos Graeca eruditione superes et latinitate Romanos ?
+          Huius ergo materiae ducem nobis Aesopum noueris, qui responso Delphici Apollinis monitus
+          ridicula orsus est, ut legenda firmaret. Verum has pro exemplo fabulas et Socrates diuinis
+          operibus indidit et poemati suo Flaccus aptauit, quod in se sub iocorum communium specie
+          uitae argumenta contineant. Quas Graecis iambis Babrius repetens in duo uolumina
+          coartauit. Phaedrus etiam partem aliquam quinque in libellos resoluit. De his ergo ad
+          quadraginta et duas in unum redactas fabulas dedi, quas rudi latinitate compositas elegis
+          sum explicare conatus. Habes ergo opus quo animum oblectes, ingenium exerceas,
+          sollicitudinem leues totumque uiuendi ordinem cautus agnoscas. Loqui uero arbores, feras
+          cum hominibus gemere, uerbis certare uolucres, animalia ridere fecimus, ut pro singulorum
+          necessitatibus uel ab ipsis [in]animis sententia proferatur.</p>
       </div>
       <div type="poem" xml:id="avianus-01">
         <head type="sur">Avianus 1</head>
@@ -703,7 +1303,8 @@
         <l met="penta_el">uix miserum uacua delituisse fuga.</l>
         <l met="hexa_dac">Nam quae praeda, rogas, quae spes contingere posset,</l>
         <l met="penta_el">iurgia nutricis cum mihi uerba darent ?</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec sibi dicta putet seque hac sciat arte notari</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec sibi dicta putet seque hac sciat
+          arte notari</l>
         <l met="penta_el">femineam quisquis credidit esse fidem.</l>
       </div>
       <div type="poem" xml:id="avianus-02">
@@ -724,7 +1325,8 @@
         <l met="penta_el">ingemuit uotis haec licuisse suis.</l>
         <l met="hexa_dac">Nam dedit exosae post haec documenta quietis</l>
         <l met="penta_el">mon sine supremo magna labore peti.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic quicumque noua sublatus laude tumecit</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic quicumque noua sublatus laude
+          tumecit</l>
         <l met="penta_el">dat merito poenas, dum meliora cupit.</l>
       </div>
       <div type="poem" xml:id="avianus-03">
@@ -738,7 +1340,7 @@
         <l met="hexa_dac">Ne tibi transuerso placeant haec deuia, nate,</l>
         <l met="penta_el">Rursus in obliquos neu uelis ire pedes ;</l>
         <l met="hexa_dac">sed nisu contenta ferens uestigia recto,</l>
-        <l met="penta_el">innocuos  proso tramite sista gradus.</l>
+        <l met="penta_el">innocuos proso tramite sista gradus.</l>
         <l met="hexa_dac">Cui natus : Faciam, si me praecesseris, inquit,</l>
         <l met="penta_el">rectaque monstrantem certior ipse sequar.</l>
         <l met="hexa_dac">Nam stultum nimis est, cum tu prauissima temptes,</l>
@@ -772,7 +1374,8 @@
         <l met="hexa_dac">Metiri se quemque decet propriisque iuuari</l>
         <l met="penta_el">laudibus, alterius nec bona ferre sibi,</l>
         <l met="hexa_dac">ne detracta grauem faciant miracula risum,</l>
-        <l met="penta_el"><milestone unit="ana:promythium"/>coeperit in solis cum remanere malis.</l>
+        <l met="penta_el"><milestone unit="ana:promythium"/>coeperit in solis cum remanere
+          malis.</l>
         <l met="hexa_dac">Exuuias asinus Gaetuli forte leonis</l>
         <l met="penta_el">repperit et spoliis induit ora nouis</l>
         <l met="hexa_dac">aptauitque suis incongrua tegmina membris,</l>
@@ -835,7 +1438,8 @@
         <l met="hexa_dac">Contentum propriis sapientem uiuere rebus,</l>
         <l met="penta_el">nec cupere alterius, nostra fabella monet,</l>
         <l met="hexa_dac">indignata cito ne stet Fortuna recursu</l>
-        <l met="penta_el"><milestone unit="ana:promythium"/>atque eadem minuat quae dedit ante rota.</l>
+        <l met="penta_el"><milestone unit="ana:promythium"/>atque eadem minuat quae dedit ante
+          rota.</l>
         <l met="hexa_dac">Corporis immensis fertur pecus isse per auras</l>
         <l met="penta_el">et magnum precibus sollicitasse Iouem :</l>
         <l met="hexa_dac">turpe nimis cunctis irridendumque uideri</l>
@@ -1006,7 +1610,8 @@
         <l met="penta_el">et quamuis leuibus prouida cedo notis.</l>
         <l met="hexa_dac">In tua praeruptus offendit robora nimbus ;</l>
         <l met="penta_el">motibus aura meis ludificata perit.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec nos dicta monent magnisw obsistere frustra</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec nos dicta monent magnisw obsistere
+          frustra</l>
         <l met="penta_el">paulatimque truces exsuperare minas.</l>
       </div>
       <div type="poem" xml:id="avianus-17">
@@ -1042,7 +1647,7 @@
         <l met="penta_el">rursus et e pastu turba rediret amans.</l>
         <l met="hexa_dac">Hos quoque collatis inter se cornibus ingens</l>
         <l met="penta_el">dicitur in siluis pertimuisse leo,</l>
-        <l met="hexa_dac">dum metus oblatam prohibet  temptare rapinam</l>
+        <l met="hexa_dac">dum metus oblatam prohibet temptare rapinam</l>
         <l met="penta_el">et coniuratos horret adire boues.</l>
         <l met="hexa_dac">Sed quamuis audax factisque immanior esset,</l>
         <l met="penta_el">tantorum solus uiribus impar erat.</l>
@@ -1155,7 +1760,8 @@
         <l met="penta_el">siue decus busti, seu uelis esse deum.</l>
         <l met="hexa_dac">Subdita namque tibi est magni reuerentia fati,</l>
         <l met="penta_el">atque eadem retines funera nostra manu.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Conuenit hoc illis quibus est permissa potestas</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Conuenit hoc illis quibus est permissa
+          potestas</l>
         <l met="penta_el">an praestare magis, seu nocuisse uelint.</l>
       </div>
       <div type="poem" xml:id="avianus-24">
@@ -1229,7 +1835,8 @@
         <l met="penta_el">indignata noua calliditate dolos.</l>
         <l met="hexa_dac">Nam breuis immersis accrescens sponte lapillis</l>
         <l met="penta_el">potandi facilem praebuit unda uiam.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Viribus haec docuit quam sit prudentia maior,</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Viribus haec docuit quam sit prudentia
+          maior,</l>
         <l met="penta_el">qua coeptum uolucris explicuisset opus.</l>
       </div>
       <div type="poem" xml:id="avianus-28">
@@ -1300,7 +1907,8 @@
         <l met="penta_el">affirmans stultum non habuisse suem :</l>
         <l met="hexa_dac">Nam cur membrorum demens in damna redisset</l>
         <l met="penta_el">atque uno totiens posset ab hoste capi ?</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec illos descripta monent, qui saepius ausi,</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec illos descripta monent, qui saepius
+          ausi,</l>
         <l met="penta_el">numquam peccatis abstinuere manus.</l>
       </div>
       <div type="poem" xml:id="avianus-31">
@@ -1324,7 +1932,8 @@
         <head type="sur">Avianus 32</head>
         <pb ed="perry" n="P291"/>
         <head>[DE HOMINE ET PLAVSTRO]</head>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haerentem luteo sub gurgite rusticus axem</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haerentem luteo sub gurgite rusticus
+          axem</l>
         <l met="penta_el">liquerat et nexos ad iuga tarda boues,</l>
         <l met="hexa_dac">frustra depositis confidens numina uotis</l>
         <l met="penta_el">ferre suis rebus, cum resideret, opem.</l>
@@ -1353,7 +1962,8 @@
         <l met="penta_el">Et vacuam solitis fetibus esse uidet,</l>
         <l met="hexa_dac">Ingemuit tantae deceptus scrimine fraudis</l>
         <l met="penta_el">Nam poenam meritis rettulit inde suis.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic qui cuncta deos uno male tempore poscunt,</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic qui cuncta deos uno male tempore
+          poscunt,</l>
         <l met="penta_el">Iustius his etiam uota diurna negant.</l>
       </div>
       <div type="poem" xml:id="avianus-34">
@@ -1363,7 +1973,8 @@
         <l met="hexa_dac">Quisquis torpentem passus transisse iuuentam</l>
         <l met="penta_el">nec timuit uitae prouidus ante mala</l>
         <l met="hexa_dac">confectus senio, confectus senio, postquam grauis affuit aetas,</l>
-        <l met="penta_el"><milestone unit="ana:promythium"/>heu frustra alterius saepe rogabit opem.</l>
+        <l met="penta_el"><milestone unit="ana:promythium"/>heu frustra alterius saepe rogabit
+          opem.</l>
         <l met="hexa_dac">Solibus ereptos hiemi formica labores</l>
         <l met="penta_el">distulit et breuibus condidit ante cauis.</l>
         <l met="hexa_dac">Verum ubi candentes suscepit terra pruinas,</l>
@@ -1399,7 +2010,8 @@
         <l met="penta_el">haeret et inuita cum genitrice fugit.</l>
         <l met="hexa_dac">Mox quoque dilecti succedit in oscula fratris,</l>
         <l met="penta_el">seruatus uetulis unicus heres auis.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic multos neglecta iuuant atque, ordine uerso,</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Sic multos neglecta iuuant atque, ordine
+          uerso,</l>
         <l met="penta_el">spes humiles rursus in meliora refert.</l>
       </div>
       <div type="poem" xml:id="avianus-36">
@@ -1422,7 +2034,8 @@
         <l met="penta_el">expertem nostri quae facit esse iugi.</l>
         <l met="hexa_dac">Proderit ergo graues quamuis perferre labores</l>
         <l met="penta_el">otia quam tenerum mox peritura pati.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Est hominum sors ista, magis felicibus ut mors</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Est hominum sors ista, magis felicibus
+          ut mors</l>
         <l met="penta_el">sit cita, cum miseros uita diurna regat.</l>
       </div>
       <div type="poem" xml:id="avianus-37">
@@ -1438,7 +2051,7 @@
         <l met="hexa_dac">Sed quod crassa malum circumdat guttura ferrum ?</l>
         <l met="penta_el">Ne custodita fas sit abire domo.</l>
         <l met="hexa_dac">At tu magna diu moribundus lustra pererras,</l>
-        <l met="penta_el">donec se siluis obuia  praeda ferat.</l>
+        <l met="penta_el">donec se siluis obuia praeda ferat.</l>
         <l met="hexa_dac">Perge igitur nostris tua subdere colla catenis,</l>
         <l met="penta_el">dum liceat faciles promeruisse dapes.</l>
         <l met="hexa_dac">Protinus ille grauem gemitu collectus in iram</l>
@@ -1525,7 +2138,8 @@
         <l met="penta_el">Pronior in tenues uicta cucurrit aquas.</l>
         <l met="hexa_dac">Infelix, quae magna sibi cognomina sumens,</l>
         <l met="penta_el">Ausa pharetratis nubibus ista loqui.</l>
-        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec poterunt miseros posthac exempla monere</l>
+        <l met="hexa_dac"><milestone unit="ana:epimythium"/>Haec poterunt miseros posthac exempla
+          monere</l>
         <l met="penta_el">Subdita nobilibus ut sua fata gemant.</l>
       </div>
       <div type="poem" xml:id="avianus-42">

--- a/xml/baudoin_fables-esope_1660.xml
+++ b/xml/baudoin_fables-esope_1660.xml
@@ -8,7 +8,7 @@
     <fileDesc>
       <titleStmt>
         <title>Les Fables d’Esope Phrygien</title>
-        <author key="Baudoin, Jean (1590?-1650)">Jean Baudoin</author>
+        <author key="Baudoin, Jean (1590?-1650)" ref="https://data.bnf.fr/fr/11890604/jean_baudoin/">Jean Baudoin</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -24,7 +24,7 @@
       <publicationStmt>
         <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2018"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/baudoin_fables-esope_1660/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/baudoin_fables-esope_1660/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2018 Sorbonne Université, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
@@ -36,7 +36,7 @@
         </availability>
       </publicationStmt>
       <sourceDesc>
-        <bibl>Jean <author>Baudoin</author>, <title>Les Fables d’Esope Phrygien. Traduction Nouvelle. Illustrée de Discours Moraux, Philosophiques et Politiques, par J. Baudoin. Avec les figures en taille douce</title>. A <pubPlace>Roüen</pubPlace>, chez <publisher>Jean et David Berthelin</publisher>, ruë aux Juifs, et dans la Court du Palais. <date>M. DC. LX</date>.</bibl>
+        <bibl>Jean Baudoin, <hi rend="i">Les Fables d’Esope Phrygien. Traduction Nouvelle. Illustrée de Discours Moraux, Philosophiques et Politiques, par J. Baudoin. Avec les figures en taille douce</hi>. A <pubPlace>Roüen</pubPlace>, chez <publisher>Jean et David Berthelin</publisher>, ruë aux Juifs, et dans la Court du Palais. <date>M. DC. LX</date>.</bibl>
       </sourceDesc>
     </fileDesc>
     <profileDesc>

--- a/xml/hervieux_fabulistes-latins-ed2-01_1893.xml
+++ b/xml/hervieux_fabulistes-latins-ed2-01_1893.xml
@@ -10,7 +10,7 @@
         <title>Les fabulistes latins depuis le siècle d’Auguste jusqu’à la fin du moyen âge. Tome
           I : Phèdre et ses anciens imitateurs directs et indirects (2<hi rend="sup"
           >e</hi> éd.)</title>
-        <author key="Hervieux, Léopold (1831-1900)">Léopold Hervieux</author>
+        <author key="Hervieux, Léopold (1831-1900)" ref="https://data.bnf.fr/fr/12998664/leopold_hervieux/">Léopold Hervieux</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -48,10 +48,10 @@
         </availability>
       </publicationStmt>
       <sourceDesc>
-        <bibl><author>Léopold Hervieux</author>, <title>Les fabulistes latins depuis le siècle
-            d’Auguste jusqu’à la fin du moyen âge</title>, <biblScope>tome I</biblScope> : <hi
+        <bibl>Léopold Hervieux, <hi rend="i">Les fabulistes latins depuis le siècle
+            d’Auguste jusqu’à la fin du moyen âge</hi>, tome I : <hi
             rend="i">Phèdre et ses anciens imitateurs directs et indirects</hi>, <edition>deuxième
-            edition entièrement refondue</edition>, <pubPlace>Paris</pubPlace>, L<publisher>ibrairie
+            edition entièrement refondue</edition>, <pubPlace>Paris</pubPlace>, <publisher>Librairie
             de Firmin-Didot et Cie</publisher>, <date>1893</date>, XII-848 p. PDF : <ref
             target="http://gallica.bnf.fr/ark:/12148/bpt6k6527660g">Gallica</ref>.</bibl>
       </sourceDesc>
@@ -61,7 +61,7 @@
         <date when="1893"/>
       </creation>
       <langUsage>
-        <language ident="fre">fre</language>
+        <language ident="fre"/>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/xml/la-fontaine_fables.xml
+++ b/xml/la-fontaine_fables.xml
@@ -9,7 +9,7 @@
       <!-- erreur sur la place des figures en début de div ; encodage provisoire des types en milestone ET -->
       <titleStmt>
         <title>Fables choisies, mises en vers</title>
-        <author key="La Fontaine, Jean de (1621-1695)">Jean de La Fontaine</author>
+        <author key="La Fontaine, Jean de (1621-1695)" ref="https://data.bnf.fr/fr/11910267/jean_de_la_fontaine/">Jean de La Fontaine</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -35,9 +35,9 @@
         </respStmt>
       </editionStmt>
       <publicationStmt>
-        <publisher>Université Paris-Sorbonne, LABEX OBVIL</publisher>
+        <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2015"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/xml/la-fontaine_fables/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/xml/la-fontaine_fables/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2015 Université Paris-Sorbonne, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>
@@ -49,7 +49,7 @@
         </availability>
       </publicationStmt>
       <sourceDesc>
-        <bibl><title>Fables choisies, mises en vers. Par M. de La Fontaine, et par luy revuës, corrigées et augmentées</title>, A <pubPlace>Paris</pubPlace>, chez <pubPlace>Denys Thierry</pubPlace>, ruë S. Jacques, et Claude Barbin, au Palais, [<date>1692</date>].</bibl>
+        <bibl><hi rend="i">Fables choisies, mises en vers. Par M. de La Fontaine, et par luy revuës, corrigées et augmentées</hi>, A <pubPlace>Paris</pubPlace>, chez <publisher>Denys Thierry</publisher>, ruë S. Jacques, et <publisher>Claude Barbin</publisher>, au Palais, [<date>1692</date>].</bibl>
       </sourceDesc>
     </fileDesc>
     <profileDesc>
@@ -57,7 +57,7 @@
         <date when="1692"/>
       </creation>
       <langUsage>
-        <language ident="fr"/>
+        <language ident="fre"/>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/xml/marie-de-france_fables.xml
+++ b/xml/marie-de-france_fables.xml
@@ -8,7 +8,7 @@
     <fileDesc>
       <titleStmt>
         <title>Fables</title>
-        <author key="Marie de France (11..-11..)">Marie de France</author>
+        <author key="Marie de France (11..-11..)" ref="https://data.bnf.fr/fr/11886884/marie_de_france/">Marie de France</author>
         <editor>Baptiste Laïd, d’après le texte établi par Charles Brucker (deuxième édition, 1998)</editor>
       </titleStmt>
       <editionStmt>
@@ -25,7 +25,7 @@
       <publicationStmt>
         <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2018"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/xml/marie-de-france_fables</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/xml/marie-de-france_fables</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2018 Sorbonne Université, agissant pour le Laboratoire d’Excellence « Observatoire de la vie littéraire » (ci-après dénommé OBVIL).</p>

--- a/xml/verdizzotti_cento-favole-morali_1570.xml
+++ b/xml/verdizzotti_cento-favole-morali_1570.xml
@@ -8,7 +8,7 @@
     <fileDesc>
       <titleStmt>
         <title>Cento favole morali</title>
-        <author key="Verdizzotti, Giovan Mario (1537/40-1604/07)">Giovan Mario Verdizzotti</author>
+        <author key="Verdizotti, Giovanni Mario (1525-1600?)" ref ="https://data.bnf.fr/fr/12180964/giovanni_mario_verdizotti/">Giovan Mario Verdizzotti</author>
       </titleStmt>
       <editionStmt>
         <edition>OBVIL</edition>
@@ -28,7 +28,7 @@
       <publicationStmt>
         <publisher>Sorbonne Université, LABEX OBVIL</publisher>
         <date when="2018"/>
-        <idno>http://obvil.paris-sorbonne.fr/corpus/fabula-numerica/verdizzotti_cento-favole-morali_1570/</idno>
+        <idno>http://obvil.sorbonne-universite.site/corpus/fabula-numerica/verdizzotti_cento-favole-morali_1570/</idno>
         <availability status="restricted">
           <licence target="http://creativecommons.org/licenses/by-nc-nd/3.0/fr/">
             <p>Copyright © 2018 Sorbonne Université, agissant pour le Laboratoire d’Excellence
@@ -50,11 +50,11 @@
         </availability>
       </publicationStmt>
       <sourceDesc>
-        <bibl>Giovan Mario <author>Verdizzotti</author>, <title>Cento Favole Morali De i piu
+        <bibl>Giovan Mario Verdizzotti, <hi rend="i">Cento Favole Morali De i piu
             illustri antichi, &amp; moderni autori Greci, &amp; Latini, scielte, &amp; trattate in
             varie maniere di versi volgari da M. Gio. Mario Verdizotti : nelle quali oltra
             l’ornamento di varie e belle figure, si contengono molti precetti pertinenti alla
-            prudenza della vita virtuosa &amp; civile</title>, <pubPlace>In Venetia</pubPlace>,
+            prudenza della vita virtuosa &amp; civile</hi>, In <pubPlace>Venetia</pubPlace>,
           appresso <publisher>Giordano Zileti, &amp; compagni</publisher>, <date>M D LXX</date>.
           PDF : <ref target="http://gallica.bnf.fr/ark:/12148/bpt6k3136418">Gallica</ref>.</bibl>
       </sourceDesc>


### PR DESCRIPTION
Modifications sur les fichiers : 
- teiheader selon le modèle de l'Obvil
- remplacement des `<milestone unit="manuscrits"/>`par des `<bibl>` #1 
- contenu des balises `<p rend="mentioncr">` intégré à la suite des références bibliographiques #2 
- pour la bibliographie commentée #2 : modifications des `<p rend="analysebiblio">`en `<quote type="comment"` et des `<p rend="bibliteration">` en `<bibl>`